### PR TITLE
Add dashboard variables to single-instance built-in dashboards

### DIFF
--- a/AWS/Page_AWS CloudFront.json
+++ b/AWS/Page_AWS CloudFront.json
@@ -115,6 +115,17 @@
   },
   "sf_discoverySelectors" : [ "_exists_:DistributionId" ],
   "sf_description" : "",
+  "sf_filterAlias" : {
+    "variables" : [ {
+      "dimension" : "DistributionId",
+      "alias" : "DistributionId",
+      "globalScope" : true,
+      "required" : true,
+      "description" : "",
+      "restricted" : false,
+      "preferredSuggestions" : [ ]
+    } ]
+  },
   "sf_type" : "Dashboard",
   "sf_discoveryQuery" : "namespace:\"AWS/CloudFront\" AND _exists_:DistributionId",
   "marshallId" : 3,

--- a/AWS/Page_AWS EBS.json
+++ b/AWS/Page_AWS EBS.json
@@ -162,6 +162,17 @@
     "version" : 1
   },
   "sf_discoverySelectors" : [ "_exists_:VolumeId" ],
+  "sf_filterAlias" : {
+    "variables" : [ {
+      "dimension" : "VolumeId",
+      "alias" : "VolumeId",
+      "globalScope" : true,
+      "required" : true,
+      "description" : "",
+      "restricted" : false,
+      "preferredSuggestions" : [ ]
+    } ]
+  },
   "sf_type" : "Dashboard",
   "sf_discoveryQuery" : "namespace:\"AWS/EBS\" AND _exists_:VolumeId",
   "marshallId" : 3,

--- a/AWS/Page_AWS EC2.json
+++ b/AWS/Page_AWS EC2.json
@@ -114,6 +114,17 @@
     "version" : 1
   },
   "sf_discoverySelectors" : [ "_exists_:InstanceId" ],
+  "sf_filterAlias" : {
+    "variables" : [ {
+      "dimension" : "InstanceId",
+      "alias" : "InstanceId",
+      "globalScope" : true,
+      "required" : true,
+      "description" : "",
+      "restricted" : false,
+      "preferredSuggestions" : [ ]
+    } ]
+  },
   "sf_type" : "Dashboard",
   "sf_discoveryQuery" : "namespace:\"AWS/EC2\" AND _exists_:InstanceId",
   "marshallId" : 3,

--- a/AWS/Page_AWS ECS.json
+++ b/AWS/Page_AWS ECS.json
@@ -90,6 +90,17 @@
         "sf_discoverySelectors": [
             "_exists_:ServiceName"
         ],
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "ServiceName",
+            "alias" : "ServiceName",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_type": "Dashboard",
         "marshallMemberOf": [
             3
@@ -2165,6 +2176,17 @@
         "sf_discoverySelectors": [
             "_exists_:ClusterName"
         ],
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "ClusterName",
+            "alias" : "ClusterName",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_type": "Dashboard",
         "marshallMemberOf": [
             3

--- a/AWS/Page_AWS ELB.json
+++ b/AWS/Page_AWS ELB.json
@@ -126,6 +126,17 @@
     "version" : 1
   },
   "sf_discoverySelectors" : [ "_exists_:LoadBalancerName" ],
+  "sf_filterAlias" : {
+    "variables" : [ {
+      "dimension" : "LoadBalancerName",
+      "alias" : "LoadBalancerName",
+      "globalScope" : true,
+      "required" : true,
+      "description" : "",
+      "restricted" : false,
+      "preferredSuggestions" : [ ]
+    } ]
+  },
   "sf_type" : "Dashboard",
   "sf_discoveryQuery" : "namespace:\"AWS/ELB\"",
   "marshallId" : 3,

--- a/AWS/Page_AWS ElastiCache.json
+++ b/AWS/Page_AWS ElastiCache.json
@@ -342,6 +342,17 @@
     "version" : 1
   },
   "sf_discoverySelectors" : [ "_exists_:CacheClusterId" ],
+  "sf_filterAlias" : {
+    "variables" : [ {
+      "dimension" : "CacheClusterId",
+      "alias" : "CacheClusterId",
+      "globalScope" : true,
+      "required" : true,
+      "description" : "",
+      "restricted" : false,
+      "preferredSuggestions" : [ ]
+    } ]
+  },
   "sf_type" : "Dashboard",
   "sf_discoveryQuery" : "1 AND namespace:\"AWS/ElastiCache\"",
   "marshallId" : 3,
@@ -6765,6 +6776,17 @@
     "version" : 1
   },
   "sf_discoverySelectors" : [ "_exists_:CacheNodeId" ],
+  "sf_filterAlias" : {
+    "variables" : [ {
+      "dimension" : "CacheNodeId",
+      "alias" : "CacheNodeId",
+      "globalScope" : true,
+      "required" : true,
+      "description" : "",
+      "restricted" : false,
+      "preferredSuggestions" : [ ]
+    } ]
+  },
   "sf_type" : "Dashboard",
   "sf_discoveryQuery" : "1 AND namespace:\"AWS/ElastiCache\"",
   "marshallId" : 32,

--- a/AWS/Page_AWS OpsWorks.json
+++ b/AWS/Page_AWS OpsWorks.json
@@ -143,6 +143,17 @@
             "_exists_:InstanceId", 
             "_exists_:StackId"
         ], 
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "InstanceId",
+            "alias" : "InstanceId",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_type": "Dashboard", 
         "marshallMemberOf": [
             3

--- a/AWS/Page_AWS RDS.json
+++ b/AWS/Page_AWS RDS.json
@@ -4534,6 +4534,17 @@
         "sf_discoverySelectors": [
             "_exists_:DBInstanceIdentifier"
         ], 
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "DBInstanceIdentifier",
+            "alias" : "DBInstanceIdentifier",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_type": "Dashboard", 
         "marshallMemberOf": [
             3

--- a/AWS/Page_AWS Route53.json
+++ b/AWS/Page_AWS Route53.json
@@ -898,6 +898,17 @@
         "sf_discoverySelectors": [
             "_exists_:HealthCheckId"
         ],
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "HealthCheckId",
+            "alias" : "HealthCheckId",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_type": "Dashboard",
         "marshallMemberOf": [
             3

--- a/AWS/Page_AWS SQS.json
+++ b/AWS/Page_AWS SQS.json
@@ -1396,6 +1396,17 @@
     "version" : 1
   },
   "sf_discoverySelectors" : [ "_exists_:QueueName" ],
+  "sf_filterAlias" : {
+    "variables" : [ {
+      "dimension" : "QueueName",
+      "alias" : "QueueName",
+      "globalScope" : true,
+      "required" : true,
+      "description" : "",
+      "restricted" : false,
+      "preferredSuggestions" : [ ]
+    } ]
+  },
   "sf_type" : "Dashboard",
   "sf_discoveryQuery" : "namespace:\"AWS/SQS\" AND _exists_:QueueName",
   "marshallId" : 13,

--- a/CollectD/Page_ActiveMQ.json
+++ b/CollectD/Page_ActiveMQ.json
@@ -158,6 +158,17 @@
         "sf_discoverySelectors": [
             "_exists_:host"
         ],
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "host",
+            "alias" : "host",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_type": "Dashboard",
         "marshallMemberOf": [
             2
@@ -4450,6 +4461,17 @@
         "sf_discoverySelectors": [
             "_exists_:plugin_instance"
         ],
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "plugin_instance",
+            "alias" : "plugin_instance",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_type": "Dashboard",
         "marshallMemberOf": [
             2
@@ -5816,6 +5838,17 @@
         "sf_discoverySelectors": [
             "_exists_:plugin_instance"
         ],
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "plugin_instance",
+            "alias" : "plugin_instance",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_type": "Dashboard",
         "marshallMemberOf": [
             2

--- a/CollectD/Page_Apache.json
+++ b/CollectD/Page_Apache.json
@@ -140,6 +140,17 @@
         "sf_discoverySelectors": [
             "_exists_:host"
         ],
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "host",
+            "alias" : "host",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_type": "Dashboard",
         "marshallMemberOf": [
             3

--- a/CollectD/Page_Cassandra.json
+++ b/CollectD/Page_Cassandra.json
@@ -3389,6 +3389,17 @@
         "sf_discoverySelectors": [
             "_exists_:host"
         ],
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "host",
+            "alias" : "host",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_type": "Dashboard",
         "marshallMemberOf": [
             3

--- a/CollectD/Page_CollectD.json
+++ b/CollectD/Page_CollectD.json
@@ -3019,6 +3019,17 @@
         "sf_discoverySelectors": [
             "_exists_:host"
         ],
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "host",
+            "alias" : "host",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_type": "Dashboard",
         "marshallMemberOf": [
             3

--- a/CollectD/Page_Docker.json
+++ b/CollectD/Page_Docker.json
@@ -155,6 +155,17 @@
         "sf_discoverySelectors": [
             "_exists_:host"
         ],
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "host",
+            "alias" : "host",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_type": "Dashboard",
         "marshallMemberOf": [
             3
@@ -3239,6 +3250,17 @@
         "sf_discoverySelectors": [
             "_exists_:plugin_instance"
         ],
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "plugin_instance",
+            "alias" : "plugin_instance",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_type": "Dashboard",
         "marshallMemberOf": [
             3

--- a/CollectD/Page_Elasticsearch.json
+++ b/CollectD/Page_Elasticsearch.json
@@ -185,10 +185,6 @@
         "sf_discoverySelectors": [
             "_exists_:host"
         ],
-        "sf_type": "Dashboard",
-        "marshallMemberOf": [
-            2
-        ],
         "sf_filterAlias" : {
           "variables" : [ {
             "dimension" : "host",
@@ -200,6 +196,10 @@
             "preferredSuggestions" : [ ]
           } ]
         },
+        "sf_type": "Dashboard",
+        "marshallMemberOf": [
+            2
+        ],
         "sf_dashboard": "Elasticsearch Node"
     },
     {
@@ -3073,6 +3073,17 @@
         "sf_discoverySelectors": [
             "_exists_:plugin_instance"
         ],
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "plugin_instance",
+            "alias" : "plugin_instance",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_type": "Dashboard",
         "marshallMemberOf": [
             2

--- a/CollectD/Page_Elasticsearch.json
+++ b/CollectD/Page_Elasticsearch.json
@@ -189,6 +189,17 @@
         "marshallMemberOf": [
             2
         ],
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "host",
+            "alias" : "host",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_dashboard": "Elasticsearch Node"
     },
     {

--- a/CollectD/Page_Kafka.json
+++ b/CollectD/Page_Kafka.json
@@ -2121,6 +2121,17 @@
         "sf_discoverySelectors": [
             "_exists_:host"
         ], 
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "host",
+            "alias" : "host",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_type": "Dashboard", 
         "marshallMemberOf": [
             2

--- a/CollectD/Page_Memcached.json
+++ b/CollectD/Page_Memcached.json
@@ -154,6 +154,17 @@
         "sf_discoverySelectors": [
             "_exists_:host"
         ],
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "host",
+            "alias" : "host",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_type": "Dashboard",
         "marshallMemberOf": [
             3

--- a/CollectD/Page_Mesos.json
+++ b/CollectD/Page_Mesos.json
@@ -250,6 +250,17 @@
         "sf_discoverySelectors": [
             "_exists_:cluster"
         ], 
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "cluster",
+            "alias" : "cluster",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_type": "Dashboard", 
         "marshallMemberOf": [
             2
@@ -3740,6 +3751,17 @@
             "_exists_:plugin_instance", 
             "_exists_:host"
         ], 
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "host",
+            "alias" : "host",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_type": "Dashboard", 
         "marshallMemberOf": [
             2
@@ -7678,6 +7700,17 @@
             "_exists_:plugin_instance", 
             "_exists_:host"
         ], 
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "host",
+            "alias" : "host",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_type": "Dashboard", 
         "marshallMemberOf": [
             2

--- a/CollectD/Page_MongoDB.json
+++ b/CollectD/Page_MongoDB.json
@@ -4227,6 +4227,17 @@
         "sf_discoverySelectors": [
             "_exists_:cluster"
         ],
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "cluster",
+            "alias" : "cluster",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_type": "Dashboard",
         "marshallMemberOf": [
             3
@@ -8526,6 +8537,17 @@
         "sf_discoverySelectors": [
             "_exists_:host"
         ],
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "host",
+            "alias" : "host",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_type": "Dashboard",
         "marshallMemberOf": [
             3

--- a/CollectD/Page_MySQL.json
+++ b/CollectD/Page_MySQL.json
@@ -2903,6 +2903,17 @@
         "sf_discoverySelectors": [
             "_exists_:host"
         ],
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "host",
+            "alias" : "host",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_type": "Dashboard",
         "marshallMemberOf": [
             3

--- a/CollectD/Page_Nginx.json
+++ b/CollectD/Page_Nginx.json
@@ -1850,10 +1850,32 @@
         "sf_discoverySelectors": [
             "_exists_:host"
         ],
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "host",
+            "alias" : "host",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_type": "Dashboard",
         "marshallMemberOf": [
             3
         ],
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "host",
+            "alias" : "host",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_dashboard": "Nginx Server"
     },
     {

--- a/CollectD/Page_PostgreSQL.json
+++ b/CollectD/Page_PostgreSQL.json
@@ -166,6 +166,17 @@
         "sf_discoverySelectors": [
             "_exists_:host"
         ],
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "host",
+            "alias" : "host",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_type": "Dashboard",
         "marshallMemberOf": [
             3

--- a/CollectD/Page_RabbitMQ.json
+++ b/CollectD/Page_RabbitMQ.json
@@ -184,6 +184,17 @@
         "sf_discoverySelectors": [
             "_exists_:host"
         ],
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "host",
+            "alias" : "host",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_type": "Dashboard",
         "marshallMemberOf": [
             2

--- a/CollectD/Page_Redis.json
+++ b/CollectD/Page_Redis.json
@@ -154,6 +154,17 @@
         "sf_discoverySelectors": [
             "_exists_:plugin_instance"
         ],
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "plugin_instance",
+            "alias" : "plugin_instance",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_type": "Dashboard",
         "marshallMemberOf": [
             3

--- a/CollectD/Page_Varnish.json
+++ b/CollectD/Page_Varnish.json
@@ -218,6 +218,17 @@
         "sf_discoverySelectors": [
             "_exists_:host"
         ], 
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "host",
+            "alias" : "host",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_type": "Dashboard", 
         "marshallMemberOf": [
             3

--- a/CollectD/Page_Zookeeper.json
+++ b/CollectD/Page_Zookeeper.json
@@ -2781,6 +2781,17 @@
         "sf_discoverySelectors": [
             "_exists_:host"
         ],
+        "sf_filterAlias" : {
+          "variables" : [ {
+            "dimension" : "host",
+            "alias" : "host",
+            "globalScope" : true,
+            "required" : true,
+            "description" : "",
+            "restricted" : false,
+            "preferredSuggestions" : [ ]
+          } ]
+        },
         "sf_type": "Dashboard",
         "marshallMemberOf": [
             3


### PR DESCRIPTION
Adds a dashboard variable to single-instance built-in dashboards so that
an instance is always selected and the dashboard will render something
meaningful. This will allow us to make links to built-in dashboards on
the dashboards page point to a dashboard page rather than the catalog,
which would be consistent with the rest of the dashboard links on that
page.

This commit only adds a dashboard variable to "single-instance"
dashboards, or dashboards whose `sf_discoverySelectors` contained only
clauses that began with `"_exists_"`. The dimension of the variable was
chosen as the value of that `"_exists_"` selector if there was only one
selector or the value which seemed most likely to represent the relevant
instance if there were multiple selectors.

The code to add to each serialized dashboard was determined by exporting
the same dashboard with and without dashboard variables and diff-ing the
resulting JSON files:

    <     "variables" : [ {
    <       "dimension" : "host",
    <       "alias" : "host",
    <       "value" : "i-c3dae4e8",
    <       "globalScope" : true,
    <       "required" : true,
    <       "description" : "",
    <       "restricted" : false,
    <       "preferredSuggestions" : [ ]
    <     } ]
    ---
    >     "variables" : [ ]

To test this, you can checkout this branch and then import a modified dashboard
group into an org that already has instances for the dashboard group you're
interested in and then inspect the imported dashboards. The imported
single-instance dashboards should have a dashboard variable.