### PR TITLE
Updating the collectd dashboards

### DIFF
--- a/CollectD/Page_CollectD.json
+++ b/CollectD/Page_CollectD.json
@@ -1,4865 +1,5385 @@
-[
-    {
-        "marshallScope": 3
-    },
-    {
-        "sf_tags": [
-            "inactive"
-        ],
-        "marshallId": 1,
-        "sf_tag": "inactive",
-        "sf_type": "Tag"
-    },
-    {
-        "marshallId": 2,
-        "sf_type": "Service",
-        "sf_description": "",
-        "sf_service": "Infrastructure"
-    },
-    {
-        "sf_page": "Infrastructure",
-        "marshallId": 3,
-        "marshallMemberOf": [
-            1,
-            2
-        ],
-        "sf_type": "Page",
-        "sf_description": "Dashboards about infrastructure as measured by collectd."
-    },
-    {
-        "marshallId": 4,
-        "sf_uiModel": {
-            "widgets": [
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 0,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "New Text Block",
-                        "chartIndex": 13,
-                        "id": 1
-                    },
-                    "row": 0
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 4,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "New Text Block",
-                        "chartIndex": 1,
-                        "id": 2
-                    },
-                    "row": 0
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 8,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 6,
-                        "id": 3
-                    },
-                    "row": 0
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 0,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 2,
-                        "id": 4
-                    },
-                    "row": 1
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 4,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1433981315431,
-                        "id": 5
-                    },
-                    "row": 1
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 8,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1433983517758,
-                        "id": 6
-                    },
-                    "row": 1
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 0,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1433972294516,
-                        "id": 7
-                    },
-                    "row": 2
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 4,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "New Text Block",
-                        "chartIndex": 4,
-                        "id": 8
-                    },
-                    "row": 2
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 8,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "New Text Block",
-                        "chartIndex": 3,
-                        "id": 9
-                    },
-                    "row": 2
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 0,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1433978780955,
-                        "id": 10
-                    },
-                    "row": 3
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 4,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 10,
-                        "id": 11
-                    },
-                    "row": 3
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 8,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1433985567407,
-                        "id": 12
-                    },
-                    "row": 3
-                }
-            ],
-            "version": 1
+[ {
+  "marshallScope" : 2
+}, {
+  "sf_description" : "",
+  "sf_type" : "Service",
+  "sf_service" : "Infrastructure",
+  "marshallId" : 1
+}, {
+  "sf_page" : "Infrastructure",
+  "sf_description" : "Dashboards about infrastructure as measured by collectd.",
+  "sf_type" : "Page",
+  "marshallId" : 2,
+  "marshallMemberOf" : [ 1 ]
+}, {
+  "sf_dashboard" : "Collectd (a)",
+  "sf_uiModel" : {
+    "widgets" : [ {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 0,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "New Text Block",
+        "chartIndex" : 13,
+        "id" : 1
+      },
+      "row" : 0
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 4,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "New Text Block",
+        "chartIndex" : 1,
+        "id" : 2
+      },
+      "row" : 0
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 8,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 6,
+        "id" : 3
+      },
+      "row" : 0
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 0,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 2,
+        "id" : 4
+      },
+      "row" : 1
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 4,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1433981315431,
+        "id" : 5
+      },
+      "row" : 1
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 8,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1433983517758,
+        "id" : 6
+      },
+      "row" : 1
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 0,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1433972294516,
+        "id" : 7
+      },
+      "row" : 2
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 4,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "New Text Block",
+        "chartIndex" : 4,
+        "id" : 8
+      },
+      "row" : 2
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 8,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "New Text Block",
+        "chartIndex" : 3,
+        "id" : 9
+      },
+      "row" : 2
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 0,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1433978780955,
+        "id" : 10
+      },
+      "row" : 3
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 4,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 10,
+        "id" : 11
+      },
+      "row" : 3
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 8,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1433985567407,
+        "id" : 12
+      },
+      "row" : 3
+    } ],
+    "version" : 1
+  },
+  "sf_discoverySelectors" : [ "_exists_:aws_region", "_exists_:aws_availability_zone", "sf_key:host", "_exists_:aws_instance_type" ],
+  "sf_description" : "",
+  "sf_type" : "Dashboard",
+  "sf_discoveryQuery" : "sf_hostHasService:collectd AND _missing_:host_metadata_version",
+  "marshallId" : 3,
+  "marshallMemberOf" : [ 2 ]
+}, {
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 25,
+    "allPlotConstructs" : [ ],
+    "chartType" : "area",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "query" : "plugin_instance:cpu-average",
+        "type" : "property",
+        "NOT" : false,
+        "value" : "plugin_instance:cpu-average"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "aggregation",
+        "propertyValue" : "aggregation",
+        "NOT" : false,
+        "query" : "plugin:aggregation",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "cpu.idle - Mean by host",
+      "seriesData" : {
+        "metric" : "cpu.idle"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_description": "",
-        "sf_discoveryQuery": "plugin:aggregation",
-        "sf_discoverySelectors": [
-            "sf_key:host",
-            "_exists_:aws_region",
-            "_exists_:aws_availability_zone",
-            "_exists_:aws_instance_type"
-        ],
-        "sf_type": "Dashboard",
-        "marshallMemberOf": [
-            3
-        ],
-        "sf_dashboard": "Collectd (a)"
-    },
-    {
-        "marshallId": 5,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "allPlotConstructs": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -3600000,
-                "updateInterval": "",
-                "disableThrottle": false,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": 0,
-                        "max": null,
-                        "label": "received - RED",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    },
-                    {
-                        "max": null,
-                        "label": "transmitted - BLUE",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "title": {
-                            "text": ""
-                        },
-                        "min": 0
-                    }
-                ],
-                "sortPreference": "",
-                "forcedResolution": "0"
-            },
-            "allPlotProgramText": [
-                "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.disk.*disk_ops.write AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_5_6')"
-            ],
-            "currentUniqueKey": 5,
-            "uiHelperValue": "##CHARTID##_14",
-            "allDetectorDecorators": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "interface",
-                            "propertyValue": "interface",
-                            "NOT": false,
-                            "query": "plugin:interface",
-                            "property": "plugin",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:eth*",
-                            "propertyValue": "eth*",
-                            "NOT": false,
-                            "query": "plugin_instance:eth*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "transmitted bits/sec",
-                    "seriesData": {
-                        "metric": "if_octets.tx"
-                    },
-                    "sf_programText": "",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SCALE",
-                                "options": {
-                                    "scaleAmount": 8
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 1,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#0077c2",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "AUTO"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "interface",
-                            "propertyValue": "interface",
-                            "NOT": false,
-                            "query": "plugin:interface",
-                            "property": "plugin",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:eth*",
-                            "propertyValue": "eth*",
-                            "NOT": false,
-                            "query": "plugin_instance:eth*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "received bits/sec",
-                    "seriesData": {
-                        "metric": "if_octets.rx"
-                    },
-                    "sf_programText": "find(query='(sf_metric:disk_ops.write AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_CGrk08YAgAA_3_9=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGrk08YAgAA_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08YAgAA_9')",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SCALE",
-                                "options": {
-                                    "scaleAmount": 8
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#b04600",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "AUTO"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "sf_detectorDecorators": [],
-            "revisionNumber": 14
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
         },
-        "sf_description": "bits/sec",
-        "sf_chartIndex": 1433978780955,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_14=id(report=1);A => find(query='(sf_metric:if_octets.tx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!sum -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');C => find(query='(sf_metric:if_octets.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!sum -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_3_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_14=id(report=1);A => find(query='(sf_metric:if_octets.tx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!sum -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');C => find(query='(sf_metric:if_octets.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!sum -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_3_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Total Network I/O",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            4
-        ]
-    },
-    {
-        "marshallId": 6,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "allPlotConstructs": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "stackedChart": true,
-                "forcedResolution": "0",
-                "useKMG2": true,
-                "colorByMetric": true,
-                "range": -3600000,
-                "maxDecimalPlaces": 4,
-                "updateInterval": "",
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": 0,
-                        "max": null,
-                        "label": "bytes",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": "-value",
-                "disableThrottle": false
-            },
-            "allPlotProgramText": [
-                "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.free AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3=id",
-                "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.used AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3=id",
-                "_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK=[?B,?A,!OUT]{?B  /  (?A  +  ?B)  *  100->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('sf_source')->groupby('aws_Name')->stats:!mean->_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_2_3');_SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3->?B:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK;_SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK"
-            ],
-            "currentUniqueKey": 7,
-            "uiHelperValue": "##CHARTID##_18",
-            "allDetectorDecorators": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "memory",
-                            "propertyValue": "memory",
-                            "NOT": false,
-                            "query": "plugin:memory",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "free",
-                    "seriesData": {
-                        "metric": "memory.free"
-                    },
-                    "sf_programText": "",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [
-                                        {
-                                            "value": "sf_metric"
-                                        }
-                                    ],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#05ce00",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": 5,
-                        "extrapolationPolicy": "LAST_VALUE_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "memory",
-                            "propertyValue": "memory",
-                            "NOT": false,
-                            "query": "plugin:memory",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "used by processes",
-                    "seriesData": {
-                        "metric": "memory.used"
-                    },
-                    "sf_programText": "",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [
-                                        {
-                                            "value": "sf_metric"
-                                        }
-                                    ],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#b04600",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": 5,
-                        "extrapolationPolicy": "LAST_VALUE_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "memory",
-                            "propertyValue": "memory",
-                            "NOT": false,
-                            "query": "plugin:memory",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 3,
-                    "name": "buffer cache",
-                    "seriesData": {
-                        "metric": "memory.buffered"
-                    },
-                    "sf_programText": "",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [
-                                        {
-                                            "value": "sf_metric"
-                                        }
-                                    ],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#0077c2",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": 5,
-                        "extrapolationPolicy": "LAST_VALUE_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "memory",
-                            "propertyValue": "memory",
-                            "NOT": false,
-                            "query": "plugin:memory",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 4,
-                    "name": "file/page cache",
-                    "seriesData": {
-                        "metric": "memory.cached"
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [
-                                        {
-                                            "value": "sf_metric"
-                                        }
-                                    ],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#999999",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": 5,
-                        "extrapolationPolicy": "LAST_VALUE_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 5,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "area",
-            "sf_detectorDecorators": [],
-            "revisionNumber": 18
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "query" : "aws_service:quantizer",
+        "type" : "property",
+        "value" : "Aws_service:quantizer"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "cpu %",
+      "valid" : true,
+      "seriesData" : { },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "type" : "ratio",
+      "expressionText" : "(1 - A/H) * 100",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "query" : "aws_service:quantizer",
+        "type" : "property",
+        "value" : "Aws_service:quantizer"
+      } ],
+      "uniqueKey" : 3,
+      "name" : "min",
+      "valid" : true,
+      "seriesData" : { },
+      "sf_programText" : "_SF_PLOT_KEY_CGrk08NAYAA_3_15_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_CGrk08NAYAA_3_15_MACROBLOCK:!OUT->_SF_PLOT_KEY_CGrk08NAYAA_3_15=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08NAYAA_3_15',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08NAYAA_15');_SF_PLOT_KEY_CGrk08NAYAA_1_15->?A:_SF_PLOT_KEY_CGrk08NAYAA_3_15_MACROBLOCK",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_chartIndex": 1433972294516,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_18=id(report=1);A => find(query='(sf_metric:memory.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_18 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');B => find(query='(sf_metric:memory.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_18 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');D => find(query='(sf_metric:memory.buffered AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_18 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');E => find(query='(sf_metric:memory.cached AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_5_18 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_5_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_18=id(report=1);A => find(query='(sf_metric:memory.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');B => find(query='(sf_metric:memory.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');D => find(query='(sf_metric:memory.buffered AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');E => find(query='(sf_metric:memory.cached AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_5_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_5_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Total Memory",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            4
-        ]
-    },
-    {
-        "marshallId": 7,
-        "sf_uiModel": {
-            "chartMode": "list",
-            "allPlotConstructs": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -3600000,
-                "updateInterval": "",
-                "yAxisConfigurations": [
-                    {
-                        "max": null,
-                        "min": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "id": "yAxis0"
-                    },
-                    {
-                        "max": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "title": {
-                            "text": ""
-                        },
-                        "min": null
-                    }
-                ],
-                "sortPreference": "-value"
-            },
-            "allPlotProgramText": [
-                "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.vmem.vmpage_io.swap.in AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_3_4')",
-                "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.vmem.vmpage_io.swap.out AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_3_4')"
-            ],
-            "currentUniqueKey": 5,
-            "uiHelperValue": "##CHARTID##_11",
-            "allDetectorDecorators": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "vmem",
-                            "propertyValue": "vmem",
-                            "NOT": false,
-                            "query": "plugin:vmem",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "pages swapped in/sec",
-                    "seriesData": {
-                        "metric": "vmpage_io.swap.in"
-                    },
-                    "sf_programText": "",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "vmem",
-                            "propertyValue": "vmem",
-                            "NOT": false,
-                            "query": "plugin:vmem",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "pages swapped out/sec",
-                    "seriesData": {
-                        "metric": "vmpage_io.swap.out"
-                    },
-                    "sf_programText": "find(refresh=300000,query='sf_metric:collectd.vmem.vmpage_io.swap.in AND sf_organizationID:BqDQY5OAAAA AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_BwzVGs0AEAA_2_2=id -> publish(defaultSource='_SF_PLOT_KEY_BwzVGs0AEAA_2_2',metric='_SF_PLOT_KEY_BwzVGs0AEAA_2_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='BwzVGs0AEAA_2')",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 1,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "sf-icon-property",
-                            "query": "aws_service:quantizer",
-                            "type": "property",
-                            "value": "Aws_service:quantizer"
-                        }
-                    ],
-                    "uniqueKey": 3,
-                    "name": "",
-                    "seriesData": {},
-                    "sf_programText": "",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [
-                                        {
-                                            "value": "host"
-                                        }
-                                    ],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "MEAN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "TOPN",
-                                "options": {
-                                    "count": 5
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "expressionText": "A+B",
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "ratio",
-                    "valid": true,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 4,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "sf_detectorDecorators": [],
-            "revisionNumber": 11
+        "fn" : {
+          "type" : "MIN",
+          "options" : { }
         },
-        "sf_chartIndex": 3,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_11_MACROBLOCK=[?A,?B,!OUT]{?A + ?B->!OUT};find(query='(sf_metric:vmpage_io.swap.in AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:vmem))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_11;find(query='(sf_metric:vmpage_io.swap.out AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:vmem))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_11;_SF_PLOT_KEY_##CHARTID##_3_11_MACROBLOCK:!OUT->groupby('host')->stats:!mean->groupby()->groupby()->select(count=5):!top->split() -> stats:!mean->_SF_PLOT_KEY_##CHARTID##_3_11->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_1_11->?A:_SF_PLOT_KEY_##CHARTID##_3_11_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_11->?B:_SF_PLOT_KEY_##CHARTID##_3_11_MACROBLOCK",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_11_MACROBLOCK=[?A,?B,!OUT]{?A + ?B->!OUT};find(query='(sf_metric:vmpage_io.swap.in AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:vmem))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');find(query='(sf_metric:vmpage_io.swap.out AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:vmem))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_3_11_MACROBLOCK:!OUT->groupby('host')->stats:!mean->groupby()->groupby()->select(count=5):!top->split() -> stats:!mean->_SF_PLOT_KEY_##CHARTID##_3_11->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_1_11->?A:_SF_PLOT_KEY_##CHARTID##_3_11_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_11->?B:_SF_PLOT_KEY_##CHARTID##_3_11_MACROBLOCK",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Top Mem Page Swaps/sec",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 10000,
-        "marshallMemberOf": [
-            4
-        ],
-        "sf_throttledProgramText": ""
-    },
-    {
-        "marshallId": 8,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "allPlotConstructs": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "forcedResolution": "0",
-                "colorByMetric": false,
-                "range": -3600000,
-                "updateInterval": "",
-                "yAxisConfigurations": [
-                    {
-                        "max": 110,
-                        "min": 0,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": "",
-                "disableThrottle": false
-            },
-            "allPlotProgramText": [
-                "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.aggregation.cpu-average.cpu.idle AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5=id",
-                "_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('aws_Name')->_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_0_5');_SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK"
-            ],
-            "currentUniqueKey": 10,
-            "uiHelperValue": "##CHARTID##_24",
-            "allDetectorDecorators": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "query": "plugin_instance:cpu-average",
-                            "type": "property",
-                            "NOT": false,
-                            "value": "plugin_instance:cpu-average"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "aggregation",
-                            "propertyValue": "aggregation",
-                            "NOT": false,
-                            "query": "plugin:aggregation",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "cpu.idle - Mean by host",
-                    "seriesData": {
-                        "metric": "cpu.idle"
-                    },
-                    "sf_programText": "",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [
-                                        {
-                                            "value": "host"
-                                        }
-                                    ],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "MEAN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "sf-icon-property",
-                            "query": "aws_service:quantizer",
-                            "type": "property",
-                            "value": "Aws_service:quantizer"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "cpu %",
-                    "valid": true,
-                    "seriesData": {},
-                    "sf_programText": "",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "type": "ratio",
-                    "expressionText": "100 - A",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "sf-icon-property",
-                            "query": "aws_service:quantizer",
-                            "type": "property",
-                            "value": "Aws_service:quantizer"
-                        }
-                    ],
-                    "uniqueKey": 3,
-                    "name": "min",
-                    "valid": true,
-                    "seriesData": {},
-                    "sf_programText": "_SF_PLOT_KEY_CGrk08NAYAA_3_15_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_CGrk08NAYAA_3_15_MACROBLOCK:!OUT->_SF_PLOT_KEY_CGrk08NAYAA_3_15=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08NAYAA_3_15',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08NAYAA_15');_SF_PLOT_KEY_CGrk08NAYAA_1_15->?A:_SF_PLOT_KEY_CGrk08NAYAA_3_15_MACROBLOCK",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "MIN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#05ce00",
-                        "visualization": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "ratio",
-                    "expressionText": "B",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "sf-icon-property",
-                            "query": "aws_service:quantizer",
-                            "type": "property",
-                            "value": "Aws_service:quantizer"
-                        }
-                    ],
-                    "uniqueKey": 4,
-                    "name": "p10",
-                    "valid": true,
-                    "seriesData": {},
-                    "sf_programText": "_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_CGrk08NAYAA_4_19=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08NAYAA_4_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08NAYAA_19');_SF_PLOT_KEY_CGrk08NAYAA_3_19->?C:_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "PERCENTILE",
-                                "options": {
-                                    "percentile": 10
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#00b9ff",
-                        "visualization": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "ratio",
-                    "expressionText": "B",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "sf-icon-property",
-                            "query": "aws_service:quantizer",
-                            "type": "property",
-                            "value": "Aws_service:quantizer"
-                        }
-                    ],
-                    "uniqueKey": 5,
-                    "name": "median",
-                    "valid": true,
-                    "seriesData": {},
-                    "sf_programText": "_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_CGrk08NAYAA_4_19=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08NAYAA_4_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08NAYAA_19');_SF_PLOT_KEY_CGrk08NAYAA_3_19->?C:_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "PERCENTILE",
-                                "options": {
-                                    "percentile": 50
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#e5b312",
-                        "visualization": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "ratio",
-                    "expressionText": "B",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "sf-icon-property",
-                            "query": "aws_service:quantizer",
-                            "type": "property",
-                            "value": "Aws_service:quantizer"
-                        }
-                    ],
-                    "uniqueKey": 6,
-                    "name": "p90",
-                    "valid": true,
-                    "seriesData": {},
-                    "sf_programText": "_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_CGrk08NAYAA_4_19=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08NAYAA_4_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08NAYAA_19');_SF_PLOT_KEY_CGrk08NAYAA_3_19->?C:_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "PERCENTILE",
-                                "options": {
-                                    "percentile": 90
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#f47e00",
-                        "visualization": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "ratio",
-                    "expressionText": "B",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "sf-icon-property",
-                            "query": "aws_service:quantizer",
-                            "type": "property",
-                            "value": "Aws_service:quantizer"
-                        }
-                    ],
-                    "uniqueKey": 7,
-                    "name": "max",
-                    "valid": true,
-                    "seriesData": {},
-                    "sf_programText": "_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_CGrk08NAYAA_4_19=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08NAYAA_4_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08NAYAA_19');_SF_PLOT_KEY_CGrk08NAYAA_3_19->?C:_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "MAX",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#bd468d",
-                        "visualization": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "ratio",
-                    "expressionText": "B",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 8,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "area",
-            "sf_detectorDecorators": [],
-            "revisionNumber": 24
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#05ce00",
+        "visualization" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "ratio",
+      "expressionText" : "B",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "query" : "aws_service:quantizer",
+        "type" : "property",
+        "value" : "Aws_service:quantizer"
+      } ],
+      "uniqueKey" : 4,
+      "name" : "p10",
+      "valid" : true,
+      "seriesData" : { },
+      "sf_programText" : "_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_CGrk08NAYAA_4_19=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08NAYAA_4_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08NAYAA_19');_SF_PLOT_KEY_CGrk08NAYAA_3_19->?C:_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_description": "percentile distribution",
-        "sf_chartIndex": 1,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_24_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_##CHARTID##_4_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_24_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_5_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_6_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_24_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_7_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_24_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_8_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK=[?C,!OUT]{?C->!OUT};find(query='(sf_metric:cpu.idle AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin_instance:cpu\\\\-average) AND (plugin:aggregation))') -> fetch -> groupby('host') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_24;_SF_PLOT_KEY_##CHARTID##_3_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_1_24->?A:_SF_PLOT_KEY_##CHARTID##_3_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_24_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_4_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_3_24->?C:_SF_PLOT_KEY_##CHARTID##_4_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_5_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_3_24->?C:_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_24_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_6_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_3_24->?C:_SF_PLOT_KEY_##CHARTID##_6_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_24_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_7_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_3_24->?C:_SF_PLOT_KEY_##CHARTID##_7_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_8_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_3_24->?C:_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_24_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_##CHARTID##_4_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_24_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_5_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_6_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_24_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_7_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_24_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_8_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK=[?C,!OUT]{?C->!OUT};find(query='(sf_metric:cpu.idle AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin_instance:cpu\\\\-average) AND (plugin:aggregation))') -> fetch -> groupby('host') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_24 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_3_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_1_24->?A:_SF_PLOT_KEY_##CHARTID##_3_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_24_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_4_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_3_24->?C:_SF_PLOT_KEY_##CHARTID##_4_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_5_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_3_24->?C:_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_24_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_6_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_3_24->?C:_SF_PLOT_KEY_##CHARTID##_6_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_24_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_7_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_3_24->?C:_SF_PLOT_KEY_##CHARTID##_7_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_8_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_3_24->?C:_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "CPU %",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            4
-        ],
-        "sf_throttledProgramText": ""
-    },
-    {
-        "marshallId": 9,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "allPlotConstructs": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "stackedChart": true,
-                "colorByMetric": false,
-                "range": -3600000,
-                "maxDecimalPlaces": 3,
-                "updateInterval": "",
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": null,
-                        "max": null,
-                        "label": "bytes",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": "+value"
-            },
-            "currentUniqueKey": 6,
-            "uiHelperValue": "##CHARTID##_8",
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "df",
-                            "propertyValue": "df",
-                            "NOT": false,
-                            "query": "plugin:df",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "used bytes",
-                    "seriesData": {
-                        "metric": "df_complex.used"
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#b04600",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": 5,
-                        "extrapolationPolicy": "LAST_VALUE_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "df",
-                            "propertyValue": "df",
-                            "NOT": false,
-                            "query": "plugin:df",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "free bytes",
-                    "seriesData": {
-                        "metric": "df_complex.free"
-                    },
-                    "sf_programText": "find(query='(sf_metric:df_complex.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2) AND (plugin:df))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY___OBJECT_ID___2_2=id(report=1) -> publish(metric='_SF_PLOT_KEY___OBJECT_ID___2_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='__OBJECT_ID___2')",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#007c1d",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": 5,
-                        "extrapolationPolicy": "LAST_VALUE_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "area",
-            "revisionNumber": 8
+        "fn" : {
+          "type" : "PERCENTILE",
+          "options" : {
+            "percentile" : 10
+          }
         },
-        "sf_chartIndex": 1433983517758,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_8=id(report=1);find(query='(sf_metric:df_complex.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:df))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8');find(query='(sf_metric:df_complex.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:df))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_8=id(report=1);find(query='(sf_metric:df_complex.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:df))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_8 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8');find(query='(sf_metric:df_complex.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:df))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_8 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Total Disk Space",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            4
-        ]
-    },
-    {
-        "marshallId": 10,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "allPlotConstructs": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "stackedChart": false,
-                "colorByMetric": true,
-                "range": -3600000,
-                "updateInterval": "",
-                "disableThrottle": false,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": 0,
-                        "max": null,
-                        "label": "interface errors - RED",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    },
-                    {
-                        "max": null,
-                        "label": "retransmits - BLUE",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "title": {
-                            "text": ""
-                        },
-                        "min": null
-                    }
-                ],
-                "sortPreference": "",
-                "forcedResolution": "0"
-            },
-            "allPlotProgramText": [
-                "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.interface.*.if_errors.* AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_10_8')"
-            ],
-            "currentUniqueKey": 6,
-            "uiHelperValue": "##CHARTID##_19",
-            "allDetectorDecorators": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "interface",
-                            "propertyValue": "interface",
-                            "NOT": false,
-                            "query": "plugin:interface",
-                            "property": "plugin",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:eth*",
-                            "propertyValue": "eth*",
-                            "NOT": false,
-                            "query": "plugin_instance:eth*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "errors/sec",
-                    "seriesData": {
-                        "metric": "if_errors.rx"
-                    },
-                    "sf_programText": "",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "interface",
-                            "propertyValue": "interface",
-                            "NOT": false,
-                            "query": "plugin:interface",
-                            "property": "plugin",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:eth*",
-                            "propertyValue": "eth*",
-                            "NOT": false,
-                            "query": "plugin_instance:eth*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "if_errors.tx",
-                    "seriesData": {
-                        "metric": "if_errors.tx"
-                    },
-                    "sf_programText": "",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "interface errors / sec",
-                    "valid": true,
-                    "seriesData": {},
-                    "sf_programText": "",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#b04600",
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "ratio",
-                    "expressionText": "A + B",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "protocols",
-                            "propertyValue": "protocols",
-                            "NOT": false,
-                            "query": "plugin:protocols",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 4,
-                    "name": "retransmits / sec",
-                    "seriesData": {
-                        "metric": "protocol_counter.RetransSegs"
-                    },
-                    "sf_programText": "",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 1,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#0077c2",
-                        "rollupPolicy": "DELTA_ROLLUP",
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 5,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "sf_detectorDecorators": [],
-            "revisionNumber": 19
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#00b9ff",
+        "visualization" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "ratio",
+      "expressionText" : "B",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "query" : "aws_service:quantizer",
+        "type" : "property",
+        "value" : "Aws_service:quantizer"
+      } ],
+      "uniqueKey" : 5,
+      "name" : "median",
+      "valid" : true,
+      "seriesData" : { },
+      "sf_programText" : "_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_CGrk08NAYAA_4_19=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08NAYAA_4_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08NAYAA_19');_SF_PLOT_KEY_CGrk08NAYAA_3_19->?C:_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_description": "errors/sec",
-        "sf_chartIndex": 1433985567407,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_19=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK=[?A,?B,!OUT]{?A  +  ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_4_19=id(report=1);A => find(query='(sf_metric:if_errors.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_19;B => find(query='(sf_metric:if_errors.tx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_19;_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK:!OUT->groupby()->stats:!sum->_SF_PLOT_KEY_##CHARTID##_3_19->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');_SF_PLOT_KEY_##CHARTID##_1_19->?A:_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_19->?B:_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK;D => find(query='(sf_metric:protocol_counter.RetransSegs AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:protocols))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_19 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_19=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK=[?A,?B,!OUT]{?A  +  ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_4_19=id(report=1);A => find(query='(sf_metric:if_errors.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_19 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');B => find(query='(sf_metric:if_errors.tx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_19 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK:!OUT->groupby()->stats:!sum->_SF_PLOT_KEY_##CHARTID##_3_19->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');_SF_PLOT_KEY_##CHARTID##_1_19->?A:_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_19->?B:_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK;D => find(query='(sf_metric:protocol_counter.RetransSegs AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:protocols))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_19 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Total Network Errors",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            4
-        ]
-    },
-    {
-        "marshallId": 11,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "allPlotConstructs": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "forcedResolution": "0",
-                "colorByMetric": false,
-                "range": -3600000,
-                "updateInterval": "",
-                "yAxisConfigurations": [
-                    {
-                        "max": 120,
-                        "min": 0,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": "",
-                "disableThrottle": false
-            },
-            "allPlotProgramText": [
-                "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.free AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3=id",
-                "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.used AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3=id",
-                "_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK=[?B,?A,!OUT]{?B  /  (?A  +  ?B)  *  100->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('sf_source')->groupby('aws_Name')->stats:!mean->_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_2_3');_SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3->?B:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK;_SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK"
-            ],
-            "currentUniqueKey": 12,
-            "uiHelperValue": "##CHARTID##_17",
-            "allDetectorDecorators": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "memory",
-                            "propertyValue": "memory",
-                            "NOT": false,
-                            "query": "plugin:memory",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "memory.free",
-                    "seriesData": {
-                        "metric": "memory.free"
-                    },
-                    "sf_programText": "",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "memory",
-                            "propertyValue": "memory",
-                            "NOT": false,
-                            "query": "plugin:memory",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "memory.used",
-                    "seriesData": {
-                        "metric": "memory.used"
-                    },
-                    "sf_programText": "",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "sf-icon-property",
-                            "query": "aws_service:quantizer",
-                            "type": "property",
-                            "value": "Aws_service:quantizer"
-                        }
-                    ],
-                    "uniqueKey": 3,
-                    "name": "mem %",
-                    "valid": true,
-                    "seriesData": {
-                        "metric": null
-                    },
-                    "sf_programText": "",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "visualization": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "AUTO"
-                    },
-                    "type": "ratio",
-                    "expressionText": "B / (A + B) * 100",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 4,
-                    "name": "min",
-                    "seriesData": {},
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "MIN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "expressionText": "C",
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#05ce00",
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "ratio",
-                    "valid": true,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 5,
-                    "name": "p10",
-                    "seriesData": {},
-                    "sf_programText": "_SF_PLOT_KEY_CGrk08TAYAA_6_12_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08TAYAA_6_12_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_CGrk08TAYAA_6_12=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08TAYAA_6_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08TAYAA_12');_SF_PLOT_KEY_CGrk08TAYAA_3_12->?C:_SF_PLOT_KEY_CGrk08TAYAA_6_12_MACROBLOCK",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "PERCENTILE",
-                                "options": {
-                                    "percentile": 10
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "expressionText": "C",
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#0dba8f",
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "ratio",
-                    "valid": true,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 6,
-                    "name": "median",
-                    "seriesData": {},
-                    "sf_programText": "_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_CGrk08TAYAA_7_12=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08TAYAA_7_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08TAYAA_12');_SF_PLOT_KEY_CGrk08TAYAA_3_12->?C:_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "PERCENTILE",
-                                "options": {
-                                    "percentile": 50
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "expressionText": "C",
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#00b9ff",
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "ratio",
-                    "valid": true,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 7,
-                    "name": "p90",
-                    "seriesData": {},
-                    "sf_programText": "_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_CGrk08TAYAA_7_12=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08TAYAA_7_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08TAYAA_12');_SF_PLOT_KEY_CGrk08TAYAA_3_12->?C:_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "PERCENTILE",
-                                "options": {
-                                    "percentile": 90
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "expressionText": "C",
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#ff8dd1",
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "ratio",
-                    "valid": true,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 8,
-                    "name": "max",
-                    "seriesData": {},
-                    "sf_programText": "_SF_PLOT_KEY_CGrk08TAYAA_5_13_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08TAYAA_5_13_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_CGrk08TAYAA_5_13=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08TAYAA_5_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08TAYAA_13');_SF_PLOT_KEY_CGrk08TAYAA_3_13->?C:_SF_PLOT_KEY_CGrk08TAYAA_5_13_MACROBLOCK",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "MAX",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "expressionText": "C",
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#bd468d",
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "ratio",
-                    "valid": true,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 9,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "area",
-            "sf_detectorDecorators": [],
-            "revisionNumber": 17
+        "fn" : {
+          "type" : "PERCENTILE",
+          "options" : {
+            "percentile" : 50
+          }
         },
-        "sf_description": "percentile distribution",
-        "sf_chartIndex": 4,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK=[?B,?A,!OUT]{?B  /  (?A  +  ?B)  *  100->!OUT};_SF_PLOT_KEY_##CHARTID##_5_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_17_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_7_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_17_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_8_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_17_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_9_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_9_17_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_10_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_10_17_MACROBLOCK=[?C,!OUT]{?C->!OUT};find(query='(sf_metric:memory.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_17;find(query='(sf_metric:memory.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_17;_SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_17->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_2_17->?B:_SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_17->?A:_SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_17_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_5_17->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_3_17->?C:_SF_PLOT_KEY_##CHARTID##_5_17_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_17_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_7_17->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_3_17->?C:_SF_PLOT_KEY_##CHARTID##_7_17_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_17_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_8_17->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_3_17->?C:_SF_PLOT_KEY_##CHARTID##_8_17_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_9_17_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_9_17->publish(metric='_SF_PLOT_KEY_##CHARTID##_9_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_3_17->?C:_SF_PLOT_KEY_##CHARTID##_9_17_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_10_17_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_10_17->publish(metric='_SF_PLOT_KEY_##CHARTID##_10_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_3_17->?C:_SF_PLOT_KEY_##CHARTID##_10_17_MACROBLOCK",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK=[?B,?A,!OUT]{?B  /  (?A  +  ?B)  *  100->!OUT};_SF_PLOT_KEY_##CHARTID##_5_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_17_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_7_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_17_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_8_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_17_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_9_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_9_17_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_10_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_10_17_MACROBLOCK=[?C,!OUT]{?C->!OUT};find(query='(sf_metric:memory.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_17 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');find(query='(sf_metric:memory.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_17 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_17->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_2_17->?B:_SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_17->?A:_SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_17_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_5_17->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_3_17->?C:_SF_PLOT_KEY_##CHARTID##_5_17_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_17_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_7_17->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_3_17->?C:_SF_PLOT_KEY_##CHARTID##_7_17_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_17_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_8_17->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_3_17->?C:_SF_PLOT_KEY_##CHARTID##_8_17_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_9_17_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_9_17->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_9_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_3_17->?C:_SF_PLOT_KEY_##CHARTID##_9_17_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_10_17_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_10_17->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_10_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_3_17->?C:_SF_PLOT_KEY_##CHARTID##_10_17_MACROBLOCK",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Memory Used %",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            4
-        ],
-        "sf_throttledProgramText": ""
-    },
-    {
-        "marshallId": 12,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "allPlotConstructs": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -3600000,
-                "updateInterval": "",
-                "disableThrottle": false,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": 0,
-                        "max": null,
-                        "label": "current conns - RED",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    },
-                    {
-                        "max": null,
-                        "label": "new conns / s - BLUE",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "title": {
-                            "text": ""
-                        },
-                        "min": 0
-                    }
-                ],
-                "sortPreference": "",
-                "forcedResolution": "0"
-            },
-            "allPlotProgramText": [
-                "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.protocols.Tcp.protocol_counter.CurrEstab AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch(rollup='AVERAGE_ROLLUP') -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_11_1_5=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_11_1_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_11_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_11_5')"
-            ],
-            "currentUniqueKey": 4,
-            "uiHelperValue": "##CHARTID##_14",
-            "allDetectorDecorators": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "protocols",
-                            "propertyValue": "protocols",
-                            "NOT": false,
-                            "query": "plugin:protocols",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "# current conns",
-                    "seriesData": {
-                        "metric": "protocol_counter.CurrEstab"
-                    },
-                    "sf_programText": "",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#b04600",
-                        "rollupPolicy": "MAX_ROLLUP",
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "protocols",
-                            "propertyValue": "protocols",
-                            "NOT": false,
-                            "query": "plugin:protocols",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "# new conns / sec",
-                    "seriesData": {
-                        "metric": "protocol_counter.ActiveOpens"
-                    },
-                    "sf_programText": "find(query='(sf_metric:protocol_counter.CurrEstab AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> split -> stats:!mean -> window(1m) -> stats:!mean -> groupby() -> stats:!sum -> _SF_PLOT_KEY_CGrk08gAcAA_2_11=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGrk08gAcAA_2_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08gAcAA_11')",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 1,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#0077c2",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "sf_detectorDecorators": [],
-            "revisionNumber": 14
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#e5b312",
+        "visualization" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "ratio",
+      "expressionText" : "B",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "query" : "aws_service:quantizer",
+        "type" : "property",
+        "value" : "Aws_service:quantizer"
+      } ],
+      "uniqueKey" : 6,
+      "name" : "p90",
+      "valid" : true,
+      "seriesData" : { },
+      "sf_programText" : "_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_CGrk08NAYAA_4_19=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08NAYAA_4_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08NAYAA_19');_SF_PLOT_KEY_CGrk08NAYAA_3_19->?C:_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_chartIndex": 10,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_14=id(report=1);A => find(query='(sf_metric:protocol_counter.CurrEstab AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:protocols))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP') -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');B => find(query='(sf_metric:protocol_counter.ActiveOpens AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:protocols))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_14=id(report=1);A => find(query='(sf_metric:protocol_counter.CurrEstab AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:protocols))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP') -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');B => find(query='(sf_metric:protocol_counter.ActiveOpens AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:protocols))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Total TCP Connections",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            4
-        ],
-        "sf_throttledProgramText": ""
-    },
-    {
-        "marshallId": 13,
-        "sf_uiModel": {
-            "chartMode": "list",
-            "allPlotConstructs": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "forcedResolution": "0",
-                "colorByMetric": false,
-                "range": -3600000,
-                "maxDecimalPlaces": 3,
-                "updateInterval": "",
-                "yAxisConfigurations": [
-                    {
-                        "max": 120,
-                        "min": 0,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": "-value",
-                "disableThrottle": false
-            },
-            "allPlotProgramText": [
-                "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.aggregation.cpu-average.cpu.idle AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5=id",
-                "_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('aws_Name')->_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_0_5');_SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK"
-            ],
-            "currentUniqueKey": 5,
-            "uiHelperValue": "##CHARTID##_16",
-            "allDetectorDecorators": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "query": "plugin_instance:cpu-average",
-                            "type": "property",
-                            "NOT": false,
-                            "value": "plugin_instance:cpu-average"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "aggregation",
-                            "propertyValue": "aggregation",
-                            "NOT": false,
-                            "query": "plugin:aggregation",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "cpu.idle - Mean by host - Mean(1m)",
-                    "seriesData": {
-                        "metric": "cpu.idle"
-                    },
-                    "sf_programText": "",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [
-                                        {
-                                            "value": "host"
-                                        }
-                                    ],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "MEAN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "transformation",
-                                "options": {
-                                    "amount": 1,
-                                    "transformTimeRange": "1m",
-                                    "unit": "m"
-                                }
-                            },
-                            "name": "New Transform",
-                            "fn": {
-                                "type": "MEAN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "sf-icon-property",
-                            "query": "aws_service:quantizer",
-                            "type": "property",
-                            "value": "Aws_service:quantizer"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "",
-                    "valid": true,
-                    "seriesData": {},
-                    "sf_programText": "",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "TOPN",
-                                "options": {
-                                    "count": 5
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "ratio",
-                    "expressionText": "100 - A",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "sf_programText": "",
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "sf_detectorDecorators": [],
-            "revisionNumber": 16
+        "fn" : {
+          "type" : "PERCENTILE",
+          "options" : {
+            "percentile" : 90
+          }
         },
-        "sf_chartIndex": 1433981315431,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};find(query='(sf_metric:cpu.idle AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin_instance:cpu\\\\-average) AND (plugin:aggregation))') -> fetch -> groupby('host') -> stats:!mean -> window(1m) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_16;_SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK:!OUT->groupby()->groupby()->select(count=5):!top->split() -> stats:!mean->_SF_PLOT_KEY_##CHARTID##_3_16->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');_SF_PLOT_KEY_##CHARTID##_1_16->?A:_SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};find(query='(sf_metric:cpu.idle AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin_instance:cpu\\\\-average) AND (plugin:aggregation))') -> fetch -> groupby('host') -> stats:!mean -> window(1m) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_16 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');_SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK:!OUT->groupby()->groupby()->select(count=5):!top->split() -> stats:!mean->_SF_PLOT_KEY_##CHARTID##_3_16->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');_SF_PLOT_KEY_##CHARTID##_1_16->?A:_SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Top CPU %",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 10000,
-        "marshallMemberOf": [
-            4
-        ]
-    },
-    {
-        "marshallId": 14,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "allPlotConstructs": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -3600000,
-                "updateInterval": "",
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": 0,
-                        "max": null,
-                        "label": "reads / s - RED",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    },
-                    {
-                        "max": null,
-                        "label": "writes / s - BLUE",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "title": {
-                            "text": ""
-                        },
-                        "min": 0
-                    }
-                ],
-                "sortPreference": "",
-                "forcedResolution": "0"
-            },
-            "allPlotProgramText": [
-                "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.disk.*disk_ops.write AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_5_6')"
-            ],
-            "currentUniqueKey": 5,
-            "uiHelperValue": "##CHARTID##_12",
-            "allDetectorDecorators": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "disk",
-                            "propertyValue": "disk",
-                            "NOT": false,
-                            "query": "plugin:disk",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "write ops/sec",
-                    "seriesData": {
-                        "metric": "disk_ops.write"
-                    },
-                    "sf_programText": "",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 1,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#0077c2",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "disk",
-                            "propertyValue": "disk",
-                            "NOT": false,
-                            "query": "plugin:disk",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "read ops/sec",
-                    "seriesData": {
-                        "metric": "disk_ops.read"
-                    },
-                    "sf_programText": "find(query='(sf_metric:disk_ops.write AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_CGrk08YAgAA_3_9=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGrk08YAgAA_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08YAgAA_9')",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#b04600",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "sf_detectorDecorators": [],
-            "revisionNumber": 12
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#f47e00",
+        "visualization" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "ratio",
+      "expressionText" : "B",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "query" : "aws_service:quantizer",
+        "type" : "property",
+        "value" : "Aws_service:quantizer"
+      } ],
+      "uniqueKey" : 7,
+      "name" : "max",
+      "valid" : true,
+      "seriesData" : { },
+      "sf_programText" : "_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_CGrk08NAYAA_4_19=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08NAYAA_4_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08NAYAA_19');_SF_PLOT_KEY_CGrk08NAYAA_3_19->?C:_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_chartIndex": 6,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_12=id(report=1);find(query='(sf_metric:disk_ops.write AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:disk))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');find(query='(sf_metric:disk_ops.read AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:disk))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_12=id(report=1);find(query='(sf_metric:disk_ops.write AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:disk))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');find(query='(sf_metric:disk_ops.read AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:disk))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Total Disk I/O Ops",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            4
-        ],
-        "sf_throttledProgramText": ""
-    },
-    {
-        "marshallId": 15,
-        "sf_uiModel": {
-            "chartMode": "single",
-            "allPlotConstructs": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -3600000,
-                "maxDecimalPlaces": 4,
-                "updateInterval": "",
-                "yAxisConfigurations": [
-                    {
-                        "max": null,
-                        "min": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": "",
-                "disableThrottle": false
-            },
-            "currentUniqueKey": 4,
-            "uiHelperValue": "##CHARTID##_13",
-            "allDetectorDecorators": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "memory",
-                            "propertyValue": "memory",
-                            "NOT": false,
-                            "query": "plugin:memory",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "cpu.idle - COUNT",
-                    "seriesData": {
-                        "metric": "memory.free"
-                    },
-                    "sf_programText": "",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "COUNT",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null,
-                        "maxExtrapolations": 5,
-                        "extrapolationPolicy": "LAST_VALUE_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "sf_programText": "",
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "revisionNumber": 13
+        "fn" : {
+          "type" : "MAX",
+          "options" : { }
         },
-        "sf_chartIndex": 13,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);find(query='(sf_metric:memory.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);find(query='(sf_metric:memory.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "# Active Hosts",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 10000,
-        "marshallMemberOf": [
-            4
-        ],
-        "sf_throttledProgramText": ""
-    },
-    {
-        "marshallId": 16,
-        "sf_uiModel": {
-            "chartMode": "list",
-            "allPlotConstructs": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -3600000,
-                "maxDecimalPlaces": 3,
-                "updateInterval": "",
-                "disableThrottle": false,
-                "yAxisConfigurations": [
-                    {
-                        "max": null,
-                        "min": 0,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": "-value",
-                "forcedResolution": "0"
-            },
-            "allPlotProgramText": [
-                "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.load.load.shortterm AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_1_5')"
-            ],
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_11",
-            "allDetectorDecorators": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "load",
-                            "propertyValue": "load",
-                            "NOT": false,
-                            "query": "plugin:load",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "",
-                    "seriesData": {
-                        "metric": "load.midterm"
-                    },
-                    "sf_programText": "",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "transformation",
-                                "options": {
-                                    "amount": 1,
-                                    "transformTimeRange": "1m",
-                                    "unit": "m"
-                                }
-                            },
-                            "fn": {
-                                "type": "MEAN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [
-                                        {
-                                            "value": "host"
-                                        }
-                                    ],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "MEAN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "TOPN",
-                                "options": {
-                                    "count": 5
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "sf-icon-property",
-                            "query": "aws_service:quantizer",
-                            "type": "property",
-                            "value": "Aws_service:quantizer"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "sf_programText": "",
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "sf_detectorDecorators": [],
-            "revisionNumber": 11
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#bd468d",
+        "visualization" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "ratio",
+      "expressionText" : "B",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "query" : "plugin_instance:cpu-average",
+        "type" : "property",
+        "NOT" : false,
+        "value" : "plugin_instance:cpu-average"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "aggregation",
+        "propertyValue" : "aggregation",
+        "NOT" : false,
+        "query" : "plugin:aggregation",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 8,
+      "name" : "cpu.* - Sum by host",
+      "seriesData" : {
+        "metric" : "cpu.*",
+        "regExStyle" : null
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
         },
-        "sf_description": "",
-        "sf_chartIndex": 2,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);A => find(query='(sf_metric:load.midterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:load))') -> fetch -> split -> stats:!mean -> window(1m) -> stats:!mean -> groupby('host') -> stats:!mean -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);A => find(query='(sf_metric:load.midterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:load))') -> fetch -> split -> stats:!mean -> window(1m) -> stats:!mean -> groupby('host') -> stats:!mean -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Top 5-min Load Avg",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 10000,
-        "marshallMemberOf": [
-            4
-        ],
-        "sf_throttledProgramText": ""
-    },
-    {
-        "marshallId": 17,
-        "sf_uiModel": {
-            "widgets": [
-                {
-                    "sizeX": 6,
-                    "sizeY": 1,
-                    "col": 0,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "New Text Block",
-                        "chartIndex": 1,
-                        "id": 1
-                    },
-                    "row": 0
-                },
-                {
-                    "sizeX": 6,
-                    "sizeY": 1,
-                    "col": 6,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 2,
-                        "id": 2
-                    },
-                    "row": 0
-                },
-                {
-                    "sizeX": 6,
-                    "sizeY": 1,
-                    "col": 0,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "New Text Block",
-                        "chartIndex": 4,
-                        "id": 3
-                    },
-                    "row": 1
-                },
-                {
-                    "sizeX": 6,
-                    "sizeY": 1,
-                    "col": 6,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "New Text Block",
-                        "chartIndex": 3,
-                        "id": 4
-                    },
-                    "row": 1
-                },
-                {
-                    "sizeX": 6,
-                    "sizeY": 1,
-                    "col": 0,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "New Text Block",
-                        "chartIndex": 5,
-                        "id": 5
-                    },
-                    "row": 2
-                },
-                {
-                    "sizeX": 6,
-                    "sizeY": 1,
-                    "col": 6,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1433463909939,
-                        "id": 6
-                    },
-                    "row": 2
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 0,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 8,
-                        "id": 7
-                    },
-                    "row": 3
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 8,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 12,
-                        "id": 8
-                    },
-                    "row": 3
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 4,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1442725445775,
-                        "id": 9
-                    },
-                    "row": 3
-                }
-            ],
-            "version": 1
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_description": "",
-        "sf_discoveryQuery": "plugin:aggregation",
-        "sf_discoverySelectors": [
-            "_exists_:host"
-        ],
-        "sf_type": "Dashboard",
-        "marshallMemberOf": [
-            3
-        ],
-        "sf_dashboard": "Collectd"
-    },
-    {
-        "marshallId": 18,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "allPlotConstructs": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": true,
-                "range": -3600000,
-                "updateInterval": "",
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": 0,
-                        "max": null,
-                        "label": "interface errors - RED",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    },
-                    {
-                        "max": null,
-                        "label": "retransmits - BLUE",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "title": {
-                            "text": ""
-                        },
-                        "min": 0
-                    }
-                ],
-                "sortPreference": ""
-            },
-            "allPlotProgramText": [
-                "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.interface.*.if_errors.* AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_10_8')"
-            ],
-            "currentUniqueKey": 6,
-            "uiHelperValue": "##CHARTID##_18",
-            "allDetectorDecorators": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "interface",
-                            "propertyValue": "interface",
-                            "NOT": false,
-                            "query": "plugin:interface",
-                            "property": "plugin",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:eth*",
-                            "propertyValue": "eth*",
-                            "NOT": false,
-                            "query": "plugin_instance:eth*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-zookeeper-3.4.6-0",
-                            "propertyValue": "integration-test-zookeeper-3.4.6-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-zookeeper-3.4.6-0\"",
-                            "property": "host",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "errors/sec",
-                    "seriesData": {
-                        "metric": "if_errors.rx"
-                    },
-                    "sf_programText": "",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": "DELTA_ROLLUP"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "interface",
-                            "propertyValue": "interface",
-                            "NOT": false,
-                            "query": "plugin:interface",
-                            "property": "plugin",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:eth*",
-                            "propertyValue": "eth*",
-                            "NOT": false,
-                            "query": "plugin_instance:eth*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-zookeeper-3.4.6-0",
-                            "propertyValue": "integration-test-zookeeper-3.4.6-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-zookeeper-3.4.6-0\"",
-                            "property": "host",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "if_errors.tx",
-                    "seriesData": {
-                        "metric": "if_errors.tx"
-                    },
-                    "sf_programText": "",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": "DELTA_ROLLUP"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "interface errors/sec",
-                    "valid": true,
-                    "seriesData": {},
-                    "sf_programText": "",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#b04600",
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "ratio",
-                    "expressionText": "A + B",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "protocols",
-                            "propertyValue": "protocols",
-                            "NOT": false,
-                            "query": "plugin:protocols",
-                            "property": "plugin",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-zookeeper-3.4.6-0",
-                            "propertyValue": "integration-test-zookeeper-3.4.6-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-zookeeper-3.4.6-0\"",
-                            "property": "host",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 4,
-                    "name": "retransmits/sec",
-                    "seriesData": {
-                        "metric": "protocol_counter.RetransSegs"
-                    },
-                    "sf_programText": "",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 1,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#0077c2",
-                        "rollupPolicy": "DELTA_ROLLUP",
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 5,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "sf_detectorDecorators": [],
-            "revisionNumber": 18
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : "RATE_ROLLUP"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "name" : "New Plot",
+      "type" : "plot",
+      "invisible" : false,
+      "transient" : true,
+      "dataManipulations" : [ ],
+      "yAxisIndex" : 0,
+      "queryItems" : [ ],
+      "metricDefinition" : { },
+      "seriesData" : { },
+      "uniqueKey" : 11,
+      "focusNext" : false
+    } ],
+    "uiHelperValue" : "##CHARTID##_25",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "forcedResolution" : "0",
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "max" : 110,
+        "min" : 0,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
         },
-        "sf_description": "errors/sec",
-        "sf_chartIndex": 12,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_18_MACROBLOCK=[?A,?B,!OUT]{?A  +  ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_4_18=id(report=1);find(query='(sf_metric:if_errors.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(rollup='DELTA_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_18;find(query='(sf_metric:if_errors.tx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(rollup='DELTA_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_18;_SF_PLOT_KEY_##CHARTID##_3_18_MACROBLOCK:!OUT->groupby()->stats:!sum->_SF_PLOT_KEY_##CHARTID##_3_18->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_1_18->?A:_SF_PLOT_KEY_##CHARTID##_3_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_18->?B:_SF_PLOT_KEY_##CHARTID##_3_18_MACROBLOCK;find(query='(sf_metric:protocol_counter.RetransSegs AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:protocols) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_18 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_18_MACROBLOCK=[?A,?B,!OUT]{?A  +  ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_4_18=id(report=1);find(query='(sf_metric:if_errors.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(rollup='DELTA_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');find(query='(sf_metric:if_errors.tx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(rollup='DELTA_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_3_18_MACROBLOCK:!OUT->groupby()->stats:!sum->_SF_PLOT_KEY_##CHARTID##_3_18->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_1_18->?A:_SF_PLOT_KEY_##CHARTID##_3_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_18->?B:_SF_PLOT_KEY_##CHARTID##_3_18_MACROBLOCK;find(query='(sf_metric:protocol_counter.RetransSegs AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:protocols) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Network Errors",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            17
-        ],
-        "sf_throttledProgramText": ""
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "",
+      "disableThrottle" : false
     },
-    {
-        "marshallId": 19,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "allPlotConstructs": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "stackedChart": true,
-                "useKMG2": true,
-                "colorByMetric": true,
-                "range": -3600000,
-                "maxDecimalPlaces": 4,
-                "updateInterval": "",
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": 0,
-                        "max": null,
-                        "label": "bytes",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": "-value",
-                "disableThrottle": false
-            },
-            "allPlotProgramText": [
-                "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.free AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3=id",
-                "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.used AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3=id",
-                "_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK=[?B,?A,!OUT]{?B  /  (?A  +  ?B)  *  100->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('sf_source')->groupby('aws_Name')->stats:!mean->_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_2_3');_SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3->?B:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK;_SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK"
-            ],
-            "currentUniqueKey": 7,
-            "uiHelperValue": "##CHARTID##_10",
-            "allDetectorDecorators": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-zookeeper-3.4.6-0",
-                            "propertyValue": "integration-test-zookeeper-3.4.6-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-zookeeper-3.4.6-0\"",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "memory",
-                            "propertyValue": "memory",
-                            "NOT": false,
-                            "query": "plugin:memory",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "free",
-                    "seriesData": {
-                        "metric": "memory.free"
-                    },
-                    "sf_programText": "",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#05ce00",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-zookeeper-3.4.6-0",
-                            "propertyValue": "integration-test-zookeeper-3.4.6-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-zookeeper-3.4.6-0\"",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "memory",
-                            "propertyValue": "memory",
-                            "NOT": false,
-                            "query": "plugin:memory",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "used by processes",
-                    "seriesData": {
-                        "metric": "memory.used"
-                    },
-                    "sf_programText": "",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#e9008a",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-zookeeper-3.4.6-0",
-                            "propertyValue": "integration-test-zookeeper-3.4.6-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-zookeeper-3.4.6-0\"",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "memory",
-                            "propertyValue": "memory",
-                            "NOT": false,
-                            "query": "plugin:memory",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 3,
-                    "name": "buffer cache",
-                    "seriesData": {
-                        "metric": "memory.buffered"
-                    },
-                    "sf_programText": "",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#0077c2",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-zookeeper-3.4.6-0",
-                            "propertyValue": "integration-test-zookeeper-3.4.6-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-zookeeper-3.4.6-0\"",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "memory",
-                            "propertyValue": "memory",
-                            "NOT": false,
-                            "query": "plugin:memory",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 4,
-                    "name": "file/page cache",
-                    "seriesData": {
-                        "metric": "memory.cached"
-                    },
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#999999",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 5,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "area",
-            "sf_detectorDecorators": [],
-            "revisionNumber": 10
+    "currentUniqueKey" : 12,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.aggregation.cpu-average.cpu.idle AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('aws_Name')->_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_0_5');_SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_25=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_25=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_25_MACROBLOCK=[?A,?H,!OUT]{(1  -  ?A / ?H)  *  100->!OUT};_SF_PLOT_KEY_##CHARTID##_3_25=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_25_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_4_25=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_25_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_5_25=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_25_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_6_25=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_25_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_7_25=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_25_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_8_25=id(report=1);find(query='(sf_metric:cpu.idle AND _missing_:sf_programId) AND ((plugin_instance:cpu\\\\-average) AND (plugin:aggregation))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_25;_SF_PLOT_KEY_##CHARTID##_2_25_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_2_25->publish(metric='_SF_PLOT_KEY_##CHARTID##_2_25',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_25');_SF_PLOT_KEY_##CHARTID##_1_25->?A:_SF_PLOT_KEY_##CHARTID##_2_25_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_25->?H:_SF_PLOT_KEY_##CHARTID##_2_25_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_25_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_3_25->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_25',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_25');_SF_PLOT_KEY_##CHARTID##_2_25->?B:_SF_PLOT_KEY_##CHARTID##_3_25_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_25_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_4_25->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_25',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_25');_SF_PLOT_KEY_##CHARTID##_2_25->?B:_SF_PLOT_KEY_##CHARTID##_4_25_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_25_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_5_25->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_25',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_25');_SF_PLOT_KEY_##CHARTID##_2_25->?B:_SF_PLOT_KEY_##CHARTID##_5_25_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_25_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_6_25->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_25',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_25');_SF_PLOT_KEY_##CHARTID##_2_25->?B:_SF_PLOT_KEY_##CHARTID##_6_25_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_25_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_7_25->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_25',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_25');_SF_PLOT_KEY_##CHARTID##_2_25->?B:_SF_PLOT_KEY_##CHARTID##_7_25_MACROBLOCK;find(query='(sf_metric:cpu.* AND _missing_:sf_programId) AND ((plugin_instance:cpu\\\\-average) AND (plugin:aggregation))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='RATE_ROLLUP') -> groupby('host') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_8_25",
+  "sf_description" : "percentile distribution",
+  "sf_type" : "Chart",
+  "sf_throttledProgramText" : "",
+  "marshallId" : 4,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "CPU %",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_25=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_25=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_25_MACROBLOCK=[?A,?H,!OUT]{(1  -  ?A / ?H)  *  100->!OUT};_SF_PLOT_KEY_##CHARTID##_3_25=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_25_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_4_25=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_25_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_5_25=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_25_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_6_25=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_25_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_7_25=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_25_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_8_25=id(report=1);find(query='(sf_metric:cpu.idle AND _missing_:sf_programId) AND ((plugin_instance:cpu\\\\-average) AND (plugin:aggregation))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_25 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_25',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_25');_SF_PLOT_KEY_##CHARTID##_2_25_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_2_25->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_2_25',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_25');_SF_PLOT_KEY_##CHARTID##_1_25->?A:_SF_PLOT_KEY_##CHARTID##_2_25_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_25->?H:_SF_PLOT_KEY_##CHARTID##_2_25_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_25_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_3_25->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_25',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_25');_SF_PLOT_KEY_##CHARTID##_2_25->?B:_SF_PLOT_KEY_##CHARTID##_3_25_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_25_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_4_25->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_25',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_25');_SF_PLOT_KEY_##CHARTID##_2_25->?B:_SF_PLOT_KEY_##CHARTID##_4_25_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_25_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_5_25->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_25',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_25');_SF_PLOT_KEY_##CHARTID##_2_25->?B:_SF_PLOT_KEY_##CHARTID##_5_25_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_25_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_6_25->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_25',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_25');_SF_PLOT_KEY_##CHARTID##_2_25->?B:_SF_PLOT_KEY_##CHARTID##_6_25_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_25_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_7_25->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_25',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_25');_SF_PLOT_KEY_##CHARTID##_2_25->?B:_SF_PLOT_KEY_##CHARTID##_7_25_MACROBLOCK;find(query='(sf_metric:cpu.* AND _missing_:sf_programId) AND ((plugin_instance:cpu\\\\-average) AND (plugin:aggregation))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='RATE_ROLLUP') -> groupby('host') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_8_25 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_8_25',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_25')"
+}, {
+  "sf_chart" : "Total Disk Space",
+  "sf_uiModel" : {
+    "revisionNumber" : 8,
+    "allPlotConstructs" : [ ],
+    "chartType" : "area",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "df",
+        "propertyValue" : "df",
+        "NOT" : false,
+        "query" : "plugin:df",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "used bytes",
+      "seriesData" : {
+        "metric" : "df_complex.used"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_chartIndex": 4,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_10=id(report=1);A => find(query='(sf_metric:memory.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');B => find(query='(sf_metric:memory.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');D => find(query='(sf_metric:memory.buffered AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_4_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');E => find(query='(sf_metric:memory.cached AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_5_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_5_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_10=id(report=1);A => find(query='(sf_metric:memory.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');B => find(query='(sf_metric:memory.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');D => find(query='(sf_metric:memory.buffered AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_4_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');E => find(query='(sf_metric:memory.cached AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_5_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_5_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Memory",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            17
-        ],
-        "sf_throttledProgramText": ""
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : 5,
+        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "df",
+        "propertyValue" : "df",
+        "NOT" : false,
+        "query" : "plugin:df",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "free bytes",
+      "seriesData" : {
+        "metric" : "df_complex.free"
+      },
+      "sf_programText" : "find(query='(sf_metric:df_complex.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2) AND (plugin:df))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY___OBJECT_ID___2_2=id(report=1) -> publish(metric='_SF_PLOT_KEY___OBJECT_ID___2_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='__OBJECT_ID___2')",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#007c1d",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : 5,
+        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_8",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : true,
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "maxDecimalPlaces" : 3,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : null,
+        "max" : null,
+        "label" : "bytes",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "+value"
     },
-    {
-        "marshallId": 20,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "range": -3600000,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": 0,
-                        "max": null,
-                        "label": "current conns - RED",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    },
-                    {
-                        "max": null,
-                        "label": "new conns/sec - BLUE",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "title": {
-                            "text": ""
-                        },
-                        "min": 0
-                    }
-                ],
-                "sortPreference": "",
-                "forcedResolution": "0"
-            },
-            "currentUniqueKey": 4,
-            "uiHelperValue": "##CHARTID##_3",
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "protocols",
-                            "propertyValue": "protocols",
-                            "NOT": false,
-                            "query": "plugin:protocols",
-                            "property": "plugin",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-zookeeper-3.4.6-0",
-                            "propertyValue": "integration-test-zookeeper-3.4.6-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-zookeeper-3.4.6-0\"",
-                            "property": "host",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "protocol_counter.CurrEstab",
-                    "seriesData": {
-                        "metric": "protocol_counter.CurrEstab"
-                    },
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#b04600",
-                        "rollupPolicy": "MAX_ROLLUP",
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "protocols",
-                            "propertyValue": "protocols",
-                            "NOT": false,
-                            "query": "plugin:protocols",
-                            "property": "plugin",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-zookeeper-3.4.6-0",
-                            "propertyValue": "integration-test-zookeeper-3.4.6-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-zookeeper-3.4.6-0\"",
-                            "property": "host",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "protocol_counter.ActiveOpens",
-                    "seriesData": {
-                        "metric": "protocol_counter.ActiveOpens"
-                    },
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 1,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#0077c2",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "revisionNumber": 3
+    "currentUniqueKey" : 6
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_8=id(report=1);find(query='(sf_metric:df_complex.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:df))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8');find(query='(sf_metric:df_complex.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:df))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1433983517758,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 1000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_8=id(report=1);find(query='(sf_metric:df_complex.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:df))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_8 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8');find(query='(sf_metric:df_complex.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:df))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_8 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
+  "marshallId" : 5,
+  "marshallMemberOf" : [ 3 ]
+}, {
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 17,
+    "allPlotConstructs" : [ ],
+    "chartType" : "area",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "memory",
+        "propertyValue" : "memory",
+        "NOT" : false,
+        "query" : "plugin:memory",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "memory.free",
+      "seriesData" : {
+        "metric" : "memory.free"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "memory",
+        "propertyValue" : "memory",
+        "NOT" : false,
+        "query" : "plugin:memory",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "memory.used",
+      "seriesData" : {
+        "metric" : "memory.used"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "query" : "aws_service:quantizer",
+        "type" : "property",
+        "value" : "Aws_service:quantizer"
+      } ],
+      "uniqueKey" : 3,
+      "name" : "mem %",
+      "valid" : true,
+      "seriesData" : {
+        "metric" : null
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "visualization" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "AUTO"
+      },
+      "type" : "ratio",
+      "expressionText" : "B / (A + B) * 100",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 4,
+      "name" : "min",
+      "seriesData" : { },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_chartIndex": 1442725445775,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_3=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_3=id(report=1);find(query='(sf_metric:protocol_counter.CurrEstab AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:protocols) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_3 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3');find(query='(sf_metric:protocol_counter.ActiveOpens AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:protocols) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_3 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_3=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_3=id(report=1);find(query='(sf_metric:protocol_counter.CurrEstab AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:protocols) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_3 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3');find(query='(sf_metric:protocol_counter.ActiveOpens AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:protocols) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_3 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "TCP Connections",
-        "sf_jobResolution": 1000,
-        "sf_disallowCachedProgram": true,
-        "marshallMemberOf": [
-            17
-        ]
+        "fn" : {
+          "type" : "MIN",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "C",
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#05ce00",
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "ratio",
+      "valid" : true,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 5,
+      "name" : "p10",
+      "seriesData" : { },
+      "sf_programText" : "_SF_PLOT_KEY_CGrk08TAYAA_6_12_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08TAYAA_6_12_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_CGrk08TAYAA_6_12=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08TAYAA_6_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08TAYAA_12');_SF_PLOT_KEY_CGrk08TAYAA_3_12->?C:_SF_PLOT_KEY_CGrk08TAYAA_6_12_MACROBLOCK",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "PERCENTILE",
+          "options" : {
+            "percentile" : 10
+          }
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "C",
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0dba8f",
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "ratio",
+      "valid" : true,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 6,
+      "name" : "median",
+      "seriesData" : { },
+      "sf_programText" : "_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_CGrk08TAYAA_7_12=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08TAYAA_7_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08TAYAA_12');_SF_PLOT_KEY_CGrk08TAYAA_3_12->?C:_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "PERCENTILE",
+          "options" : {
+            "percentile" : 50
+          }
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "C",
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#00b9ff",
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "ratio",
+      "valid" : true,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 7,
+      "name" : "p90",
+      "seriesData" : { },
+      "sf_programText" : "_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_CGrk08TAYAA_7_12=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08TAYAA_7_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08TAYAA_12');_SF_PLOT_KEY_CGrk08TAYAA_3_12->?C:_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "PERCENTILE",
+          "options" : {
+            "percentile" : 90
+          }
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "C",
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#ff8dd1",
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "ratio",
+      "valid" : true,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 8,
+      "name" : "max",
+      "seriesData" : { },
+      "sf_programText" : "_SF_PLOT_KEY_CGrk08TAYAA_5_13_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08TAYAA_5_13_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_CGrk08TAYAA_5_13=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08TAYAA_5_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08TAYAA_13');_SF_PLOT_KEY_CGrk08TAYAA_3_13->?C:_SF_PLOT_KEY_CGrk08TAYAA_5_13_MACROBLOCK",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "MAX",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "C",
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#bd468d",
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "ratio",
+      "valid" : true,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 9,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_17",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "forcedResolution" : "0",
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "max" : 120,
+        "min" : 0,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "",
+      "disableThrottle" : false
     },
-    {
-        "marshallId": 21,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "allPlotConstructs": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -3600000,
-                "updateInterval": "",
-                "yAxisConfigurations": [
-                    {
-                        "max": 110,
-                        "min": 0,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": ""
-            },
-            "allPlotProgramText": [
-                "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.aggregation.cpu-average.cpu.idle AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5=id",
-                "_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('aws_Name')->_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_0_5');_SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK"
-            ],
-            "currentUniqueKey": 5,
-            "uiHelperValue": "##CHARTID##_15",
-            "allDetectorDecorators": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "query": "plugin_instance:cpu-average",
-                            "type": "property",
-                            "NOT": false,
-                            "value": "plugin_instance:cpu-average"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-zookeeper-3.4.6-0",
-                            "propertyValue": "integration-test-zookeeper-3.4.6-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-zookeeper-3.4.6-0\"",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "aggregation",
-                            "propertyValue": "aggregation",
-                            "NOT": false,
-                            "query": "plugin:aggregation",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "cpu.idle",
-                    "seriesData": {
-                        "metric": "cpu.idle"
-                    },
-                    "sf_programText": "",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "sf-icon-property",
-                            "query": "aws_service:quantizer",
-                            "type": "property",
-                            "value": "Aws_service:quantizer"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "cpu %",
-                    "valid": true,
-                    "seriesData": {},
-                    "sf_programText": "",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "ratio",
-                    "expressionText": "100 - A",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "sf_programText": "",
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "area",
-            "sf_detectorDecorators": [],
-            "revisionNumber": 15
+    "currentUniqueKey" : 12,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.free AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3=id", "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.used AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK=[?B,?A,!OUT]{?B  /  (?A  +  ?B)  *  100->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('sf_source')->groupby('aws_Name')->stats:!mean->_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_2_3');_SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3->?B:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK;_SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK=[?B,?A,!OUT]{?B  /  (?A  +  ?B)  *  100->!OUT};_SF_PLOT_KEY_##CHARTID##_5_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_17_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_7_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_17_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_8_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_17_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_9_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_9_17_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_10_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_10_17_MACROBLOCK=[?C,!OUT]{?C->!OUT};find(query='(sf_metric:memory.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_17;find(query='(sf_metric:memory.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_17;_SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_17->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_2_17->?B:_SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_17->?A:_SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_17_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_5_17->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_3_17->?C:_SF_PLOT_KEY_##CHARTID##_5_17_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_17_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_7_17->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_3_17->?C:_SF_PLOT_KEY_##CHARTID##_7_17_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_17_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_8_17->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_3_17->?C:_SF_PLOT_KEY_##CHARTID##_8_17_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_9_17_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_9_17->publish(metric='_SF_PLOT_KEY_##CHARTID##_9_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_3_17->?C:_SF_PLOT_KEY_##CHARTID##_9_17_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_10_17_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_10_17->publish(metric='_SF_PLOT_KEY_##CHARTID##_10_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_3_17->?C:_SF_PLOT_KEY_##CHARTID##_10_17_MACROBLOCK",
+  "sf_description" : "percentile distribution",
+  "sf_type" : "Chart",
+  "sf_throttledProgramText" : "",
+  "marshallId" : 6,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Memory Used %",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 4,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK=[?B,?A,!OUT]{?B  /  (?A  +  ?B)  *  100->!OUT};_SF_PLOT_KEY_##CHARTID##_5_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_17_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_7_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_17_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_8_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_17_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_9_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_9_17_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_10_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_10_17_MACROBLOCK=[?C,!OUT]{?C->!OUT};find(query='(sf_metric:memory.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_17 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');find(query='(sf_metric:memory.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_17 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_17->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_2_17->?B:_SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_17->?A:_SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_17_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_5_17->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_3_17->?C:_SF_PLOT_KEY_##CHARTID##_5_17_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_17_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_7_17->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_3_17->?C:_SF_PLOT_KEY_##CHARTID##_7_17_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_17_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_8_17->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_3_17->?C:_SF_PLOT_KEY_##CHARTID##_8_17_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_9_17_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_9_17->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_9_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_3_17->?C:_SF_PLOT_KEY_##CHARTID##_9_17_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_10_17_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_10_17->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_10_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_3_17->?C:_SF_PLOT_KEY_##CHARTID##_10_17_MACROBLOCK"
+}, {
+  "sf_chart" : "Top CPU %",
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 18,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "query" : "plugin_instance:cpu-average",
+        "type" : "property",
+        "NOT" : false,
+        "value" : "plugin_instance:cpu-average"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "aggregation",
+        "propertyValue" : "aggregation",
+        "NOT" : false,
+        "query" : "plugin:aggregation",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "cpu.idle - Mean by host - Mean(1m)",
+      "seriesData" : {
+        "metric" : "cpu.idle"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_description": "",
-        "sf_chartIndex": 1,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_15=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_15=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_15_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};find(query='(sf_metric:cpu.idle AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin_instance:cpu\\\\-average) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:aggregation))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_15;_SF_PLOT_KEY_##CHARTID##_3_15_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_15->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_15',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_15');_SF_PLOT_KEY_##CHARTID##_1_15->?A:_SF_PLOT_KEY_##CHARTID##_3_15_MACROBLOCK",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_15=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_15=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_15_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};find(query='(sf_metric:cpu.idle AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin_instance:cpu\\\\-average) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:aggregation))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_15 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_15',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_15');_SF_PLOT_KEY_##CHARTID##_3_15_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_15->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_15',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_15');_SF_PLOT_KEY_##CHARTID##_1_15->?A:_SF_PLOT_KEY_##CHARTID##_3_15_MACROBLOCK",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "CPU %",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            17
-        ],
-        "sf_throttledProgramText": ""
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "type" : "transformation",
+          "options" : {
+            "amount" : 1,
+            "transformTimeRange" : "1m",
+            "unit" : "m"
+          }
+        },
+        "name" : "New Transform",
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "query" : "plugin_instance:cpu-average",
+        "type" : "property",
+        "NOT" : false,
+        "value" : "plugin_instance:cpu-average"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "aggregation",
+        "propertyValue" : "aggregation",
+        "NOT" : false,
+        "query" : "plugin:aggregation",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 3,
+      "name" : "cpu.* - Sum by host - Mean(1m)",
+      "seriesData" : {
+        "metric" : "cpu.*",
+        "regExStyle" : null
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "type" : "transformation",
+          "options" : {
+            "amount" : 1,
+            "transformTimeRange" : "1m",
+            "unit" : "m"
+          }
+        },
+        "name" : "New Transform",
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "name" : "",
+      "type" : "ratio",
+      "invisible" : false,
+      "transient" : false,
+      "dataManipulations" : [ {
+        "fn" : {
+          "type" : "TOPN",
+          "options" : {
+            "count" : 10
+          }
+        },
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "showMe" : false
+      } ],
+      "yAxisIndex" : 0,
+      "queryItems" : [ ],
+      "metricDefinition" : { },
+      "seriesData" : { },
+      "uniqueKey" : 5,
+      "focusNext" : false,
+      "valid" : true,
+      "expressionText" : "(1 - A/C) * 100"
+    }, {
+      "name" : "New Plot",
+      "type" : "plot",
+      "invisible" : false,
+      "transient" : true,
+      "dataManipulations" : [ ],
+      "yAxisIndex" : 0,
+      "queryItems" : [ ],
+      "metricDefinition" : { },
+      "seriesData" : { },
+      "uniqueKey" : 6,
+      "focusNext" : false
+    } ],
+    "uiHelperValue" : "##CHARTID##_18",
+    "chartMode" : "list",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "forcedResolution" : "0",
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "maxDecimalPlaces" : 3,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "max" : 120,
+        "min" : 0,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "-value",
+      "disableThrottle" : false
     },
-    {
-        "marshallId": 22,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "allPlotConstructs": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": true,
-                "range": -3600000,
-                "updateInterval": "",
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": 0,
-                        "max": null,
-                        "label": "input - RED",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    },
-                    {
-                        "max": null,
-                        "label": "output - BLUE",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "title": {
-                            "text": ""
-                        },
-                        "min": 0
-                    }
-                ],
-                "sortPreference": "",
-                "forcedResolution": "0"
-            },
-            "allPlotProgramText": [
-                "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.interface*.if_octets.rx AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> ?a:math(b=8):!product -> _SF_PLOT_KEY_SYNTH_CHART_ID_7_1_6=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_7_1_6',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_7_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_7_6')"
-            ],
-            "currentUniqueKey": 4,
-            "uiHelperValue": "##CHARTID##_17",
-            "allDetectorDecorators": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:eth*",
-                            "propertyValue": "eth*",
-                            "NOT": false,
-                            "query": "plugin_instance:eth*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "interface",
-                            "propertyValue": "interface",
-                            "NOT": false,
-                            "query": "plugin:interface",
-                            "property": "plugin",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-zookeeper-3.4.6-0",
-                            "propertyValue": "integration-test-zookeeper-3.4.6-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-zookeeper-3.4.6-0\"",
-                            "property": "host",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "input bits/sec",
-                    "seriesData": {
-                        "metric": "if_octets.rx"
-                    },
-                    "sf_programText": "",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "SCALE",
-                                "options": {
-                                    "scaleAmount": 8
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#b04600",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "AUTO"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:eth*",
-                            "propertyValue": "eth*",
-                            "NOT": false,
-                            "query": "plugin_instance:eth*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "interface",
-                            "propertyValue": "interface",
-                            "NOT": false,
-                            "query": "plugin:interface",
-                            "property": "plugin",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-zookeeper-3.4.6-0",
-                            "propertyValue": "integration-test-zookeeper-3.4.6-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-zookeeper-3.4.6-0\"",
-                            "property": "host",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "output bits/sec",
-                    "seriesData": {
-                        "metric": "if_octets.tx"
-                    },
-                    "sf_programText": "find(query='(sf_metric:if_octets.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2) AND (plugin_instance:eth*))') -> fetch -> split -> stats:!mean -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_CGraATOAYAA_2_12=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGraATOAYAA_2_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGraATOAYAA_12')",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "SCALE",
-                                "options": {
-                                    "scaleAmount": 8
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 1,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#0077c2",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "AUTO"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "sf_detectorDecorators": [],
-            "revisionNumber": 17
+    "currentUniqueKey" : 7,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.aggregation.cpu-average.cpu.idle AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('aws_Name')->_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_0_5');_SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK=[?A,?C,!OUT]{(1  -  ?A / ?C)  *  100->!OUT};find(query='(sf_metric:cpu.idle AND _missing_:sf_programId) AND ((plugin_instance:cpu\\\\-average) AND (plugin:aggregation))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!mean -> window(1m) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_18;find(query='(sf_metric:cpu.* AND _missing_:sf_programId) AND ((plugin_instance:cpu\\\\-average) AND (plugin:aggregation))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!sum -> window(1m) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_18;_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK:!OUT->groupby()->groupby()->select(count=10):!top->split->_SF_PLOT_KEY_##CHARTID##_5_18->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_1_18->?A:_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_18->?C:_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1433981315431,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 10000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK=[?A,?C,!OUT]{(1  -  ?A / ?C)  *  100->!OUT};find(query='(sf_metric:cpu.idle AND _missing_:sf_programId) AND ((plugin_instance:cpu\\\\-average) AND (plugin:aggregation))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!mean -> window(1m) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');find(query='(sf_metric:cpu.* AND _missing_:sf_programId) AND ((plugin_instance:cpu\\\\-average) AND (plugin:aggregation))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!sum -> window(1m) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK:!OUT->groupby()->groupby()->select(count=10):!top->split->_SF_PLOT_KEY_##CHARTID##_5_18->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_1_18->?A:_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_18->?C:_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK",
+  "marshallId" : 7,
+  "marshallMemberOf" : [ 3 ]
+}, {
+  "sf_chart" : "Total Disk I/O Ops",
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 12,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "disk",
+        "propertyValue" : "disk",
+        "NOT" : false,
+        "query" : "plugin:disk",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "write ops/sec",
+      "seriesData" : {
+        "metric" : "disk_ops.write"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_description": "bits/sec",
-        "sf_chartIndex": 8,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_17=id(report=1);A => find(query='(sf_metric:if_octets.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin_instance:eth*) AND (plugin:interface) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(maxExtrapolations=-1) -> split -> stats:!mean -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_17 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');B => find(query='(sf_metric:if_octets.tx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin_instance:eth*) AND (plugin:interface) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(maxExtrapolations=-1) -> split -> stats:!mean -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_2_17 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_17=id(report=1);A => find(query='(sf_metric:if_octets.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin_instance:eth*) AND (plugin:interface) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(maxExtrapolations=-1) -> split -> stats:!mean -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_17 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');B => find(query='(sf_metric:if_octets.tx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin_instance:eth*) AND (plugin:interface) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(maxExtrapolations=-1) -> split -> stats:!mean -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_2_17 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Network I/O",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            17
-        ],
-        "sf_throttledProgramText": ""
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 1,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "disk",
+        "propertyValue" : "disk",
+        "NOT" : false,
+        "query" : "plugin:disk",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "read ops/sec",
+      "seriesData" : {
+        "metric" : "disk_ops.read"
+      },
+      "sf_programText" : "find(query='(sf_metric:disk_ops.write AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_CGrk08YAgAA_3_9=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGrk08YAgAA_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08YAgAA_9')",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_12",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "reads / s - RED",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      }, {
+        "max" : null,
+        "label" : "writes / s - BLUE",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        },
+        "min" : 0
+      } ],
+      "sortPreference" : "",
+      "forcedResolution" : "0"
     },
-    {
-        "marshallId": 23,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "allPlotConstructs": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": true,
-                "range": -3600000,
-                "updateInterval": "",
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": 0,
-                        "max": null,
-                        "label": "read ops - RED",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    },
-                    {
-                        "max": null,
-                        "label": "write ops - BLUE",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "title": {
-                            "text": ""
-                        },
-                        "min": 0
-                    }
-                ],
-                "sortPreference": ""
-            },
-            "allPlotProgramText": [
-                "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.disk.*disk_ops.read AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_6_1_7=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_6_1_7',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_6_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_6_7')"
-            ],
-            "currentUniqueKey": 5,
-            "uiHelperValue": "##CHARTID##_18",
-            "allDetectorDecorators": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "disk",
-                            "propertyValue": "disk",
-                            "NOT": false,
-                            "query": "plugin:disk",
-                            "property": "plugin",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-zookeeper-3.4.6-0",
-                            "propertyValue": "integration-test-zookeeper-3.4.6-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-zookeeper-3.4.6-0\"",
-                            "property": "host",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "read ops/sec",
-                    "seriesData": {
-                        "metric": "disk_ops.read"
-                    },
-                    "sf_programText": "",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#b04600",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "disk",
-                            "propertyValue": "disk",
-                            "NOT": false,
-                            "query": "plugin:disk",
-                            "property": "plugin",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-zookeeper-3.4.6-0",
-                            "propertyValue": "integration-test-zookeeper-3.4.6-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-zookeeper-3.4.6-0\"",
-                            "property": "host",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "write ops/sec",
-                    "seriesData": {
-                        "metric": "disk_ops.write"
-                    },
-                    "sf_programText": "find(query='(sf_metric:disk_ops.read AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_CGraATNAgAA_3_10=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGraATNAgAA_3_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGraATNAgAA_10')",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 1,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#0077c2",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "sf_detectorDecorators": [],
-            "revisionNumber": 18
+    "currentUniqueKey" : 5,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.disk.*disk_ops.write AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_5_6')" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_12=id(report=1);find(query='(sf_metric:disk_ops.write AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:disk))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');find(query='(sf_metric:disk_ops.read AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:disk))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 6,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 1000,
+  "sf_throttledProgramText" : "",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_12=id(report=1);find(query='(sf_metric:disk_ops.write AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:disk))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');find(query='(sf_metric:disk_ops.read AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:disk))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
+  "marshallId" : 8,
+  "marshallMemberOf" : [ 3 ]
+}, {
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 13,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "load",
+        "propertyValue" : "load",
+        "NOT" : false,
+        "query" : "plugin:load",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "",
+      "seriesData" : {
+        "metric" : "load.midterm"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "transformation",
+          "options" : {
+            "amount" : 1,
+            "transformTimeRange" : "1m",
+            "unit" : "m"
+          }
         },
-        "sf_description": "operations/sec",
-        "sf_chartIndex": 5,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_18=id(report=1);A => find(query='(sf_metric:disk_ops.read AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:disk) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_18 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');C => find(query='(sf_metric:disk_ops.write AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:disk) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_18 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_18=id(report=1);A => find(query='(sf_metric:disk_ops.read AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:disk) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');C => find(query='(sf_metric:disk_ops.write AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:disk) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Disk I/O",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            17
-        ],
-        "sf_throttledProgramText": ""
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      }, {
+        "fn" : {
+          "type" : "TOPN",
+          "options" : {
+            "count" : 10
+          }
+        },
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "query" : "aws_service:quantizer",
+        "type" : "property",
+        "value" : "Aws_service:quantizer"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_13",
+    "chartMode" : "list",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "maxDecimalPlaces" : 3,
+      "updateInterval" : "",
+      "disableThrottle" : false,
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : 0,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "-value",
+      "forcedResolution" : "0"
     },
-    {
-        "marshallId": 24,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "allPlotConstructs": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "stackedChart": false,
-                "useKMG2": false,
-                "colorByMetric": false,
-                "range": -3600000,
-                "maxDecimalPlaces": 3,
-                "updateInterval": "",
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": 0,
-                        "max": null,
-                        "label": "swapped in - RED",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    },
-                    {
-                        "max": null,
-                        "label": "swapped out - BLUE",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "title": {
-                            "text": ""
-                        },
-                        "min": 0
-                    }
-                ],
-                "sortPreference": "",
-                "disableThrottle": false
-            },
-            "allPlotProgramText": [
-                "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.vmem.vmpage_io.swap.in AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_3_4')",
-                "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.vmem.vmpage_io.swap.out AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_3_4')"
-            ],
-            "currentUniqueKey": 4,
-            "uiHelperValue": "##CHARTID##_14",
-            "allDetectorDecorators": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "vmem",
-                            "propertyValue": "vmem",
-                            "NOT": false,
-                            "query": "plugin:vmem",
-                            "property": "plugin",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-zookeeper-3.4.6-0",
-                            "propertyValue": "integration-test-zookeeper-3.4.6-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-zookeeper-3.4.6-0\"",
-                            "property": "host",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "swapped in",
-                    "seriesData": {
-                        "metric": "vmpage_io.swap.in"
-                    },
-                    "sf_programText": "",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#b04600",
-                        "rollupPolicy": "DELTA_ROLLUP",
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "vmem",
-                            "propertyValue": "vmem",
-                            "NOT": false,
-                            "query": "plugin:vmem",
-                            "property": "plugin",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-zookeeper-3.4.6-0",
-                            "propertyValue": "integration-test-zookeeper-3.4.6-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-zookeeper-3.4.6-0\"",
-                            "property": "host",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "swapped out",
-                    "seriesData": {
-                        "metric": "vmpage_io.swap.out"
-                    },
-                    "sf_programText": "find(refresh=300000,query='sf_metric:collectd.vmem.vmpage_io.swap.in AND sf_organizationID:BqDQY5OAAAA AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_BwzVGs0AEAA_2_2=id -> publish(defaultSource='_SF_PLOT_KEY_BwzVGs0AEAA_2_2',metric='_SF_PLOT_KEY_BwzVGs0AEAA_2_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='BwzVGs0AEAA_2')",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 1,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#0077c2",
-                        "rollupPolicy": "DELTA_ROLLUP",
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "sf-icon-property",
-                            "query": "aws_service:quantizer",
-                            "type": "property",
-                            "value": "Aws_service:quantizer"
-                        }
-                    ],
-                    "uniqueKey": 3,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "sf_programText": "",
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "sf_detectorDecorators": [],
-            "revisionNumber": 14
+    "currentUniqueKey" : 3,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.load.load.shortterm AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_1_5')" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);find(query='(sf_metric:load.midterm AND _missing_:sf_programId) AND ((plugin:load))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> window(1m) -> stats:!mean -> groupby('host') -> stats:!mean -> groupby() -> groupby() -> select(count=10):!top -> split -> _SF_PLOT_KEY_##CHARTID##_1_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')",
+  "sf_description" : "",
+  "sf_type" : "Chart",
+  "sf_throttledProgramText" : "",
+  "marshallId" : 9,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Top 5-min Load Avg",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 2,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);find(query='(sf_metric:load.midterm AND _missing_:sf_programId) AND ((plugin:load))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> window(1m) -> stats:!mean -> groupby('host') -> stats:!mean -> groupby() -> groupby() -> select(count=10):!top -> split -> _SF_PLOT_KEY_##CHARTID##_1_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')"
+}, {
+  "sf_chart" : "Top Mem Page Swaps/sec",
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 12,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "vmem",
+        "propertyValue" : "vmem",
+        "NOT" : false,
+        "query" : "plugin:vmem",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "pages swapped in/sec",
+      "seriesData" : {
+        "metric" : "vmpage_io.swap.in"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "vmem",
+        "propertyValue" : "vmem",
+        "NOT" : false,
+        "query" : "plugin:vmem",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "pages swapped out/sec",
+      "seriesData" : {
+        "metric" : "vmpage_io.swap.out"
+      },
+      "sf_programText" : "find(refresh=300000,query='sf_metric:collectd.vmem.vmpage_io.swap.in AND sf_organizationID:BqDQY5OAAAA AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_BwzVGs0AEAA_2_2=id -> publish(defaultSource='_SF_PLOT_KEY_BwzVGs0AEAA_2_2',metric='_SF_PLOT_KEY_BwzVGs0AEAA_2_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='BwzVGs0AEAA_2')",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 1,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "query" : "aws_service:quantizer",
+        "type" : "property",
+        "value" : "Aws_service:quantizer"
+      } ],
+      "uniqueKey" : 3,
+      "name" : "",
+      "seriesData" : { },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_description": "page swaps/sec",
-        "sf_chartIndex": 3,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_14=id(report=1);find(query='(sf_metric:vmpage_io.swap.in AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:vmem) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');find(query='(sf_metric:vmpage_io.swap.out AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:vmem) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_14=id(report=1);find(query='(sf_metric:vmpage_io.swap.in AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:vmem) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');find(query='(sf_metric:vmpage_io.swap.out AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:vmem) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Memory Paging",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            17
-        ],
-        "sf_throttledProgramText": ""
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "TOPN",
+          "options" : {
+            "count" : 10
+          }
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A+B",
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "ratio",
+      "valid" : true,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 4,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_12",
+    "chartMode" : "list",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      }, {
+        "max" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        },
+        "min" : null
+      } ],
+      "sortPreference" : "-value"
     },
-    {
-        "marshallId": 25,
-        "sf_uiModel": {
-            "chartMode": "list",
-            "allPlotConstructs": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -3600000,
-                "maxDecimalPlaces": 3,
-                "updateInterval": "",
-                "yAxisConfigurations": [
-                    {
-                        "max": null,
-                        "min": 0,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": "+sf_metric"
-            },
-            "allPlotProgramText": [
-                "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.load.load.shortterm AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_1_5')"
-            ],
-            "currentUniqueKey": 5,
-            "uiHelperValue": "##CHARTID##_14",
-            "allDetectorDecorators": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "load",
-                            "propertyValue": "load",
-                            "NOT": false,
-                            "query": "plugin:load",
-                            "property": "plugin",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-zookeeper-3.4.6-0",
-                            "propertyValue": "integration-test-zookeeper-3.4.6-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-zookeeper-3.4.6-0\"",
-                            "property": "host",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "01-min",
-                    "seriesData": {
-                        "metric": "load.shortterm"
-                    },
-                    "sf_programText": "",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "MEAN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "load",
-                            "propertyValue": "load",
-                            "NOT": false,
-                            "query": "plugin:load",
-                            "property": "plugin",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-zookeeper-3.4.6-0",
-                            "propertyValue": "integration-test-zookeeper-3.4.6-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-zookeeper-3.4.6-0\"",
-                            "property": "host",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "05-min",
-                    "seriesData": {
-                        "metric": "load.midterm"
-                    },
-                    "sf_programText": "find(query='(sf_metric:load.shortterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_CGraATAAcAA_2_10=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGraATAAcAA_2_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGraATAAcAA_10')",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "MEAN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "load",
-                            "propertyValue": "load",
-                            "NOT": false,
-                            "query": "plugin:load",
-                            "property": "plugin",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-zookeeper-3.4.6-0",
-                            "propertyValue": "integration-test-zookeeper-3.4.6-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-zookeeper-3.4.6-0\"",
-                            "property": "host",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 3,
-                    "name": "15-min",
-                    "seriesData": {
-                        "metric": "load.longterm"
-                    },
-                    "sf_programText": "find(query='(sf_metric:load.shortterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_CGraATAAcAA_3_10=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGraATAAcAA_3_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGraATAAcAA_10')",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "MEAN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 4,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "sf_detectorDecorators": [],
-            "revisionNumber": 14
+    "currentUniqueKey" : 5,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.vmem.vmpage_io.swap.in AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_3_4')", "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.vmem.vmpage_io.swap.out AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_3_4')" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_12_MACROBLOCK=[?A,?B,!OUT]{?A + ?B->!OUT};find(query='(sf_metric:vmpage_io.swap.in AND _missing_:sf_programId) AND ((plugin:vmem))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_12;find(query='(sf_metric:vmpage_io.swap.out AND _missing_:sf_programId) AND ((plugin:vmem))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_12;_SF_PLOT_KEY_##CHARTID##_3_12_MACROBLOCK:!OUT->groupby('host')->stats:!mean->groupby()->groupby()->select(count=10):!top->split->_SF_PLOT_KEY_##CHARTID##_3_12->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');_SF_PLOT_KEY_##CHARTID##_1_12->?A:_SF_PLOT_KEY_##CHARTID##_3_12_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_12->?B:_SF_PLOT_KEY_##CHARTID##_3_12_MACROBLOCK",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 3,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 10000,
+  "sf_throttledProgramText" : "",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_12_MACROBLOCK=[?A,?B,!OUT]{?A + ?B->!OUT};find(query='(sf_metric:vmpage_io.swap.in AND _missing_:sf_programId) AND ((plugin:vmem))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');find(query='(sf_metric:vmpage_io.swap.out AND _missing_:sf_programId) AND ((plugin:vmem))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');_SF_PLOT_KEY_##CHARTID##_3_12_MACROBLOCK:!OUT->groupby('host')->stats:!mean->groupby()->groupby()->select(count=10):!top->split->_SF_PLOT_KEY_##CHARTID##_3_12->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');_SF_PLOT_KEY_##CHARTID##_1_12->?A:_SF_PLOT_KEY_##CHARTID##_3_12_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_12->?B:_SF_PLOT_KEY_##CHARTID##_3_12_MACROBLOCK",
+  "marshallId" : 10,
+  "marshallMemberOf" : [ 3 ]
+}, {
+  "sf_chart" : "# Active Hosts",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 13,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "memory",
+        "propertyValue" : "memory",
+        "NOT" : false,
+        "query" : "plugin:memory",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "cpu.idle - COUNT",
+      "seriesData" : {
+        "metric" : "memory.free"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_description": "",
-        "sf_chartIndex": 2,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_14=id(report=1);A => find(query='(sf_metric:load.shortterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:load) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');B => find(query='(sf_metric:load.midterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:load) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');C => find(query='(sf_metric:load.longterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:load) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_14=id(report=1);A => find(query='(sf_metric:load.shortterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:load) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');B => find(query='(sf_metric:load.midterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:load) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');C => find(query='(sf_metric:load.longterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:load) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Load Average",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 10000,
-        "marshallMemberOf": [
-            17
-        ],
-        "sf_throttledProgramText": ""
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "COUNT",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null,
+        "maxExtrapolations" : 5,
+        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_13",
+    "chartMode" : "single",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "maxDecimalPlaces" : 4,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "",
+      "disableThrottle" : false
     },
-    {
-        "marshallId": 26,
-        "sf_uiModel": {
-            "chartMode": "list",
-            "allPlotConstructs": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "stackedChart": true,
-                "colorByMetric": false,
-                "range": -3600000,
-                "maxDecimalPlaces": 3,
-                "updateInterval": "",
-                "yAxisConfigurations": [
-                    {
-                        "max": null,
-                        "min": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": "+value"
-            },
-            "currentUniqueKey": 6,
-            "uiHelperValue": "##CHARTID##_5",
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "df",
-                            "propertyValue": "df",
-                            "NOT": false,
-                            "query": "plugin:df",
-                            "property": "plugin",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-zookeeper-3.4.6-0",
-                            "propertyValue": "integration-test-zookeeper-3.4.6-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-zookeeper-3.4.6-0\"",
-                            "property": "host",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "used bytes",
-                    "seriesData": {
-                        "metric": "df_complex.used"
-                    },
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#b04600",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "AUTO"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "df",
-                            "propertyValue": "df",
-                            "NOT": false,
-                            "query": "plugin:df",
-                            "property": "plugin",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-zookeeper-3.4.6-0",
-                            "propertyValue": "integration-test-zookeeper-3.4.6-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-zookeeper-3.4.6-0\"",
-                            "property": "host",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "free bytes",
-                    "seriesData": {
-                        "metric": "df_complex.free"
-                    },
-                    "sf_programText": "find(query='(sf_metric:df_complex.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2) AND (plugin:df))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY___OBJECT_ID___2_2=id(report=1) -> publish(metric='_SF_PLOT_KEY___OBJECT_ID___2_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='__OBJECT_ID___2')",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#007c1d",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "AUTO"
-                    },
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "",
-                    "seriesData": {},
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [
-                                        {
-                                            "value": "plugin_instance"
-                                        }
-                                    ],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "name": "New Aggregation",
-                            "fn": {
-                                "type": "MEAN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "BOTTOMN",
-                                "options": {
-                                    "count": 5
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "expressionText": "B/(A+B)*100",
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "ratio",
-                    "valid": true,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 4,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "valid": false,
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "revisionNumber": 5
+    "currentUniqueKey" : 4
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);find(query='(sf_metric:memory.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 13,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 10000,
+  "sf_throttledProgramText" : "",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);find(query='(sf_metric:memory.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')",
+  "marshallId" : 11,
+  "marshallMemberOf" : [ 3 ]
+}, {
+  "sf_chart" : "Total Network I/O",
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 14,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "interface",
+        "propertyValue" : "interface",
+        "NOT" : false,
+        "query" : "plugin:interface",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:eth*",
+        "propertyValue" : "eth*",
+        "NOT" : false,
+        "query" : "plugin_instance:eth*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "transmitted bits/sec",
+      "seriesData" : {
+        "metric" : "if_octets.tx"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_chartIndex": 1433463909939,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_5=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_5=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_5_MACROBLOCK=[?B,?A,!OUT]{?B / (?A + ?B) * 100->!OUT};find(query='(sf_metric:df_complex.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:df) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_5;find(query='(sf_metric:df_complex.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:df) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_5;_SF_PLOT_KEY_##CHARTID##_4_5_MACROBLOCK:!OUT->groupby('plugin_instance')->stats:!mean->groupby()->groupby()->select(count=5):!bottom->split() -> stats:!mean->_SF_PLOT_KEY_##CHARTID##_4_5->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5');_SF_PLOT_KEY_##CHARTID##_2_5->?B:_SF_PLOT_KEY_##CHARTID##_4_5_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_5->?A:_SF_PLOT_KEY_##CHARTID##_4_5_MACROBLOCK",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_5=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_5=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_5_MACROBLOCK=[?B,?A,!OUT]{?B / (?A + ?B) * 100->!OUT};find(query='(sf_metric:df_complex.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:df) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_5 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5');find(query='(sf_metric:df_complex.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:df) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_5 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5');_SF_PLOT_KEY_##CHARTID##_4_5_MACROBLOCK:!OUT->groupby('plugin_instance')->stats:!mean->groupby()->groupby()->select(count=5):!bottom->split() -> stats:!mean->_SF_PLOT_KEY_##CHARTID##_4_5->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5');_SF_PLOT_KEY_##CHARTID##_2_5->?B:_SF_PLOT_KEY_##CHARTID##_4_5_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_5->?A:_SF_PLOT_KEY_##CHARTID##_4_5_MACROBLOCK",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Disk Free %",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 10000,
-        "marshallMemberOf": [
-            17
-        ]
-    }
-]
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "SCALE",
+          "options" : {
+            "scaleAmount" : 8
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 1,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "AUTO"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "interface",
+        "propertyValue" : "interface",
+        "NOT" : false,
+        "query" : "plugin:interface",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:eth*",
+        "propertyValue" : "eth*",
+        "NOT" : false,
+        "query" : "plugin_instance:eth*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "received bits/sec",
+      "seriesData" : {
+        "metric" : "if_octets.rx"
+      },
+      "sf_programText" : "find(query='(sf_metric:disk_ops.write AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_CGrk08YAgAA_3_9=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGrk08YAgAA_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08YAgAA_9')",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "SCALE",
+          "options" : {
+            "scaleAmount" : 8
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "AUTO"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_14",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "updateInterval" : "",
+      "disableThrottle" : false,
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "received - RED",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      }, {
+        "max" : null,
+        "label" : "transmitted - BLUE",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        },
+        "min" : 0
+      } ],
+      "sortPreference" : "",
+      "forcedResolution" : "0"
+    },
+    "currentUniqueKey" : 5,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.disk.*disk_ops.write AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_5_6')" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_14=id(report=1);A => find(query='(sf_metric:if_octets.tx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!sum -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');C => find(query='(sf_metric:if_octets.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!sum -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_3_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
+  "sf_cacheProgram" : false,
+  "sf_description" : "bits/sec",
+  "sf_chartIndex" : 1433978780955,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 1000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_14=id(report=1);A => find(query='(sf_metric:if_octets.tx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!sum -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');C => find(query='(sf_metric:if_octets.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!sum -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_3_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
+  "marshallId" : 12,
+  "marshallMemberOf" : [ 3 ]
+}, {
+  "sf_chart" : "Total Network Errors",
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 19,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "interface",
+        "propertyValue" : "interface",
+        "NOT" : false,
+        "query" : "plugin:interface",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:eth*",
+        "propertyValue" : "eth*",
+        "NOT" : false,
+        "query" : "plugin_instance:eth*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "errors/sec",
+      "seriesData" : {
+        "metric" : "if_errors.rx"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "interface",
+        "propertyValue" : "interface",
+        "NOT" : false,
+        "query" : "plugin:interface",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:eth*",
+        "propertyValue" : "eth*",
+        "NOT" : false,
+        "query" : "plugin_instance:eth*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "if_errors.tx",
+      "seriesData" : {
+        "metric" : "if_errors.tx"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "interface errors / sec",
+      "valid" : true,
+      "seriesData" : { },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "ratio",
+      "expressionText" : "A + B",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "protocols",
+        "propertyValue" : "protocols",
+        "NOT" : false,
+        "query" : "plugin:protocols",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 4,
+      "name" : "retransmits / sec",
+      "seriesData" : {
+        "metric" : "protocol_counter.RetransSegs"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 1,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : "DELTA_ROLLUP",
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 5,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_19",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : false,
+      "colorByMetric" : true,
+      "range" : -3600000,
+      "updateInterval" : "",
+      "disableThrottle" : false,
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "interface errors - RED",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      }, {
+        "max" : null,
+        "label" : "retransmits - BLUE",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        },
+        "min" : null
+      } ],
+      "sortPreference" : "",
+      "forcedResolution" : "0"
+    },
+    "currentUniqueKey" : 6,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.interface.*.if_errors.* AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_10_8')" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_19=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK=[?A,?B,!OUT]{?A  +  ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_4_19=id(report=1);A => find(query='(sf_metric:if_errors.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_19;B => find(query='(sf_metric:if_errors.tx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_19;_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK:!OUT->groupby()->stats:!sum->_SF_PLOT_KEY_##CHARTID##_3_19->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');_SF_PLOT_KEY_##CHARTID##_1_19->?A:_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_19->?B:_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK;D => find(query='(sf_metric:protocol_counter.RetransSegs AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:protocols))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_19 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19')",
+  "sf_cacheProgram" : false,
+  "sf_description" : "errors/sec",
+  "sf_chartIndex" : 1433985567407,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 1000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_19=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK=[?A,?B,!OUT]{?A  +  ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_4_19=id(report=1);A => find(query='(sf_metric:if_errors.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_19 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');B => find(query='(sf_metric:if_errors.tx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_19 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK:!OUT->groupby()->stats:!sum->_SF_PLOT_KEY_##CHARTID##_3_19->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');_SF_PLOT_KEY_##CHARTID##_1_19->?A:_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_19->?B:_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK;D => find(query='(sf_metric:protocol_counter.RetransSegs AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:protocols))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_19 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19')",
+  "marshallId" : 13,
+  "marshallMemberOf" : [ 3 ]
+}, {
+  "sf_chart" : "Total TCP Connections",
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 14,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "protocols",
+        "propertyValue" : "protocols",
+        "NOT" : false,
+        "query" : "plugin:protocols",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "# current conns",
+      "seriesData" : {
+        "metric" : "protocol_counter.CurrEstab"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "rollupPolicy" : "MAX_ROLLUP",
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "protocols",
+        "propertyValue" : "protocols",
+        "NOT" : false,
+        "query" : "plugin:protocols",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "# new conns / sec",
+      "seriesData" : {
+        "metric" : "protocol_counter.ActiveOpens"
+      },
+      "sf_programText" : "find(query='(sf_metric:protocol_counter.CurrEstab AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> split -> stats:!mean -> window(1m) -> stats:!mean -> groupby() -> stats:!sum -> _SF_PLOT_KEY_CGrk08gAcAA_2_11=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGrk08gAcAA_2_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08gAcAA_11')",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 1,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_14",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "updateInterval" : "",
+      "disableThrottle" : false,
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "current conns - RED",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      }, {
+        "max" : null,
+        "label" : "new conns / s - BLUE",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        },
+        "min" : 0
+      } ],
+      "sortPreference" : "",
+      "forcedResolution" : "0"
+    },
+    "currentUniqueKey" : 4,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.protocols.Tcp.protocol_counter.CurrEstab AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch(rollup='AVERAGE_ROLLUP') -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_11_1_5=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_11_1_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_11_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_11_5')" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_14=id(report=1);A => find(query='(sf_metric:protocol_counter.CurrEstab AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:protocols))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP') -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');B => find(query='(sf_metric:protocol_counter.ActiveOpens AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:protocols))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 10,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 1000,
+  "sf_throttledProgramText" : "",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_14=id(report=1);A => find(query='(sf_metric:protocol_counter.CurrEstab AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:protocols))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP') -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');B => find(query='(sf_metric:protocol_counter.ActiveOpens AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:protocols))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
+  "marshallId" : 14,
+  "marshallMemberOf" : [ 3 ]
+}, {
+  "sf_chart" : "Total Memory",
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 18,
+    "allPlotConstructs" : [ ],
+    "chartType" : "area",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "memory",
+        "propertyValue" : "memory",
+        "NOT" : false,
+        "query" : "plugin:memory",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "free",
+      "seriesData" : {
+        "metric" : "memory.free"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "sf_metric"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#05ce00",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : 5,
+        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "memory",
+        "propertyValue" : "memory",
+        "NOT" : false,
+        "query" : "plugin:memory",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "used by processes",
+      "seriesData" : {
+        "metric" : "memory.used"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "sf_metric"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : 5,
+        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "memory",
+        "propertyValue" : "memory",
+        "NOT" : false,
+        "query" : "plugin:memory",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 3,
+      "name" : "buffer cache",
+      "seriesData" : {
+        "metric" : "memory.buffered"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "sf_metric"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : 5,
+        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "memory",
+        "propertyValue" : "memory",
+        "NOT" : false,
+        "query" : "plugin:memory",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 4,
+      "name" : "file/page cache",
+      "seriesData" : {
+        "metric" : "memory.cached"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "sf_metric"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#999999",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : 5,
+        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 5,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_18",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : true,
+      "forcedResolution" : "0",
+      "useKMG2" : true,
+      "colorByMetric" : true,
+      "range" : -3600000,
+      "maxDecimalPlaces" : 4,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "bytes",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "-value",
+      "disableThrottle" : false
+    },
+    "currentUniqueKey" : 7,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.free AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3=id", "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.used AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK=[?B,?A,!OUT]{?B  /  (?A  +  ?B)  *  100->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('sf_source')->groupby('aws_Name')->stats:!mean->_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_2_3');_SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3->?B:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK;_SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_18=id(report=1);A => find(query='(sf_metric:memory.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_18 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');B => find(query='(sf_metric:memory.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_18 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');D => find(query='(sf_metric:memory.buffered AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_18 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');E => find(query='(sf_metric:memory.cached AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_5_18 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_5_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18')",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1433972294516,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 1000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_18=id(report=1);A => find(query='(sf_metric:memory.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');B => find(query='(sf_metric:memory.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');D => find(query='(sf_metric:memory.buffered AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');E => find(query='(sf_metric:memory.cached AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_5_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_5_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18')",
+  "marshallId" : 15,
+  "marshallMemberOf" : [ 3 ]
+}, {
+  "sf_dashboard" : "Collectd",
+  "sf_uiModel" : {
+    "widgets" : [ {
+      "col" : 3,
+      "row" : 0,
+      "sizeX" : 3,
+      "sizeY" : 1,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "chartIndex" : 1459445051615,
+        "name" : "",
+        "id" : 1
+      }
+    }, {
+      "col" : 9,
+      "row" : 0,
+      "sizeX" : 3,
+      "sizeY" : 1,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "chartIndex" : 1459445557108,
+        "name" : "",
+        "id" : 3
+      }
+    }, {
+      "col" : 0,
+      "row" : 0,
+      "sizeX" : 3,
+      "sizeY" : 1,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "chartIndex" : 1459444857291,
+        "name" : "",
+        "id" : 4
+      }
+    }, {
+      "col" : 6,
+      "row" : 0,
+      "sizeX" : 3,
+      "sizeY" : 1,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "chartIndex" : 1459445812323,
+        "name" : "",
+        "id" : 2
+      }
+    }, {
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "col" : 0,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "New Text Block",
+        "chartIndex" : 1,
+        "id" : 5
+      },
+      "row" : 1
+    }, {
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "col" : 6,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 2,
+        "id" : 6
+      },
+      "row" : 1
+    }, {
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "col" : 0,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "New Text Block",
+        "chartIndex" : 4,
+        "id" : 7
+      },
+      "row" : 2
+    }, {
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "col" : 6,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "New Text Block",
+        "chartIndex" : 3,
+        "id" : 8
+      },
+      "row" : 2
+    }, {
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "col" : 0,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "New Text Block",
+        "chartIndex" : 5,
+        "id" : 9
+      },
+      "row" : 3
+    }, {
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "col" : 6,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1433463909939,
+        "id" : 10
+      },
+      "row" : 3
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 0,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 8,
+        "id" : 11
+      },
+      "row" : 4
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 4,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1442725445775,
+        "id" : 12
+      },
+      "row" : 4
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 8,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 12,
+        "id" : 13
+      },
+      "row" : 4
+    } ],
+    "version" : 1
+  },
+  "sf_discoverySelectors" : [ "_exists_:host" ],
+  "sf_description" : "",
+  "sf_type" : "Dashboard",
+  "sf_discoveryQuery" : "sf_hostHasService:collectd AND _missing_:host_metadata_version",
+  "marshallId" : 16,
+  "marshallMemberOf" : [ 2 ]
+}, {
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 16,
+    "allPlotConstructs" : [ ],
+    "chartType" : "area",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "query" : "plugin_instance:cpu-average",
+        "type" : "property",
+        "NOT" : false,
+        "value" : "plugin_instance:cpu-average"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "aggregation",
+        "propertyValue" : "aggregation",
+        "NOT" : false,
+        "query" : "plugin:aggregation",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "cpu.idle",
+      "seriesData" : {
+        "metric" : "cpu.idle"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "query" : "plugin_instance:cpu-average",
+        "type" : "property",
+        "NOT" : false,
+        "value" : "plugin_instance:cpu-average"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "aggregation",
+        "propertyValue" : "aggregation",
+        "NOT" : false,
+        "query" : "plugin:aggregation",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 3,
+      "name" : "cpu.* - Sum",
+      "seriesData" : {
+        "metric" : "cpu.*",
+        "regExStyle" : null
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "name" : "CPU utilization %",
+      "type" : "ratio",
+      "invisible" : false,
+      "transient" : false,
+      "dataManipulations" : [ ],
+      "yAxisIndex" : 0,
+      "queryItems" : [ ],
+      "metricDefinition" : { },
+      "seriesData" : { },
+      "uniqueKey" : 5,
+      "focusNext" : false,
+      "valid" : true,
+      "expressionText" : "(1 - A/C) * 100"
+    }, {
+      "name" : "New Plot",
+      "type" : "plot",
+      "invisible" : false,
+      "transient" : true,
+      "dataManipulations" : [ ],
+      "yAxisIndex" : 0,
+      "queryItems" : [ ],
+      "metricDefinition" : { },
+      "seriesData" : { },
+      "uniqueKey" : 6,
+      "focusNext" : false
+    } ],
+    "uiHelperValue" : "##CHARTID##_16",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "max" : 110,
+        "min" : 0,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0",
+        "label" : "%"
+      } ],
+      "sortPreference" : ""
+    },
+    "currentUniqueKey" : 7,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.aggregation.cpu-average.cpu.idle AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('aws_Name')->_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_0_5');_SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_16_MACROBLOCK=[?A,?C,!OUT]{(1  -  ?A / ?C)  *  100->!OUT};find(query='(sf_metric:cpu.idle AND _missing_:sf_programId) AND ((plugin_instance:cpu\\\\-average) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:aggregation))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_16;find(query='(sf_metric:cpu.* AND _missing_:sf_programId) AND ((plugin_instance:cpu\\\\-average) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:aggregation))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_16;_SF_PLOT_KEY_##CHARTID##_5_16_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_5_16->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');_SF_PLOT_KEY_##CHARTID##_1_16->?A:_SF_PLOT_KEY_##CHARTID##_5_16_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_16->?C:_SF_PLOT_KEY_##CHARTID##_5_16_MACROBLOCK",
+  "sf_description" : "",
+  "sf_type" : "Chart",
+  "sf_throttledProgramText" : "",
+  "marshallId" : 17,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "CPU %",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_16_MACROBLOCK=[?A,?C,!OUT]{(1  -  ?A / ?C)  *  100->!OUT};find(query='(sf_metric:cpu.idle AND _missing_:sf_programId) AND ((plugin_instance:cpu\\\\-average) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:aggregation))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_16 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');find(query='(sf_metric:cpu.* AND _missing_:sf_programId) AND ((plugin_instance:cpu\\\\-average) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:aggregation))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_16 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');_SF_PLOT_KEY_##CHARTID##_5_16_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_5_16->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');_SF_PLOT_KEY_##CHARTID##_1_16->?A:_SF_PLOT_KEY_##CHARTID##_5_16_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_16->?C:_SF_PLOT_KEY_##CHARTID##_5_16_MACROBLOCK"
+}, {
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 19,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:eth*",
+        "propertyValue" : "eth*",
+        "NOT" : false,
+        "query" : "plugin_instance:eth*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "interface",
+        "propertyValue" : "interface",
+        "NOT" : false,
+        "query" : "plugin:interface",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "input bits/sec",
+      "seriesData" : {
+        "metric" : "if_octets.rx"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "fn" : {
+          "type" : "SCALE",
+          "options" : {
+            "scaleAmount" : 8
+          }
+        },
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "AUTO"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:eth*",
+        "propertyValue" : "eth*",
+        "NOT" : false,
+        "query" : "plugin_instance:eth*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "interface",
+        "propertyValue" : "interface",
+        "NOT" : false,
+        "query" : "plugin:interface",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "output bits/sec",
+      "seriesData" : {
+        "metric" : "if_octets.tx"
+      },
+      "sf_programText" : "find(query='(sf_metric:if_octets.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2) AND (plugin_instance:eth*))') -> fetch -> split -> stats:!mean -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_CGraATOAYAA_2_12=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGraATOAYAA_2_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGraATOAYAA_12')",
+      "dataManipulations" : [ {
+        "fn" : {
+          "type" : "SCALE",
+          "options" : {
+            "scaleAmount" : 8
+          }
+        },
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 1,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "AUTO"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_19",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "range" : -3600000,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "input bits/s - RED",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      }, {
+        "max" : null,
+        "label" : "output bits/s - BLUE",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        },
+        "min" : 0
+      } ],
+      "sortPreference" : "",
+      "forcedResolution" : "0"
+    },
+    "currentUniqueKey" : 4,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.interface*.if_octets.rx AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> ?a:math(b=8):!product -> _SF_PLOT_KEY_SYNTH_CHART_ID_7_1_6=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_7_1_6',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_7_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_7_6')" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_19=id(report=1);find(query='(sf_metric:if_octets.rx AND _missing_:sf_programId) AND ((plugin_instance:eth*) AND (plugin:interface) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_19 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');find(query='(sf_metric:if_octets.tx AND _missing_:sf_programId) AND ((plugin_instance:eth*) AND (plugin:interface) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_2_19 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19')",
+  "sf_description" : "bits/sec",
+  "sf_type" : "Chart",
+  "sf_throttledProgramText" : "",
+  "marshallId" : 18,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "Network I/O",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 8,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_19=id(report=1);find(query='(sf_metric:if_octets.rx AND _missing_:sf_programId) AND ((plugin_instance:eth*) AND (plugin:interface) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_19 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');find(query='(sf_metric:if_octets.tx AND _missing_:sf_programId) AND ((plugin_instance:eth*) AND (plugin:interface) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_2_19 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19')"
+}, {
+  "sf_chart" : "Memory",
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 13,
+    "allPlotConstructs" : [ ],
+    "chartType" : "area",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "memory",
+        "propertyValue" : "memory",
+        "NOT" : false,
+        "query" : "plugin:memory",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "free",
+      "seriesData" : {
+        "metric" : "memory.free"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#05ce00",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "memory",
+        "propertyValue" : "memory",
+        "NOT" : false,
+        "query" : "plugin:memory",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "used by processes",
+      "seriesData" : {
+        "metric" : "memory.used"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#e9008a",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "memory",
+        "propertyValue" : "memory",
+        "NOT" : false,
+        "query" : "plugin:memory",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 3,
+      "name" : "buffer cache",
+      "seriesData" : {
+        "metric" : "memory.buffered"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "memory",
+        "propertyValue" : "memory",
+        "NOT" : false,
+        "query" : "plugin:memory",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 4,
+      "name" : "file/page cache",
+      "seriesData" : {
+        "metric" : "memory.cached"
+      },
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#999999",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "type" : "property",
+        "property" : "host",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "displayName" : "integration-test-zookeeper-3.4.6-0"
+      }, {
+        "iconClass" : "icon-properties",
+        "type" : "property",
+        "property" : "plugin",
+        "propertyValue" : "memory",
+        "query" : "plugin:memory",
+        "value" : "memory",
+        "NOT" : false,
+        "displayName" : "memory"
+      } ],
+      "uniqueKey" : 5,
+      "name" : "memory.* - Sum",
+      "seriesData" : {
+        "metric" : "memory.*",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { },
+      "configuration" : {
+        "rollupPolicy" : null
+      }
+    }, {
+      "name" : "(1 - A/E) * 100",
+      "type" : "ratio",
+      "invisible" : true,
+      "transient" : false,
+      "dataManipulations" : [ ],
+      "yAxisIndex" : 0,
+      "queryItems" : [ ],
+      "metricDefinition" : { },
+      "seriesData" : { },
+      "uniqueKey" : 7,
+      "focusNext" : false,
+      "valid" : true,
+      "expressionText" : "(1 - A/E) * 100"
+    }, {
+      "name" : "New Plot",
+      "type" : "plot",
+      "invisible" : false,
+      "transient" : true,
+      "dataManipulations" : [ ],
+      "yAxisIndex" : 0,
+      "queryItems" : [ ],
+      "metricDefinition" : { },
+      "seriesData" : { },
+      "uniqueKey" : 8,
+      "focusNext" : false
+    } ],
+    "uiHelperValue" : "##CHARTID##_13",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : true,
+      "useKMG2" : true,
+      "colorByMetric" : true,
+      "range" : -3600000,
+      "maxDecimalPlaces" : 3,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "bytes",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "-value",
+      "disableThrottle" : false
+    },
+    "currentUniqueKey" : 9,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.free AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3=id", "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.used AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK=[?B,?A,!OUT]{?B  /  (?A  +  ?B)  *  100->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('sf_source')->groupby('aws_Name')->stats:!mean->_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_2_3');_SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3->?B:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK;_SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_13_MACROBLOCK=[?A,?E,!OUT]{(1  -  ?A / ?E)  *  100->!OUT};find(query='(sf_metric:memory.free AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:memory.used AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:memory.buffered AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_3_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:memory.cached AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_4_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:memory.* AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_5_13;_SF_PLOT_KEY_##CHARTID##_7_13_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_7_13->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');_SF_PLOT_KEY_##CHARTID##_1_13->?A:_SF_PLOT_KEY_##CHARTID##_7_13_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_13->?E:_SF_PLOT_KEY_##CHARTID##_7_13_MACROBLOCK",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 4,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 1000,
+  "sf_throttledProgramText" : "",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_13_MACROBLOCK=[?A,?E,!OUT]{(1  -  ?A / ?E)  *  100->!OUT};find(query='(sf_metric:memory.free AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:memory.used AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:memory.buffered AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_3_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:memory.cached AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_4_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:memory.* AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_5_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_5_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');_SF_PLOT_KEY_##CHARTID##_7_13_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_7_13->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');_SF_PLOT_KEY_##CHARTID##_1_13->?A:_SF_PLOT_KEY_##CHARTID##_7_13_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_13->?E:_SF_PLOT_KEY_##CHARTID##_7_13_MACROBLOCK",
+  "marshallId" : 19,
+  "marshallMemberOf" : [ 16 ]
+}, {
+  "sf_chart" : "CPU Used %",
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 18,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "query" : "plugin_instance:cpu-average",
+        "type" : "property",
+        "NOT" : false,
+        "value" : "plugin_instance:cpu-average"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "aggregation",
+        "propertyValue" : "aggregation",
+        "NOT" : false,
+        "query" : "plugin:aggregation",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "cpu.idle",
+      "seriesData" : {
+        "metric" : "cpu.idle"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "query" : "plugin_instance:cpu-average",
+        "type" : "property",
+        "NOT" : false,
+        "value" : "plugin_instance:cpu-average"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "aggregation",
+        "propertyValue" : "aggregation",
+        "NOT" : false,
+        "query" : "plugin:aggregation",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 3,
+      "name" : "cpu.* - Sum",
+      "seriesData" : {
+        "metric" : "cpu.*",
+        "regExStyle" : null
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "name" : "CPU utilization %",
+      "type" : "ratio",
+      "invisible" : false,
+      "transient" : false,
+      "dataManipulations" : [ ],
+      "yAxisIndex" : 0,
+      "queryItems" : [ ],
+      "metricDefinition" : { },
+      "seriesData" : { },
+      "uniqueKey" : 5,
+      "focusNext" : false,
+      "valid" : true,
+      "expressionText" : "(1 - A/C) * 100"
+    }, {
+      "name" : "New Plot",
+      "type" : "plot",
+      "invisible" : false,
+      "transient" : true,
+      "dataManipulations" : [ ],
+      "yAxisIndex" : 0,
+      "queryItems" : [ ],
+      "metricDefinition" : { },
+      "seriesData" : { },
+      "uniqueKey" : 6,
+      "focusNext" : false
+    } ],
+    "uiHelperValue" : "##CHARTID##_18",
+    "chartMode" : "single",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "max" : 110,
+        "min" : 0,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0",
+        "label" : "%"
+      } ],
+      "sortPreference" : "",
+      "maxDecimalPlaces" : 3
+    },
+    "relatedDetectors" : [ ],
+    "currentUniqueKey" : 7,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.aggregation.cpu-average.cpu.idle AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('aws_Name')->_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_0_5');_SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK=[?A,?C,!OUT]{(1  -  ?A / ?C)  *  100->!OUT};find(query='(sf_metric:cpu.idle AND _missing_:sf_programId) AND ((plugin_instance:cpu\\\\-average) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:aggregation))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_18;find(query='(sf_metric:cpu.* AND _missing_:sf_programId) AND ((plugin_instance:cpu\\\\-average) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:aggregation))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_18;_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_5_18->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_1_18->?A:_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_18->?C:_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK",
+  "sf_cacheProgram" : true,
+  "sf_description" : "",
+  "sf_chartIndex" : 1459444857291,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 6000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK=[?A,?C,!OUT]{(1  -  ?A / ?C)  *  100->!OUT};find(query='(sf_metric:cpu.idle AND _missing_:sf_programId) AND ((plugin_instance:cpu\\\\-average) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:aggregation))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');find(query='(sf_metric:cpu.* AND _missing_:sf_programId) AND ((plugin_instance:cpu\\\\-average) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:aggregation))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_5_18->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_1_18->?A:_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_18->?C:_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK",
+  "marshallId" : 20,
+  "marshallMemberOf" : [ 16 ]
+}, {
+  "sf_chart" : "Memory Used %",
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 16,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "memory",
+        "propertyValue" : "memory",
+        "NOT" : false,
+        "query" : "plugin:memory",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "free",
+      "seriesData" : {
+        "metric" : "memory.free"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#05ce00",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "memory",
+        "propertyValue" : "memory",
+        "NOT" : false,
+        "query" : "plugin:memory",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "used by processes",
+      "seriesData" : {
+        "metric" : "memory.used"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#e9008a",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "memory",
+        "propertyValue" : "memory",
+        "NOT" : false,
+        "query" : "plugin:memory",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 3,
+      "name" : "buffer cache",
+      "seriesData" : {
+        "metric" : "memory.buffered"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "memory",
+        "propertyValue" : "memory",
+        "NOT" : false,
+        "query" : "plugin:memory",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 4,
+      "name" : "file/page cache",
+      "seriesData" : {
+        "metric" : "memory.cached"
+      },
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#999999",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "type" : "property",
+        "property" : "host",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "displayName" : "integration-test-zookeeper-3.4.6-0"
+      }, {
+        "iconClass" : "icon-properties",
+        "type" : "property",
+        "property" : "plugin",
+        "propertyValue" : "memory",
+        "query" : "plugin:memory",
+        "value" : "memory",
+        "NOT" : false,
+        "displayName" : "memory"
+      } ],
+      "uniqueKey" : 5,
+      "name" : "memory.* - Sum",
+      "seriesData" : {
+        "metric" : "memory.*",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { },
+      "configuration" : {
+        "rollupPolicy" : null
+      }
+    }, {
+      "name" : "(B/E) * 100",
+      "type" : "ratio",
+      "invisible" : false,
+      "transient" : false,
+      "dataManipulations" : [ ],
+      "yAxisIndex" : 0,
+      "queryItems" : [ ],
+      "metricDefinition" : { },
+      "seriesData" : { },
+      "uniqueKey" : 7,
+      "focusNext" : false,
+      "valid" : true,
+      "expressionText" : "(B/E) * 100",
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "colorOverride" : "#e9008a"
+      }
+    }, {
+      "name" : "New Plot",
+      "type" : "plot",
+      "invisible" : false,
+      "transient" : true,
+      "dataManipulations" : [ ],
+      "yAxisIndex" : 0,
+      "queryItems" : [ ],
+      "metricDefinition" : { },
+      "seriesData" : { },
+      "uniqueKey" : 8,
+      "focusNext" : false
+    } ],
+    "uiHelperValue" : "##CHARTID##_16",
+    "chartMode" : "single",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : true,
+      "useKMG2" : false,
+      "colorByMetric" : true,
+      "range" : -3600000,
+      "maxDecimalPlaces" : 3,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "%",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "-value",
+      "disableThrottle" : false
+    },
+    "relatedDetectors" : [ ],
+    "currentUniqueKey" : 9,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.free AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3=id", "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.used AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK=[?B,?A,!OUT]{?B  /  (?A  +  ?B)  *  100->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('sf_source')->groupby('aws_Name')->stats:!mean->_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_2_3');_SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3->?B:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK;_SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_16_MACROBLOCK=[?B,?E,!OUT]{(?B / ?E)  *  100->!OUT};find(query='(sf_metric:memory.free AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_16;find(query='(sf_metric:memory.used AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_16;find(query='(sf_metric:memory.buffered AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_3_16;find(query='(sf_metric:memory.cached AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_4_16;find(query='(sf_metric:memory.* AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_5_16;_SF_PLOT_KEY_##CHARTID##_7_16_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_7_16->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');_SF_PLOT_KEY_##CHARTID##_2_16->?B:_SF_PLOT_KEY_##CHARTID##_7_16_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_16->?E:_SF_PLOT_KEY_##CHARTID##_7_16_MACROBLOCK",
+  "sf_cacheProgram" : true,
+  "sf_description" : "",
+  "sf_chartIndex" : 1459445051615,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 6000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_16_MACROBLOCK=[?B,?E,!OUT]{(?B / ?E)  *  100->!OUT};find(query='(sf_metric:memory.free AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_16 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');find(query='(sf_metric:memory.used AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_16 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');find(query='(sf_metric:memory.buffered AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_3_16 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');find(query='(sf_metric:memory.cached AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_4_16 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');find(query='(sf_metric:memory.* AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_5_16 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_5_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');_SF_PLOT_KEY_##CHARTID##_7_16_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_7_16->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');_SF_PLOT_KEY_##CHARTID##_2_16->?B:_SF_PLOT_KEY_##CHARTID##_7_16_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_16->?E:_SF_PLOT_KEY_##CHARTID##_7_16_MACROBLOCK",
+  "marshallId" : 21,
+  "marshallMemberOf" : [ 16 ]
+}, {
+  "sf_chart" : "Disk Used %",
+  "sf_uiModel" : {
+    "revisionNumber" : 9,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "df",
+        "propertyValue" : "df",
+        "NOT" : false,
+        "query" : "plugin:df",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "used bytes",
+      "seriesData" : {
+        "metric" : "df_complex.used"
+      },
+      "dataManipulations" : [ {
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "AUTO"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "df",
+        "propertyValue" : "df",
+        "NOT" : false,
+        "query" : "plugin:df",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "free bytes",
+      "seriesData" : {
+        "metric" : "df_complex.free"
+      },
+      "sf_programText" : "find(query='(sf_metric:df_complex.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2) AND (plugin:df))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY___OBJECT_ID___2_2=id(report=1) -> publish(metric='_SF_PLOT_KEY___OBJECT_ID___2_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='__OBJECT_ID___2')",
+      "dataManipulations" : [ {
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#007c1d",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "AUTO"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "expressionText" : "(1 - B/(A+B))*100",
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "ratio",
+      "valid" : true,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 4,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_9",
+    "chartMode" : "list",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : true,
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "maxDecimalPlaces" : 3,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0",
+        "label" : "%"
+      } ],
+      "sortPreference" : "-value"
+    },
+    "relatedDetectors" : [ ],
+    "currentUniqueKey" : 6
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK=[?B,?A,!OUT]{(1  -  ?B / (?A + ?B)) * 100->!OUT};find(query='(sf_metric:df_complex.used AND _missing_:sf_programId) AND ((plugin:df) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_9;find(query='(sf_metric:df_complex.free AND _missing_:sf_programId) AND ((plugin:df) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_9;_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_9->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');_SF_PLOT_KEY_##CHARTID##_2_9->?B:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_9->?A:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK",
+  "sf_cacheProgram" : true,
+  "sf_description" : "",
+  "sf_chartIndex" : 1459445557108,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 6000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK=[?B,?A,!OUT]{(1  -  ?B / (?A + ?B)) * 100->!OUT};find(query='(sf_metric:df_complex.used AND _missing_:sf_programId) AND ((plugin:df) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');find(query='(sf_metric:df_complex.free AND _missing_:sf_programId) AND ((plugin:df) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_9->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');_SF_PLOT_KEY_##CHARTID##_2_9->?B:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_9->?A:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK",
+  "marshallId" : 22,
+  "marshallMemberOf" : [ 16 ]
+}, {
+  "sf_chart" : "TCP Connections",
+  "sf_uiModel" : {
+    "revisionNumber" : 4,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "protocols",
+        "propertyValue" : "protocols",
+        "NOT" : false,
+        "query" : "plugin:protocols",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "current",
+      "seriesData" : {
+        "metric" : "protocol_counter.CurrEstab"
+      },
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "rollupPolicy" : "MAX_ROLLUP",
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "protocols",
+        "propertyValue" : "protocols",
+        "NOT" : false,
+        "query" : "plugin:protocols",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "new",
+      "seriesData" : {
+        "metric" : "protocol_counter.ActiveOpens"
+      },
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 1,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_4",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "range" : -3600000,
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "current conns - RED",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      }, {
+        "max" : null,
+        "label" : "new conns/sec - BLUE",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        },
+        "min" : 0
+      } ],
+      "sortPreference" : "",
+      "forcedResolution" : "0"
+    },
+    "currentUniqueKey" : 4
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_4=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_4=id(report=1);find(query='(sf_metric:protocol_counter.CurrEstab AND _missing_:sf_programId) AND ((plugin:protocols) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP') -> split -> _SF_PLOT_KEY_##CHARTID##_1_4 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_4');find(query='(sf_metric:protocol_counter.ActiveOpens AND _missing_:sf_programId) AND ((plugin:protocols) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_4 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_4')",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1442725445775,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 1000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_4=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_4=id(report=1);find(query='(sf_metric:protocol_counter.CurrEstab AND _missing_:sf_programId) AND ((plugin:protocols) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP') -> split -> _SF_PLOT_KEY_##CHARTID##_1_4 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_4');find(query='(sf_metric:protocol_counter.ActiveOpens AND _missing_:sf_programId) AND ((plugin:protocols) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_4 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_4')",
+  "marshallId" : 23,
+  "marshallMemberOf" : [ 16 ]
+}, {
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 18,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "interface",
+        "propertyValue" : "interface",
+        "NOT" : false,
+        "query" : "plugin:interface",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:eth*",
+        "propertyValue" : "eth*",
+        "NOT" : false,
+        "query" : "plugin_instance:eth*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "errors/sec",
+      "seriesData" : {
+        "metric" : "if_errors.rx"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : "DELTA_ROLLUP"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "interface",
+        "propertyValue" : "interface",
+        "NOT" : false,
+        "query" : "plugin:interface",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:eth*",
+        "propertyValue" : "eth*",
+        "NOT" : false,
+        "query" : "plugin_instance:eth*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "if_errors.tx",
+      "seriesData" : {
+        "metric" : "if_errors.tx"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : "DELTA_ROLLUP"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "interface errors/sec",
+      "valid" : true,
+      "seriesData" : { },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "ratio",
+      "expressionText" : "A + B",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "protocols",
+        "propertyValue" : "protocols",
+        "NOT" : false,
+        "query" : "plugin:protocols",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 4,
+      "name" : "retransmits/sec",
+      "seriesData" : {
+        "metric" : "protocol_counter.RetransSegs"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 1,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : "DELTA_ROLLUP",
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 5,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_18",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "range" : -3600000,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "interface errors - RED",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      }, {
+        "max" : null,
+        "label" : "retransmits - BLUE",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        },
+        "min" : 0
+      } ],
+      "sortPreference" : ""
+    },
+    "currentUniqueKey" : 6,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.interface.*.if_errors.* AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_10_8')" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_18_MACROBLOCK=[?A,?B,!OUT]{?A  +  ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_4_18=id(report=1);find(query='(sf_metric:if_errors.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(rollup='DELTA_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_18;find(query='(sf_metric:if_errors.tx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(rollup='DELTA_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_18;_SF_PLOT_KEY_##CHARTID##_3_18_MACROBLOCK:!OUT->groupby()->stats:!sum->_SF_PLOT_KEY_##CHARTID##_3_18->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_1_18->?A:_SF_PLOT_KEY_##CHARTID##_3_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_18->?B:_SF_PLOT_KEY_##CHARTID##_3_18_MACROBLOCK;find(query='(sf_metric:protocol_counter.RetransSegs AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:protocols) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_18 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18')",
+  "sf_description" : "errors/sec",
+  "sf_type" : "Chart",
+  "sf_throttledProgramText" : "",
+  "marshallId" : 24,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "Network Errors",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 12,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_18_MACROBLOCK=[?A,?B,!OUT]{?A  +  ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_4_18=id(report=1);find(query='(sf_metric:if_errors.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(rollup='DELTA_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');find(query='(sf_metric:if_errors.tx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(rollup='DELTA_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_3_18_MACROBLOCK:!OUT->groupby()->stats:!sum->_SF_PLOT_KEY_##CHARTID##_3_18->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_1_18->?A:_SF_PLOT_KEY_##CHARTID##_3_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_18->?B:_SF_PLOT_KEY_##CHARTID##_3_18_MACROBLOCK;find(query='(sf_metric:protocol_counter.RetransSegs AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:protocols) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18')"
+}, {
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 14,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "vmem",
+        "propertyValue" : "vmem",
+        "NOT" : false,
+        "query" : "plugin:vmem",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "swapped in",
+      "seriesData" : {
+        "metric" : "vmpage_io.swap.in"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "rollupPolicy" : "DELTA_ROLLUP",
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "vmem",
+        "propertyValue" : "vmem",
+        "NOT" : false,
+        "query" : "plugin:vmem",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "swapped out",
+      "seriesData" : {
+        "metric" : "vmpage_io.swap.out"
+      },
+      "sf_programText" : "find(refresh=300000,query='sf_metric:collectd.vmem.vmpage_io.swap.in AND sf_organizationID:BqDQY5OAAAA AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_BwzVGs0AEAA_2_2=id -> publish(defaultSource='_SF_PLOT_KEY_BwzVGs0AEAA_2_2',metric='_SF_PLOT_KEY_BwzVGs0AEAA_2_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='BwzVGs0AEAA_2')",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 1,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : "DELTA_ROLLUP",
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "query" : "aws_service:quantizer",
+        "type" : "property",
+        "value" : "Aws_service:quantizer"
+      } ],
+      "uniqueKey" : 3,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_14",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : false,
+      "useKMG2" : false,
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "maxDecimalPlaces" : 3,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "swapped in - RED",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      }, {
+        "max" : null,
+        "label" : "swapped out - BLUE",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        },
+        "min" : 0
+      } ],
+      "sortPreference" : "",
+      "disableThrottle" : false
+    },
+    "currentUniqueKey" : 4,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.vmem.vmpage_io.swap.in AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_3_4')", "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.vmem.vmpage_io.swap.out AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_3_4')" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_14=id(report=1);find(query='(sf_metric:vmpage_io.swap.in AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:vmem) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');find(query='(sf_metric:vmpage_io.swap.out AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:vmem) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
+  "sf_description" : "page swaps/sec",
+  "sf_type" : "Chart",
+  "sf_throttledProgramText" : "",
+  "marshallId" : 25,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "Memory Paging",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 3,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_14=id(report=1);find(query='(sf_metric:vmpage_io.swap.in AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:vmem) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');find(query='(sf_metric:vmpage_io.swap.out AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:vmem) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')"
+}, {
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 18,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "disk",
+        "propertyValue" : "disk",
+        "NOT" : false,
+        "query" : "plugin:disk",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "read ops/sec",
+      "seriesData" : {
+        "metric" : "disk_ops.read"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "disk",
+        "propertyValue" : "disk",
+        "NOT" : false,
+        "query" : "plugin:disk",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "write ops/sec",
+      "seriesData" : {
+        "metric" : "disk_ops.write"
+      },
+      "sf_programText" : "find(query='(sf_metric:disk_ops.read AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_CGraATNAgAA_3_10=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGraATNAgAA_3_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGraATNAgAA_10')",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 1,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_18",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "range" : -3600000,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "read ops - RED",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      }, {
+        "max" : null,
+        "label" : "write ops - BLUE",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        },
+        "min" : 0
+      } ],
+      "sortPreference" : ""
+    },
+    "currentUniqueKey" : 5,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.disk.*disk_ops.read AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_6_1_7=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_6_1_7',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_6_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_6_7')" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_18=id(report=1);A => find(query='(sf_metric:disk_ops.read AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:disk) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_18 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');C => find(query='(sf_metric:disk_ops.write AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:disk) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_18 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18')",
+  "sf_description" : "operations/sec",
+  "sf_type" : "Chart",
+  "sf_throttledProgramText" : "",
+  "marshallId" : 26,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "Disk I/O",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 5,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_18=id(report=1);A => find(query='(sf_metric:disk_ops.read AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:disk) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');C => find(query='(sf_metric:disk_ops.write AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:disk) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18')"
+}, {
+  "sf_chart" : "Disk Free %",
+  "sf_uiModel" : {
+    "revisionNumber" : 7,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "df",
+        "propertyValue" : "df",
+        "NOT" : false,
+        "query" : "plugin:df",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "used bytes",
+      "seriesData" : {
+        "metric" : "df_complex.used"
+      },
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "AUTO"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "df",
+        "propertyValue" : "df",
+        "NOT" : false,
+        "query" : "plugin:df",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "free bytes",
+      "seriesData" : {
+        "metric" : "df_complex.free"
+      },
+      "sf_programText" : "find(query='(sf_metric:df_complex.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2) AND (plugin:df))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY___OBJECT_ID___2_2=id(report=1) -> publish(metric='_SF_PLOT_KEY___OBJECT_ID___2_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='__OBJECT_ID___2')",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#007c1d",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "AUTO"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "",
+      "seriesData" : { },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      }, {
+        "fn" : {
+          "type" : "TOPN",
+          "options" : {
+            "count" : 10
+          }
+        },
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "B/(A+B)*100",
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "ratio",
+      "valid" : true,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 4,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_7",
+    "chartMode" : "list",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : true,
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "maxDecimalPlaces" : 3,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "+value"
+    },
+    "currentUniqueKey" : 6
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_7_MACROBLOCK=[?B,?A,!OUT]{?B / (?A + ?B) * 100->!OUT};find(query='(sf_metric:df_complex.used AND _missing_:sf_programId) AND ((plugin:df) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_7;find(query='(sf_metric:df_complex.free AND _missing_:sf_programId) AND ((plugin:df) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_7;_SF_PLOT_KEY_##CHARTID##_3_7_MACROBLOCK:!OUT->groupby('plugin_instance')->stats:!mean->groupby()->groupby()->select(count=10):!top->split->_SF_PLOT_KEY_##CHARTID##_3_7->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');_SF_PLOT_KEY_##CHARTID##_2_7->?B:_SF_PLOT_KEY_##CHARTID##_3_7_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_7->?A:_SF_PLOT_KEY_##CHARTID##_3_7_MACROBLOCK",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1433463909939,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 10000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_7_MACROBLOCK=[?B,?A,!OUT]{?B / (?A + ?B) * 100->!OUT};find(query='(sf_metric:df_complex.used AND _missing_:sf_programId) AND ((plugin:df) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_7 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');find(query='(sf_metric:df_complex.free AND _missing_:sf_programId) AND ((plugin:df) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_7 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');_SF_PLOT_KEY_##CHARTID##_3_7_MACROBLOCK:!OUT->groupby('plugin_instance')->stats:!mean->groupby()->groupby()->select(count=10):!top->split->_SF_PLOT_KEY_##CHARTID##_3_7->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');_SF_PLOT_KEY_##CHARTID##_2_7->?B:_SF_PLOT_KEY_##CHARTID##_3_7_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_7->?A:_SF_PLOT_KEY_##CHARTID##_3_7_MACROBLOCK",
+  "marshallId" : 27,
+  "marshallMemberOf" : [ 16 ]
+}, {
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 14,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "load",
+        "propertyValue" : "load",
+        "NOT" : false,
+        "query" : "plugin:load",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "01-min",
+      "seriesData" : {
+        "metric" : "load.shortterm"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "load",
+        "propertyValue" : "load",
+        "NOT" : false,
+        "query" : "plugin:load",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "05-min",
+      "seriesData" : {
+        "metric" : "load.midterm"
+      },
+      "sf_programText" : "find(query='(sf_metric:load.shortterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_CGraATAAcAA_2_10=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGraATAAcAA_2_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGraATAAcAA_10')",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "load",
+        "propertyValue" : "load",
+        "NOT" : false,
+        "query" : "plugin:load",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 3,
+      "name" : "15-min",
+      "seriesData" : {
+        "metric" : "load.longterm"
+      },
+      "sf_programText" : "find(query='(sf_metric:load.shortterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_CGraATAAcAA_3_10=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGraATAAcAA_3_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGraATAAcAA_10')",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 4,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_14",
+    "chartMode" : "list",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "maxDecimalPlaces" : 3,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : 0,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "+sf_metric"
+    },
+    "currentUniqueKey" : 5,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.load.load.shortterm AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_1_5')" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_14=id(report=1);A => find(query='(sf_metric:load.shortterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:load) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');B => find(query='(sf_metric:load.midterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:load) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');C => find(query='(sf_metric:load.longterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:load) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
+  "sf_description" : "",
+  "sf_type" : "Chart",
+  "sf_throttledProgramText" : "",
+  "marshallId" : 28,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "Load Average",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 2,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_14=id(report=1);A => find(query='(sf_metric:load.shortterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:load) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');B => find(query='(sf_metric:load.midterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:load) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');C => find(query='(sf_metric:load.longterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:load) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')"
+}, {
+  "sf_chart" : "Total Network bits/sec",
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 26,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:eth*",
+        "propertyValue" : "eth*",
+        "NOT" : false,
+        "query" : "plugin_instance:eth*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "interface",
+        "propertyValue" : "interface",
+        "NOT" : false,
+        "query" : "plugin:interface",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "input bits/sec",
+      "seriesData" : {
+        "metric" : "if_octets.rx"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "fn" : {
+          "type" : "SCALE",
+          "options" : {
+            "scaleAmount" : 8
+          }
+        },
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "AUTO"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:eth*",
+        "propertyValue" : "eth*",
+        "NOT" : false,
+        "query" : "plugin_instance:eth*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "interface",
+        "propertyValue" : "interface",
+        "NOT" : false,
+        "query" : "plugin:interface",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "output bits/sec",
+      "seriesData" : {
+        "metric" : "if_octets.tx"
+      },
+      "sf_programText" : "find(query='(sf_metric:if_octets.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2) AND (plugin_instance:eth*))') -> fetch -> split -> stats:!mean -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_CGraATOAYAA_2_12=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGraATOAYAA_2_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGraATOAYAA_12')",
+      "dataManipulations" : [ {
+        "fn" : {
+          "type" : "SCALE",
+          "options" : {
+            "scaleAmount" : 8
+          }
+        },
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 1,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "AUTO"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "A + B",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "type" : "ratio",
+      "valid" : true,
+      "metricDefinition" : { },
+      "expressionText" : "A + B"
+    }, {
+      "name" : "New Plot",
+      "type" : "plot",
+      "invisible" : false,
+      "transient" : true,
+      "dataManipulations" : [ ],
+      "yAxisIndex" : 0,
+      "queryItems" : [ ],
+      "metricDefinition" : { },
+      "seriesData" : { },
+      "uniqueKey" : 4,
+      "focusNext" : false
+    } ],
+    "uiHelperValue" : "##CHARTID##_26",
+    "chartMode" : "list",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "range" : -3600000,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "bits/s",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      }, {
+        "max" : null,
+        "label" : "",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        },
+        "min" : 0
+      } ],
+      "sortPreference" : "+sf_metric",
+      "forcedResolution" : "0",
+      "maxDecimalPlaces" : 4,
+      "useKMG2" : true,
+      "hideDimensionsInList" : true
+    },
+    "relatedDetectors" : [ ],
+    "currentUniqueKey" : 5,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.interface*.if_octets.rx AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> ?a:math(b=8):!product -> _SF_PLOT_KEY_SYNTH_CHART_ID_7_1_6=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_7_1_6',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_7_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_7_6')" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_26_MACROBLOCK=[?A,?B,!OUT]{?A  +  ?B->!OUT};find(query='(sf_metric:if_octets.rx AND _missing_:sf_programId) AND ((plugin_instance:eth*) AND (plugin:interface) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_26 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');find(query='(sf_metric:if_octets.tx AND _missing_:sf_programId) AND ((plugin_instance:eth*) AND (plugin:interface) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_2_26 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_3_26_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_1_26->?A:_SF_PLOT_KEY_##CHARTID##_3_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_26->?B:_SF_PLOT_KEY_##CHARTID##_3_26_MACROBLOCK",
+  "sf_cacheProgram" : true,
+  "sf_description" : "",
+  "sf_chartIndex" : 1459445812323,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 6000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_26_MACROBLOCK=[?A,?B,!OUT]{?A  +  ?B->!OUT};find(query='(sf_metric:if_octets.rx AND _missing_:sf_programId) AND ((plugin_instance:eth*) AND (plugin:interface) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_26 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');find(query='(sf_metric:if_octets.tx AND _missing_:sf_programId) AND ((plugin_instance:eth*) AND (plugin:interface) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_2_26 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_3_26_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_26->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_1_26->?A:_SF_PLOT_KEY_##CHARTID##_3_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_26->?B:_SF_PLOT_KEY_##CHARTID##_3_26_MACROBLOCK",
+  "marshallId" : 29,
+  "marshallMemberOf" : [ 16 ]
+} ]

--- a/CollectD/Page_CollectD_SFX.json
+++ b/CollectD/Page_CollectD_SFX.json
@@ -1,0 +1,4738 @@
+[ {
+  "marshallScope" : 2
+}, {
+  "sf_description" : "",
+  "sf_type" : "Service",
+  "sf_service" : "Infrastructure",
+  "marshallId" : 1
+}, {
+  "sf_page" : "Infrastructure",
+  "sf_description" : "Dashboards about infrastructure as measured by collectd and the SignalFx collectd plugin.",
+  "sf_type" : "Page",
+  "marshallId" : 2,
+  "marshallMemberOf" : [ 1 ]
+}, {
+  "sf_dashboard" : "Collectd (a)",
+  "sf_uiModel" : {
+    "widgets" : [ {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 0,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "New Text Block",
+        "chartIndex" : 13,
+        "id" : 1
+      },
+      "row" : 0
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 4,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "New Text Block",
+        "chartIndex" : 1,
+        "id" : 2
+      },
+      "row" : 0
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 8,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 6,
+        "id" : 3
+      },
+      "row" : 0
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 0,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 2,
+        "id" : 4
+      },
+      "row" : 1
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 4,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1433981315431,
+        "id" : 5
+      },
+      "row" : 1
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 8,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1433983517758,
+        "id" : 6
+      },
+      "row" : 1
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 0,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1433972294516,
+        "id" : 7
+      },
+      "row" : 2
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 4,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "New Text Block",
+        "chartIndex" : 4,
+        "id" : 8
+      },
+      "row" : 2
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 8,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "New Text Block",
+        "chartIndex" : 3,
+        "id" : 9
+      },
+      "row" : 2
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 0,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1433978780955,
+        "id" : 10
+      },
+      "row" : 3
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 4,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 10,
+        "id" : 11
+      },
+      "row" : 3
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 8,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1433985567407,
+        "id" : 12
+      },
+      "row" : 3
+    } ],
+    "version" : 1
+  },
+  "sf_discoverySelectors" : [ "_exists_:aws_region", "_exists_:aws_availability_zone", "sf_key:host", "_exists_:aws_instance_type" ],
+  "sf_description" : "",
+  "sf_type" : "Dashboard",
+  "sf_discoveryQuery" : "plugin:signalfx-metadata",
+  "marshallId" : 3,
+  "marshallMemberOf" : [ 2 ]
+}, {
+  "sf_chart" : "# Active Hosts",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 13,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "memory",
+        "propertyValue" : "memory",
+        "NOT" : false,
+        "query" : "plugin:memory",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "cpu.idle - COUNT",
+      "seriesData" : {
+        "metric" : "memory.free"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "COUNT",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null,
+        "maxExtrapolations" : 5,
+        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_13",
+    "chartMode" : "single",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "maxDecimalPlaces" : 4,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "",
+      "disableThrottle" : false
+    },
+    "currentUniqueKey" : 4
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);find(query='(sf_metric:memory.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 13,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 10000,
+  "sf_throttledProgramText" : "",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);find(query='(sf_metric:memory.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')",
+  "marshallId" : 4,
+  "marshallMemberOf" : [ 3 ]
+}, {
+  "sf_chart" : "Top CPU %",
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 19,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "type" : "property",
+        "property" : "plugin",
+        "propertyValue" : "signalfx-metadata",
+        "query" : "plugin:\"signalfx-metadata\"",
+        "value" : "signalfx-metadata",
+        "NOT" : false,
+        "displayName" : "signalfx-metadata"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "",
+      "seriesData" : {
+        "metric" : "cpu.utilization",
+        "regExStyle" : null
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "type" : "transformation",
+          "options" : {
+            "amount" : 1,
+            "transformTimeRange" : "1m",
+            "unit" : "m"
+          }
+        },
+        "name" : "New Transform",
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      }, {
+        "fn" : {
+          "type" : "TOPN",
+          "options" : {
+            "count" : 10
+          }
+        },
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "name" : "New Plot",
+      "type" : "plot",
+      "invisible" : false,
+      "transient" : true,
+      "dataManipulations" : [ ],
+      "yAxisIndex" : 0,
+      "queryItems" : [ ],
+      "metricDefinition" : { },
+      "seriesData" : { },
+      "uniqueKey" : 6,
+      "focusNext" : false
+    } ],
+    "uiHelperValue" : "##CHARTID##_19",
+    "chartMode" : "list",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "forcedResolution" : "0",
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "maxDecimalPlaces" : 3,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "max" : 120,
+        "min" : 0,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "-value",
+      "disableThrottle" : false,
+      "hideDimensionsInList" : false
+    },
+    "currentUniqueKey" : 7,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.aggregation.cpu-average.cpu.idle AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('aws_Name')->_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_0_5');_SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_19=id(report=1);find(query='(sf_metric:cpu.utilization AND _missing_:sf_programId) AND ((plugin:signalfx\\\\-metadata))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!mean -> window(1m) -> stats:!mean -> groupby() -> groupby() -> select(count=10):!top -> split -> _SF_PLOT_KEY_##CHARTID##_1_19 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19')",
+  "sf_cacheProgram" : true,
+  "sf_chartIndex" : 1433981315431,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 6000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_19=id(report=1);find(query='(sf_metric:cpu.utilization AND _missing_:sf_programId) AND ((plugin:signalfx\\\\-metadata))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!mean -> window(1m) -> stats:!mean -> groupby() -> groupby() -> select(count=10):!top -> split -> _SF_PLOT_KEY_##CHARTID##_1_19 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19')",
+  "marshallId" : 5,
+  "marshallMemberOf" : [ 3 ]
+}, {
+  "sf_chart" : "Total Disk Space",
+  "sf_uiModel" : {
+    "revisionNumber" : 8,
+    "allPlotConstructs" : [ ],
+    "chartType" : "area",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "df",
+        "propertyValue" : "df",
+        "NOT" : false,
+        "query" : "plugin:df",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "used bytes",
+      "seriesData" : {
+        "metric" : "df_complex.used"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : 5,
+        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "df",
+        "propertyValue" : "df",
+        "NOT" : false,
+        "query" : "plugin:df",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "free bytes",
+      "seriesData" : {
+        "metric" : "df_complex.free"
+      },
+      "sf_programText" : "find(query='(sf_metric:df_complex.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2) AND (plugin:df))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY___OBJECT_ID___2_2=id(report=1) -> publish(metric='_SF_PLOT_KEY___OBJECT_ID___2_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='__OBJECT_ID___2')",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#007c1d",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : 5,
+        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_8",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : true,
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "maxDecimalPlaces" : 3,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : null,
+        "max" : null,
+        "label" : "bytes",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "+value"
+    },
+    "currentUniqueKey" : 6
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_8=id(report=1);find(query='(sf_metric:df_complex.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:df))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8');find(query='(sf_metric:df_complex.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:df))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1433983517758,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 1000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_8=id(report=1);find(query='(sf_metric:df_complex.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:df))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_8 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8');find(query='(sf_metric:df_complex.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:df))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_8 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
+  "marshallId" : 6,
+  "marshallMemberOf" : [ 3 ]
+}, {
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 18,
+    "allPlotConstructs" : [ ],
+    "chartType" : "area",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "type" : "property",
+        "property" : "plugin",
+        "propertyValue" : "signalfx-metadata",
+        "query" : "plugin:\"signalfx-metadata\"",
+        "value" : "signalfx-metadata",
+        "NOT" : false,
+        "displayName" : "signalfx-metadata"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "memory.utilization",
+      "seriesData" : {
+        "metric" : "memory.utilization",
+        "regExStyle" : null
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 4,
+      "name" : "min",
+      "seriesData" : { },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "MIN",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#05ce00",
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "ratio",
+      "valid" : true,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 5,
+      "name" : "p10",
+      "seriesData" : { },
+      "sf_programText" : "_SF_PLOT_KEY_CGrk08TAYAA_6_12_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08TAYAA_6_12_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_CGrk08TAYAA_6_12=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08TAYAA_6_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08TAYAA_12');_SF_PLOT_KEY_CGrk08TAYAA_3_12->?C:_SF_PLOT_KEY_CGrk08TAYAA_6_12_MACROBLOCK",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "PERCENTILE",
+          "options" : {
+            "percentile" : 10
+          }
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0dba8f",
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "ratio",
+      "valid" : true,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 6,
+      "name" : "median",
+      "seriesData" : { },
+      "sf_programText" : "_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_CGrk08TAYAA_7_12=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08TAYAA_7_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08TAYAA_12');_SF_PLOT_KEY_CGrk08TAYAA_3_12->?C:_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "PERCENTILE",
+          "options" : {
+            "percentile" : 50
+          }
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#00b9ff",
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "ratio",
+      "valid" : true,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 7,
+      "name" : "p90",
+      "seriesData" : { },
+      "sf_programText" : "_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_CGrk08TAYAA_7_12=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08TAYAA_7_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08TAYAA_12');_SF_PLOT_KEY_CGrk08TAYAA_3_12->?C:_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "PERCENTILE",
+          "options" : {
+            "percentile" : 90
+          }
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#ff8dd1",
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "ratio",
+      "valid" : true,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 8,
+      "name" : "max",
+      "seriesData" : { },
+      "sf_programText" : "_SF_PLOT_KEY_CGrk08TAYAA_5_13_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08TAYAA_5_13_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_CGrk08TAYAA_5_13=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08TAYAA_5_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08TAYAA_13');_SF_PLOT_KEY_CGrk08TAYAA_3_13->?C:_SF_PLOT_KEY_CGrk08TAYAA_5_13_MACROBLOCK",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "MAX",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#bd468d",
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "ratio",
+      "valid" : true,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 9,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_18",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "forcedResolution" : "0",
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "max" : 120,
+        "min" : 0,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "",
+      "disableThrottle" : false,
+      "stackedChart" : false
+    },
+    "currentUniqueKey" : 12,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.free AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3=id", "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.used AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK=[?B,?A,!OUT]{?B  /  (?A  +  ?B)  *  100->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('sf_source')->groupby('aws_Name')->stats:!mean->_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_2_3');_SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3->?B:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK;_SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_18_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_5_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_6_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_18_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_7_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_8_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_18_MACROBLOCK=[?A,!OUT]{?A->!OUT};find(query='(sf_metric:memory.utilization AND _missing_:sf_programId) AND ((plugin:signalfx\\\\-metadata))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_18;_SF_PLOT_KEY_##CHARTID##_4_18_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_4_18->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_1_18->?A:_SF_PLOT_KEY_##CHARTID##_4_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_5_18->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_1_18->?A:_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_18_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_6_18->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_1_18->?A:_SF_PLOT_KEY_##CHARTID##_6_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_7_18->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_1_18->?A:_SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_18_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_8_18->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_1_18->?A:_SF_PLOT_KEY_##CHARTID##_8_18_MACROBLOCK",
+  "sf_description" : "percentile distribution",
+  "sf_type" : "Chart",
+  "sf_throttledProgramText" : "",
+  "marshallId" : 7,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Memory Used %",
+  "sf_cacheProgram" : true,
+  "sf_chartIndex" : 4,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 6000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_18_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_5_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_6_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_18_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_7_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_8_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_18_MACROBLOCK=[?A,!OUT]{?A->!OUT};find(query='(sf_metric:memory.utilization AND _missing_:sf_programId) AND ((plugin:signalfx\\\\-metadata))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_4_18_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_4_18->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_1_18->?A:_SF_PLOT_KEY_##CHARTID##_4_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_5_18->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_1_18->?A:_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_18_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_6_18->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_1_18->?A:_SF_PLOT_KEY_##CHARTID##_6_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_7_18->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_1_18->?A:_SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_18_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_8_18->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_1_18->?A:_SF_PLOT_KEY_##CHARTID##_8_18_MACROBLOCK"
+}, {
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 26,
+    "allPlotConstructs" : [ ],
+    "chartType" : "area",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "type" : "property",
+        "property" : "plugin",
+        "propertyValue" : "signalfx-metadata",
+        "query" : "plugin:\"signalfx-metadata\"",
+        "value" : "signalfx-metadata",
+        "NOT" : false,
+        "displayName" : "signalfx-metadata"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "cpu.utilization - Mean by host",
+      "seriesData" : {
+        "metric" : "cpu.utilization",
+        "regExStyle" : null
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "query" : "aws_service:quantizer",
+        "type" : "property",
+        "value" : "Aws_service:quantizer"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "cpu %",
+      "valid" : true,
+      "seriesData" : { },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "fn" : {
+          "type" : "MAX",
+          "options" : { }
+        },
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "ratio",
+      "expressionText" : "A",
+      "metricDefinition" : { },
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "colorOverride" : "#bd468d"
+      }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "query" : "aws_service:quantizer",
+        "type" : "property",
+        "value" : "Aws_service:quantizer"
+      } ],
+      "uniqueKey" : 3,
+      "name" : "min",
+      "valid" : true,
+      "seriesData" : { },
+      "sf_programText" : "_SF_PLOT_KEY_CGrk08NAYAA_3_15_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_CGrk08NAYAA_3_15_MACROBLOCK:!OUT->_SF_PLOT_KEY_CGrk08NAYAA_3_15=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08NAYAA_3_15',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08NAYAA_15');_SF_PLOT_KEY_CGrk08NAYAA_1_15->?A:_SF_PLOT_KEY_CGrk08NAYAA_3_15_MACROBLOCK",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "MIN",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#05ce00",
+        "visualization" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "ratio",
+      "expressionText" : "A",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "query" : "aws_service:quantizer",
+        "type" : "property",
+        "value" : "Aws_service:quantizer"
+      } ],
+      "uniqueKey" : 4,
+      "name" : "p10",
+      "valid" : true,
+      "seriesData" : { },
+      "sf_programText" : "_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_CGrk08NAYAA_4_19=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08NAYAA_4_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08NAYAA_19');_SF_PLOT_KEY_CGrk08NAYAA_3_19->?C:_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "PERCENTILE",
+          "options" : {
+            "percentile" : 10
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#00b9ff",
+        "visualization" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "ratio",
+      "expressionText" : "A",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "query" : "aws_service:quantizer",
+        "type" : "property",
+        "value" : "Aws_service:quantizer"
+      } ],
+      "uniqueKey" : 5,
+      "name" : "median",
+      "valid" : true,
+      "seriesData" : { },
+      "sf_programText" : "_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_CGrk08NAYAA_4_19=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08NAYAA_4_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08NAYAA_19');_SF_PLOT_KEY_CGrk08NAYAA_3_19->?C:_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "PERCENTILE",
+          "options" : {
+            "percentile" : 50
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#e5b312",
+        "visualization" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "ratio",
+      "expressionText" : "A",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "query" : "aws_service:quantizer",
+        "type" : "property",
+        "value" : "Aws_service:quantizer"
+      } ],
+      "uniqueKey" : 6,
+      "name" : "p90",
+      "valid" : true,
+      "seriesData" : { },
+      "sf_programText" : "_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_CGrk08NAYAA_4_19=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08NAYAA_4_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08NAYAA_19');_SF_PLOT_KEY_CGrk08NAYAA_3_19->?C:_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "PERCENTILE",
+          "options" : {
+            "percentile" : 90
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#f47e00",
+        "visualization" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "ratio",
+      "expressionText" : "A",
+      "metricDefinition" : { }
+    }, {
+      "name" : "New Plot",
+      "type" : "plot",
+      "invisible" : false,
+      "transient" : true,
+      "dataManipulations" : [ ],
+      "yAxisIndex" : 0,
+      "queryItems" : [ ],
+      "metricDefinition" : { },
+      "seriesData" : { },
+      "uniqueKey" : 11,
+      "focusNext" : false
+    } ],
+    "uiHelperValue" : "##CHARTID##_26",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "forcedResolution" : "0",
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "max" : 110,
+        "min" : 0,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "",
+      "disableThrottle" : false
+    },
+    "currentUniqueKey" : 12,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.aggregation.cpu-average.cpu.idle AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('aws_Name')->_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_0_5');_SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_26_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_3_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_26_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_4_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_26_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_5_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_6_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_26_MACROBLOCK=[?A,!OUT]{?A->!OUT};find(query='(sf_metric:cpu.utilization AND _missing_:sf_programId) AND ((plugin:signalfx\\\\-metadata))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_26;_SF_PLOT_KEY_##CHARTID##_2_26_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_2_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_2_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_1_26->?A:_SF_PLOT_KEY_##CHARTID##_2_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_26_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_3_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_1_26->?A:_SF_PLOT_KEY_##CHARTID##_3_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_26_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_4_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_1_26->?A:_SF_PLOT_KEY_##CHARTID##_4_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_5_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_1_26->?A:_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_26_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_6_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_1_26->?A:_SF_PLOT_KEY_##CHARTID##_6_26_MACROBLOCK",
+  "sf_description" : "percentile distribution",
+  "sf_type" : "Chart",
+  "sf_throttledProgramText" : "",
+  "marshallId" : 8,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "CPU %",
+  "sf_cacheProgram" : true,
+  "sf_chartIndex" : 1,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 6000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_26_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_3_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_26_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_4_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_26_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_5_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_6_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_26_MACROBLOCK=[?A,!OUT]{?A->!OUT};find(query='(sf_metric:cpu.utilization AND _missing_:sf_programId) AND ((plugin:signalfx\\\\-metadata))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_26 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_2_26_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_2_26->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_2_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_1_26->?A:_SF_PLOT_KEY_##CHARTID##_2_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_26_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_3_26->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_1_26->?A:_SF_PLOT_KEY_##CHARTID##_3_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_26_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_4_26->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_1_26->?A:_SF_PLOT_KEY_##CHARTID##_4_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_5_26->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_1_26->?A:_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_26_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_6_26->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_1_26->?A:_SF_PLOT_KEY_##CHARTID##_6_26_MACROBLOCK"
+}, {
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 13,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "load",
+        "propertyValue" : "load",
+        "NOT" : false,
+        "query" : "plugin:load",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "",
+      "seriesData" : {
+        "metric" : "load.midterm"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "transformation",
+          "options" : {
+            "amount" : 1,
+            "transformTimeRange" : "1m",
+            "unit" : "m"
+          }
+        },
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      }, {
+        "fn" : {
+          "type" : "TOPN",
+          "options" : {
+            "count" : 10
+          }
+        },
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "query" : "aws_service:quantizer",
+        "type" : "property",
+        "value" : "Aws_service:quantizer"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_13",
+    "chartMode" : "list",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "maxDecimalPlaces" : 3,
+      "updateInterval" : "",
+      "disableThrottle" : false,
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : 0,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "-value",
+      "forcedResolution" : "0"
+    },
+    "currentUniqueKey" : 3,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.load.load.shortterm AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_1_5')" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);find(query='(sf_metric:load.midterm AND _missing_:sf_programId) AND ((plugin:load))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> window(1m) -> stats:!mean -> groupby('host') -> stats:!mean -> groupby() -> groupby() -> select(count=10):!top -> split -> _SF_PLOT_KEY_##CHARTID##_1_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')",
+  "sf_description" : "",
+  "sf_type" : "Chart",
+  "sf_throttledProgramText" : "",
+  "marshallId" : 9,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Top 5-min Load Avg",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 2,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);find(query='(sf_metric:load.midterm AND _missing_:sf_programId) AND ((plugin:load))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> window(1m) -> stats:!mean -> groupby('host') -> stats:!mean -> groupby() -> groupby() -> select(count=10):!top -> split -> _SF_PLOT_KEY_##CHARTID##_1_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')"
+}, {
+  "sf_chart" : "Total Network Errors",
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 19,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "interface",
+        "propertyValue" : "interface",
+        "NOT" : false,
+        "query" : "plugin:interface",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:eth*",
+        "propertyValue" : "eth*",
+        "NOT" : false,
+        "query" : "plugin_instance:eth*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "errors/sec",
+      "seriesData" : {
+        "metric" : "if_errors.rx"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "interface",
+        "propertyValue" : "interface",
+        "NOT" : false,
+        "query" : "plugin:interface",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:eth*",
+        "propertyValue" : "eth*",
+        "NOT" : false,
+        "query" : "plugin_instance:eth*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "if_errors.tx",
+      "seriesData" : {
+        "metric" : "if_errors.tx"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "interface errors / sec",
+      "valid" : true,
+      "seriesData" : { },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "ratio",
+      "expressionText" : "A + B",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "protocols",
+        "propertyValue" : "protocols",
+        "NOT" : false,
+        "query" : "plugin:protocols",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 4,
+      "name" : "retransmits / sec",
+      "seriesData" : {
+        "metric" : "protocol_counter.RetransSegs"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 1,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : "DELTA_ROLLUP",
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 5,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_19",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : false,
+      "colorByMetric" : true,
+      "range" : -3600000,
+      "updateInterval" : "",
+      "disableThrottle" : false,
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "interface errors - RED",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      }, {
+        "max" : null,
+        "label" : "retransmits - BLUE",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        },
+        "min" : null
+      } ],
+      "sortPreference" : "",
+      "forcedResolution" : "0"
+    },
+    "currentUniqueKey" : 6,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.interface.*.if_errors.* AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_10_8')" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_19=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK=[?A,?B,!OUT]{?A  +  ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_4_19=id(report=1);A => find(query='(sf_metric:if_errors.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_19;B => find(query='(sf_metric:if_errors.tx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_19;_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK:!OUT->groupby()->stats:!sum->_SF_PLOT_KEY_##CHARTID##_3_19->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');_SF_PLOT_KEY_##CHARTID##_1_19->?A:_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_19->?B:_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK;D => find(query='(sf_metric:protocol_counter.RetransSegs AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:protocols))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_19 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19')",
+  "sf_cacheProgram" : false,
+  "sf_description" : "errors/sec",
+  "sf_chartIndex" : 1433985567407,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 1000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_19=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK=[?A,?B,!OUT]{?A  +  ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_4_19=id(report=1);A => find(query='(sf_metric:if_errors.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_19 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');B => find(query='(sf_metric:if_errors.tx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_19 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK:!OUT->groupby()->stats:!sum->_SF_PLOT_KEY_##CHARTID##_3_19->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');_SF_PLOT_KEY_##CHARTID##_1_19->?A:_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_19->?B:_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK;D => find(query='(sf_metric:protocol_counter.RetransSegs AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:protocols))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_19 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19')",
+  "marshallId" : 10,
+  "marshallMemberOf" : [ 3 ]
+}, {
+  "sf_chart" : "Total Memory",
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 18,
+    "allPlotConstructs" : [ ],
+    "chartType" : "area",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "memory",
+        "propertyValue" : "memory",
+        "NOT" : false,
+        "query" : "plugin:memory",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "free",
+      "seriesData" : {
+        "metric" : "memory.free"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "sf_metric"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#05ce00",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : 5,
+        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "memory",
+        "propertyValue" : "memory",
+        "NOT" : false,
+        "query" : "plugin:memory",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "used by processes",
+      "seriesData" : {
+        "metric" : "memory.used"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "sf_metric"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : 5,
+        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "memory",
+        "propertyValue" : "memory",
+        "NOT" : false,
+        "query" : "plugin:memory",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 3,
+      "name" : "buffer cache",
+      "seriesData" : {
+        "metric" : "memory.buffered"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "sf_metric"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : 5,
+        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "memory",
+        "propertyValue" : "memory",
+        "NOT" : false,
+        "query" : "plugin:memory",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 4,
+      "name" : "file/page cache",
+      "seriesData" : {
+        "metric" : "memory.cached"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "sf_metric"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#999999",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : 5,
+        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 5,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_18",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : true,
+      "forcedResolution" : "0",
+      "useKMG2" : true,
+      "colorByMetric" : true,
+      "range" : -3600000,
+      "maxDecimalPlaces" : 4,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "bytes",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "-value",
+      "disableThrottle" : false
+    },
+    "currentUniqueKey" : 7,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.free AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3=id", "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.used AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK=[?B,?A,!OUT]{?B  /  (?A  +  ?B)  *  100->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('sf_source')->groupby('aws_Name')->stats:!mean->_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_2_3');_SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3->?B:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK;_SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_18=id(report=1);A => find(query='(sf_metric:memory.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_18 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');B => find(query='(sf_metric:memory.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_18 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');D => find(query='(sf_metric:memory.buffered AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_18 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');E => find(query='(sf_metric:memory.cached AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_5_18 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_5_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18')",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1433972294516,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 1000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_18=id(report=1);A => find(query='(sf_metric:memory.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');B => find(query='(sf_metric:memory.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');D => find(query='(sf_metric:memory.buffered AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');E => find(query='(sf_metric:memory.cached AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_5_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_5_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18')",
+  "marshallId" : 11,
+  "marshallMemberOf" : [ 3 ]
+}, {
+  "sf_chart" : "Total Disk I/O Ops",
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 12,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "disk",
+        "propertyValue" : "disk",
+        "NOT" : false,
+        "query" : "plugin:disk",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "write ops/sec",
+      "seriesData" : {
+        "metric" : "disk_ops.write"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 1,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "disk",
+        "propertyValue" : "disk",
+        "NOT" : false,
+        "query" : "plugin:disk",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "read ops/sec",
+      "seriesData" : {
+        "metric" : "disk_ops.read"
+      },
+      "sf_programText" : "find(query='(sf_metric:disk_ops.write AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_CGrk08YAgAA_3_9=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGrk08YAgAA_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08YAgAA_9')",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_12",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "reads / s - RED",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      }, {
+        "max" : null,
+        "label" : "writes / s - BLUE",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        },
+        "min" : 0
+      } ],
+      "sortPreference" : "",
+      "forcedResolution" : "0"
+    },
+    "currentUniqueKey" : 5,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.disk.*disk_ops.write AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_5_6')" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_12=id(report=1);find(query='(sf_metric:disk_ops.write AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:disk))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');find(query='(sf_metric:disk_ops.read AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:disk))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 6,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 1000,
+  "sf_throttledProgramText" : "",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_12=id(report=1);find(query='(sf_metric:disk_ops.write AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:disk))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');find(query='(sf_metric:disk_ops.read AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:disk))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
+  "marshallId" : 12,
+  "marshallMemberOf" : [ 3 ]
+}, {
+  "sf_chart" : "Total Network I/O",
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 14,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "interface",
+        "propertyValue" : "interface",
+        "NOT" : false,
+        "query" : "plugin:interface",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:eth*",
+        "propertyValue" : "eth*",
+        "NOT" : false,
+        "query" : "plugin_instance:eth*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "transmitted bits/sec",
+      "seriesData" : {
+        "metric" : "if_octets.tx"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "SCALE",
+          "options" : {
+            "scaleAmount" : 8
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 1,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "AUTO"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "interface",
+        "propertyValue" : "interface",
+        "NOT" : false,
+        "query" : "plugin:interface",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:eth*",
+        "propertyValue" : "eth*",
+        "NOT" : false,
+        "query" : "plugin_instance:eth*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "received bits/sec",
+      "seriesData" : {
+        "metric" : "if_octets.rx"
+      },
+      "sf_programText" : "find(query='(sf_metric:disk_ops.write AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_CGrk08YAgAA_3_9=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGrk08YAgAA_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08YAgAA_9')",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "SCALE",
+          "options" : {
+            "scaleAmount" : 8
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "AUTO"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_14",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "updateInterval" : "",
+      "disableThrottle" : false,
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "received - RED",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      }, {
+        "max" : null,
+        "label" : "transmitted - BLUE",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        },
+        "min" : 0
+      } ],
+      "sortPreference" : "",
+      "forcedResolution" : "0"
+    },
+    "currentUniqueKey" : 5,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.disk.*disk_ops.write AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_5_6')" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_14=id(report=1);A => find(query='(sf_metric:if_octets.tx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!sum -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');C => find(query='(sf_metric:if_octets.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!sum -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_3_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
+  "sf_cacheProgram" : false,
+  "sf_description" : "bits/sec",
+  "sf_chartIndex" : 1433978780955,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 1000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_14=id(report=1);A => find(query='(sf_metric:if_octets.tx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!sum -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');C => find(query='(sf_metric:if_octets.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!sum -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_3_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
+  "marshallId" : 13,
+  "marshallMemberOf" : [ 3 ]
+}, {
+  "sf_chart" : "Total TCP Connections",
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 14,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "protocols",
+        "propertyValue" : "protocols",
+        "NOT" : false,
+        "query" : "plugin:protocols",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "# current conns",
+      "seriesData" : {
+        "metric" : "protocol_counter.CurrEstab"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "rollupPolicy" : "MAX_ROLLUP",
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "protocols",
+        "propertyValue" : "protocols",
+        "NOT" : false,
+        "query" : "plugin:protocols",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "# new conns / sec",
+      "seriesData" : {
+        "metric" : "protocol_counter.ActiveOpens"
+      },
+      "sf_programText" : "find(query='(sf_metric:protocol_counter.CurrEstab AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> split -> stats:!mean -> window(1m) -> stats:!mean -> groupby() -> stats:!sum -> _SF_PLOT_KEY_CGrk08gAcAA_2_11=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGrk08gAcAA_2_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08gAcAA_11')",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 1,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_14",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "updateInterval" : "",
+      "disableThrottle" : false,
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "current conns - RED",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      }, {
+        "max" : null,
+        "label" : "new conns / s - BLUE",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        },
+        "min" : 0
+      } ],
+      "sortPreference" : "",
+      "forcedResolution" : "0"
+    },
+    "currentUniqueKey" : 4,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.protocols.Tcp.protocol_counter.CurrEstab AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch(rollup='AVERAGE_ROLLUP') -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_11_1_5=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_11_1_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_11_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_11_5')" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_14=id(report=1);A => find(query='(sf_metric:protocol_counter.CurrEstab AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:protocols))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP') -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');B => find(query='(sf_metric:protocol_counter.ActiveOpens AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:protocols))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 10,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 1000,
+  "sf_throttledProgramText" : "",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_14=id(report=1);A => find(query='(sf_metric:protocol_counter.CurrEstab AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:protocols))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP') -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');B => find(query='(sf_metric:protocol_counter.ActiveOpens AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:protocols))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
+  "marshallId" : 14,
+  "marshallMemberOf" : [ 3 ]
+}, {
+  "sf_chart" : "Top Mem Page Swaps/sec",
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 12,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "vmem",
+        "propertyValue" : "vmem",
+        "NOT" : false,
+        "query" : "plugin:vmem",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "pages swapped in/sec",
+      "seriesData" : {
+        "metric" : "vmpage_io.swap.in"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "vmem",
+        "propertyValue" : "vmem",
+        "NOT" : false,
+        "query" : "plugin:vmem",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "pages swapped out/sec",
+      "seriesData" : {
+        "metric" : "vmpage_io.swap.out"
+      },
+      "sf_programText" : "find(refresh=300000,query='sf_metric:collectd.vmem.vmpage_io.swap.in AND sf_organizationID:BqDQY5OAAAA AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_BwzVGs0AEAA_2_2=id -> publish(defaultSource='_SF_PLOT_KEY_BwzVGs0AEAA_2_2',metric='_SF_PLOT_KEY_BwzVGs0AEAA_2_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='BwzVGs0AEAA_2')",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 1,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "query" : "aws_service:quantizer",
+        "type" : "property",
+        "value" : "Aws_service:quantizer"
+      } ],
+      "uniqueKey" : 3,
+      "name" : "",
+      "seriesData" : { },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "TOPN",
+          "options" : {
+            "count" : 10
+          }
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A+B",
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "ratio",
+      "valid" : true,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 4,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_12",
+    "chartMode" : "list",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      }, {
+        "max" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        },
+        "min" : null
+      } ],
+      "sortPreference" : "-value"
+    },
+    "currentUniqueKey" : 5,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.vmem.vmpage_io.swap.in AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_3_4')", "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.vmem.vmpage_io.swap.out AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_3_4')" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_12_MACROBLOCK=[?A,?B,!OUT]{?A + ?B->!OUT};find(query='(sf_metric:vmpage_io.swap.in AND _missing_:sf_programId) AND ((plugin:vmem))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_12;find(query='(sf_metric:vmpage_io.swap.out AND _missing_:sf_programId) AND ((plugin:vmem))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_12;_SF_PLOT_KEY_##CHARTID##_3_12_MACROBLOCK:!OUT->groupby('host')->stats:!mean->groupby()->groupby()->select(count=10):!top->split->_SF_PLOT_KEY_##CHARTID##_3_12->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');_SF_PLOT_KEY_##CHARTID##_1_12->?A:_SF_PLOT_KEY_##CHARTID##_3_12_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_12->?B:_SF_PLOT_KEY_##CHARTID##_3_12_MACROBLOCK",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 3,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 10000,
+  "sf_throttledProgramText" : "",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_12_MACROBLOCK=[?A,?B,!OUT]{?A + ?B->!OUT};find(query='(sf_metric:vmpage_io.swap.in AND _missing_:sf_programId) AND ((plugin:vmem))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');find(query='(sf_metric:vmpage_io.swap.out AND _missing_:sf_programId) AND ((plugin:vmem))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');_SF_PLOT_KEY_##CHARTID##_3_12_MACROBLOCK:!OUT->groupby('host')->stats:!mean->groupby()->groupby()->select(count=10):!top->split->_SF_PLOT_KEY_##CHARTID##_3_12->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');_SF_PLOT_KEY_##CHARTID##_1_12->?A:_SF_PLOT_KEY_##CHARTID##_3_12_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_12->?B:_SF_PLOT_KEY_##CHARTID##_3_12_MACROBLOCK",
+  "marshallId" : 15,
+  "marshallMemberOf" : [ 3 ]
+}, {
+  "sf_dashboard" : "Collectd",
+  "sf_uiModel" : {
+    "widgets" : [ {
+      "col" : 3,
+      "row" : 0,
+      "sizeX" : 3,
+      "sizeY" : 1,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "chartIndex" : 1459445051615,
+        "name" : "",
+        "id" : 1
+      }
+    }, {
+      "col" : 9,
+      "row" : 0,
+      "sizeX" : 3,
+      "sizeY" : 1,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "chartIndex" : 1459445557108,
+        "name" : "",
+        "id" : 3
+      }
+    }, {
+      "col" : 0,
+      "row" : 0,
+      "sizeX" : 3,
+      "sizeY" : 1,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "chartIndex" : 1459444857291,
+        "name" : "",
+        "id" : 4
+      }
+    }, {
+      "col" : 6,
+      "row" : 0,
+      "sizeX" : 3,
+      "sizeY" : 1,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "chartIndex" : 1459445812323,
+        "name" : "",
+        "id" : 2
+      }
+    }, {
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "col" : 0,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "New Text Block",
+        "chartIndex" : 1,
+        "id" : 5
+      },
+      "row" : 1
+    }, {
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "col" : 6,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 2,
+        "id" : 6
+      },
+      "row" : 1
+    }, {
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "col" : 0,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "New Text Block",
+        "chartIndex" : 4,
+        "id" : 7
+      },
+      "row" : 2
+    }, {
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "col" : 6,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "New Text Block",
+        "chartIndex" : 3,
+        "id" : 8
+      },
+      "row" : 2
+    }, {
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "col" : 0,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "New Text Block",
+        "chartIndex" : 5,
+        "id" : 9
+      },
+      "row" : 3
+    }, {
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "col" : 6,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1433463909939,
+        "id" : 10
+      },
+      "row" : 3
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 0,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 8,
+        "id" : 11
+      },
+      "row" : 4
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 4,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1442725445775,
+        "id" : 12
+      },
+      "row" : 4
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 8,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 12,
+        "id" : 13
+      },
+      "row" : 4
+    } ],
+    "version" : 1
+  },
+  "sf_discoverySelectors" : [ "_exists_:host" ],
+  "sf_description" : "",
+  "sf_type" : "Dashboard",
+  "sf_discoveryQuery" : "plugin:signalfx-metadata",
+  "marshallId" : 16,
+  "marshallMemberOf" : [ 2 ]
+}, {
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 18,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "disk",
+        "propertyValue" : "disk",
+        "NOT" : false,
+        "query" : "plugin:disk",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "read ops/sec",
+      "seriesData" : {
+        "metric" : "disk_ops.read"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "disk",
+        "propertyValue" : "disk",
+        "NOT" : false,
+        "query" : "plugin:disk",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "write ops/sec",
+      "seriesData" : {
+        "metric" : "disk_ops.write"
+      },
+      "sf_programText" : "find(query='(sf_metric:disk_ops.read AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_CGraATNAgAA_3_10=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGraATNAgAA_3_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGraATNAgAA_10')",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 1,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_18",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "range" : -3600000,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "read ops - RED",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      }, {
+        "max" : null,
+        "label" : "write ops - BLUE",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        },
+        "min" : 0
+      } ],
+      "sortPreference" : ""
+    },
+    "currentUniqueKey" : 5,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.disk.*disk_ops.read AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_6_1_7=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_6_1_7',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_6_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_6_7')" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_18=id(report=1);A => find(query='(sf_metric:disk_ops.read AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:disk) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_18 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');C => find(query='(sf_metric:disk_ops.write AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:disk) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_18 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18')",
+  "sf_description" : "operations/sec",
+  "sf_type" : "Chart",
+  "sf_throttledProgramText" : "",
+  "marshallId" : 17,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "Disk I/O",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 5,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_18=id(report=1);A => find(query='(sf_metric:disk_ops.read AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:disk) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');C => find(query='(sf_metric:disk_ops.write AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:disk) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18')"
+}, {
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 14,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "load",
+        "propertyValue" : "load",
+        "NOT" : false,
+        "query" : "plugin:load",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "01-min",
+      "seriesData" : {
+        "metric" : "load.shortterm"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "load",
+        "propertyValue" : "load",
+        "NOT" : false,
+        "query" : "plugin:load",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "05-min",
+      "seriesData" : {
+        "metric" : "load.midterm"
+      },
+      "sf_programText" : "find(query='(sf_metric:load.shortterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_CGraATAAcAA_2_10=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGraATAAcAA_2_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGraATAAcAA_10')",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "load",
+        "propertyValue" : "load",
+        "NOT" : false,
+        "query" : "plugin:load",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 3,
+      "name" : "15-min",
+      "seriesData" : {
+        "metric" : "load.longterm"
+      },
+      "sf_programText" : "find(query='(sf_metric:load.shortterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_CGraATAAcAA_3_10=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGraATAAcAA_3_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGraATAAcAA_10')",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 4,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_14",
+    "chartMode" : "list",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "maxDecimalPlaces" : 3,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : 0,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "+sf_metric"
+    },
+    "currentUniqueKey" : 5,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.load.load.shortterm AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_1_5')" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_14=id(report=1);A => find(query='(sf_metric:load.shortterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:load) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');B => find(query='(sf_metric:load.midterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:load) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');C => find(query='(sf_metric:load.longterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:load) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
+  "sf_description" : "",
+  "sf_type" : "Chart",
+  "sf_throttledProgramText" : "",
+  "marshallId" : 18,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "Load Average",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 2,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_14=id(report=1);A => find(query='(sf_metric:load.shortterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:load) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');B => find(query='(sf_metric:load.midterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:load) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');C => find(query='(sf_metric:load.longterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:load) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')"
+}, {
+  "sf_chart" : "Total Network bits/sec",
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 26,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:eth*",
+        "propertyValue" : "eth*",
+        "NOT" : false,
+        "query" : "plugin_instance:eth*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "interface",
+        "propertyValue" : "interface",
+        "NOT" : false,
+        "query" : "plugin:interface",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "input bits/sec",
+      "seriesData" : {
+        "metric" : "if_octets.rx"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "fn" : {
+          "type" : "SCALE",
+          "options" : {
+            "scaleAmount" : 8
+          }
+        },
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "AUTO"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:eth*",
+        "propertyValue" : "eth*",
+        "NOT" : false,
+        "query" : "plugin_instance:eth*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "interface",
+        "propertyValue" : "interface",
+        "NOT" : false,
+        "query" : "plugin:interface",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "output bits/sec",
+      "seriesData" : {
+        "metric" : "if_octets.tx"
+      },
+      "sf_programText" : "find(query='(sf_metric:if_octets.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2) AND (plugin_instance:eth*))') -> fetch -> split -> stats:!mean -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_CGraATOAYAA_2_12=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGraATOAYAA_2_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGraATOAYAA_12')",
+      "dataManipulations" : [ {
+        "fn" : {
+          "type" : "SCALE",
+          "options" : {
+            "scaleAmount" : 8
+          }
+        },
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 1,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "AUTO"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "A + B",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "type" : "ratio",
+      "valid" : true,
+      "metricDefinition" : { },
+      "expressionText" : "A + B"
+    }, {
+      "name" : "New Plot",
+      "type" : "plot",
+      "invisible" : false,
+      "transient" : true,
+      "dataManipulations" : [ ],
+      "yAxisIndex" : 0,
+      "queryItems" : [ ],
+      "metricDefinition" : { },
+      "seriesData" : { },
+      "uniqueKey" : 4,
+      "focusNext" : false
+    } ],
+    "uiHelperValue" : "##CHARTID##_26",
+    "chartMode" : "list",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "range" : -3600000,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "bits/s",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      }, {
+        "max" : null,
+        "label" : "",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        },
+        "min" : 0
+      } ],
+      "sortPreference" : "+sf_metric",
+      "forcedResolution" : "0",
+      "maxDecimalPlaces" : 4,
+      "useKMG2" : true,
+      "hideDimensionsInList" : true
+    },
+    "relatedDetectors" : [ ],
+    "currentUniqueKey" : 5,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.interface*.if_octets.rx AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> ?a:math(b=8):!product -> _SF_PLOT_KEY_SYNTH_CHART_ID_7_1_6=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_7_1_6',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_7_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_7_6')" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_26_MACROBLOCK=[?A,?B,!OUT]{?A  +  ?B->!OUT};find(query='(sf_metric:if_octets.rx AND _missing_:sf_programId) AND ((plugin_instance:eth*) AND (plugin:interface) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_26 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');find(query='(sf_metric:if_octets.tx AND _missing_:sf_programId) AND ((plugin_instance:eth*) AND (plugin:interface) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_2_26 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_3_26_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_1_26->?A:_SF_PLOT_KEY_##CHARTID##_3_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_26->?B:_SF_PLOT_KEY_##CHARTID##_3_26_MACROBLOCK",
+  "sf_cacheProgram" : true,
+  "sf_description" : "",
+  "sf_chartIndex" : 1459445812323,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 6000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_26_MACROBLOCK=[?A,?B,!OUT]{?A  +  ?B->!OUT};find(query='(sf_metric:if_octets.rx AND _missing_:sf_programId) AND ((plugin_instance:eth*) AND (plugin:interface) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_26 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');find(query='(sf_metric:if_octets.tx AND _missing_:sf_programId) AND ((plugin_instance:eth*) AND (plugin:interface) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_2_26 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_3_26_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_26->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_1_26->?A:_SF_PLOT_KEY_##CHARTID##_3_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_26->?B:_SF_PLOT_KEY_##CHARTID##_3_26_MACROBLOCK",
+  "marshallId" : 19,
+  "marshallMemberOf" : [ 16 ]
+}, {
+  "sf_chart" : "Disk Free %",
+  "sf_uiModel" : {
+    "revisionNumber" : 8,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "type" : "property",
+        "property" : "plugin",
+        "propertyValue" : "signalfx-metadata",
+        "query" : "plugin:\"signalfx-metadata\"",
+        "value" : "signalfx-metadata",
+        "NOT" : false,
+        "displayName" : "signalfx-metadata"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "used bytes",
+      "seriesData" : {
+        "metric" : "disk.utilization",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "AUTO"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "expressionText" : "100 - A",
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "ratio",
+      "valid" : true,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 4,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_8",
+    "chartMode" : "list",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : true,
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "maxDecimalPlaces" : 3,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "+value"
+    },
+    "currentUniqueKey" : 6
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_8_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};find(query='(sf_metric:disk.utilization AND _missing_:sf_programId) AND ((plugin:signalfx\\\\-metadata) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_8;_SF_PLOT_KEY_##CHARTID##_3_8_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_8->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8');_SF_PLOT_KEY_##CHARTID##_1_8->?A:_SF_PLOT_KEY_##CHARTID##_3_8_MACROBLOCK",
+  "sf_cacheProgram" : true,
+  "sf_chartIndex" : 1433463909939,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 6000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_8_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};find(query='(sf_metric:disk.utilization AND _missing_:sf_programId) AND ((plugin:signalfx\\\\-metadata) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_8 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8');_SF_PLOT_KEY_##CHARTID##_3_8_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_8->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8');_SF_PLOT_KEY_##CHARTID##_1_8->?A:_SF_PLOT_KEY_##CHARTID##_3_8_MACROBLOCK",
+  "marshallId" : 20,
+  "marshallMemberOf" : [ 16 ]
+}, {
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 19,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:eth*",
+        "propertyValue" : "eth*",
+        "NOT" : false,
+        "query" : "plugin_instance:eth*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "interface",
+        "propertyValue" : "interface",
+        "NOT" : false,
+        "query" : "plugin:interface",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "input bits/sec",
+      "seriesData" : {
+        "metric" : "if_octets.rx"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "fn" : {
+          "type" : "SCALE",
+          "options" : {
+            "scaleAmount" : 8
+          }
+        },
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "AUTO"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:eth*",
+        "propertyValue" : "eth*",
+        "NOT" : false,
+        "query" : "plugin_instance:eth*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "interface",
+        "propertyValue" : "interface",
+        "NOT" : false,
+        "query" : "plugin:interface",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "output bits/sec",
+      "seriesData" : {
+        "metric" : "if_octets.tx"
+      },
+      "sf_programText" : "find(query='(sf_metric:if_octets.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2) AND (plugin_instance:eth*))') -> fetch -> split -> stats:!mean -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_CGraATOAYAA_2_12=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGraATOAYAA_2_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGraATOAYAA_12')",
+      "dataManipulations" : [ {
+        "fn" : {
+          "type" : "SCALE",
+          "options" : {
+            "scaleAmount" : 8
+          }
+        },
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 1,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "AUTO"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_19",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "range" : -3600000,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "input bits/s - RED",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      }, {
+        "max" : null,
+        "label" : "output bits/s - BLUE",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        },
+        "min" : 0
+      } ],
+      "sortPreference" : "",
+      "forcedResolution" : "0"
+    },
+    "currentUniqueKey" : 4,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.interface*.if_octets.rx AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> ?a:math(b=8):!product -> _SF_PLOT_KEY_SYNTH_CHART_ID_7_1_6=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_7_1_6',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_7_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_7_6')" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_19=id(report=1);find(query='(sf_metric:if_octets.rx AND _missing_:sf_programId) AND ((plugin_instance:eth*) AND (plugin:interface) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_19 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');find(query='(sf_metric:if_octets.tx AND _missing_:sf_programId) AND ((plugin_instance:eth*) AND (plugin:interface) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_2_19 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19')",
+  "sf_description" : "bits/sec",
+  "sf_type" : "Chart",
+  "sf_throttledProgramText" : "",
+  "marshallId" : 21,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "Network I/O",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 8,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_19=id(report=1);find(query='(sf_metric:if_octets.rx AND _missing_:sf_programId) AND ((plugin_instance:eth*) AND (plugin:interface) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_19 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');find(query='(sf_metric:if_octets.tx AND _missing_:sf_programId) AND ((plugin_instance:eth*) AND (plugin:interface) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_2_19 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19')"
+}, {
+  "sf_chart" : "Memory Used %",
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 17,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "type" : "property",
+        "property" : "plugin",
+        "propertyValue" : "signalfx-metadata",
+        "query" : "plugin:\"signalfx-metadata\"",
+        "value" : "signalfx-metadata",
+        "NOT" : false,
+        "displayName" : "signalfx-metadata"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "free",
+      "seriesData" : {
+        "metric" : "memory.utilization",
+        "regExStyle" : null
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#05ce00",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "name" : "New Plot",
+      "type" : "plot",
+      "invisible" : false,
+      "transient" : true,
+      "dataManipulations" : [ ],
+      "yAxisIndex" : 0,
+      "queryItems" : [ ],
+      "metricDefinition" : { },
+      "seriesData" : { },
+      "uniqueKey" : 8,
+      "focusNext" : false
+    } ],
+    "uiHelperValue" : "##CHARTID##_17",
+    "chartMode" : "single",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : true,
+      "useKMG2" : false,
+      "colorByMetric" : true,
+      "range" : -3600000,
+      "maxDecimalPlaces" : 3,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "%",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "-value",
+      "disableThrottle" : false
+    },
+    "relatedDetectors" : [ ],
+    "currentUniqueKey" : 9,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.free AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3=id", "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.used AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK=[?B,?A,!OUT]{?B  /  (?A  +  ?B)  *  100->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('sf_source')->groupby('aws_Name')->stats:!mean->_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_2_3');_SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3->?B:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK;_SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_17=id(report=1);find(query='(sf_metric:memory.utilization AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:signalfx\\\\-metadata))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_17 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17')",
+  "sf_cacheProgram" : false,
+  "sf_description" : "",
+  "sf_chartIndex" : 1459445051615,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 6000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_17=id(report=1);find(query='(sf_metric:memory.utilization AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:signalfx\\\\-metadata))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_17 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17')",
+  "marshallId" : 22,
+  "marshallMemberOf" : [ 16 ]
+}, {
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 14,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "vmem",
+        "propertyValue" : "vmem",
+        "NOT" : false,
+        "query" : "plugin:vmem",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "swapped in",
+      "seriesData" : {
+        "metric" : "vmpage_io.swap.in"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "rollupPolicy" : "DELTA_ROLLUP",
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "vmem",
+        "propertyValue" : "vmem",
+        "NOT" : false,
+        "query" : "plugin:vmem",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "swapped out",
+      "seriesData" : {
+        "metric" : "vmpage_io.swap.out"
+      },
+      "sf_programText" : "find(refresh=300000,query='sf_metric:collectd.vmem.vmpage_io.swap.in AND sf_organizationID:BqDQY5OAAAA AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_BwzVGs0AEAA_2_2=id -> publish(defaultSource='_SF_PLOT_KEY_BwzVGs0AEAA_2_2',metric='_SF_PLOT_KEY_BwzVGs0AEAA_2_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='BwzVGs0AEAA_2')",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 1,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : "DELTA_ROLLUP",
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "query" : "aws_service:quantizer",
+        "type" : "property",
+        "value" : "Aws_service:quantizer"
+      } ],
+      "uniqueKey" : 3,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_14",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : false,
+      "useKMG2" : false,
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "maxDecimalPlaces" : 3,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "swapped in - RED",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      }, {
+        "max" : null,
+        "label" : "swapped out - BLUE",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        },
+        "min" : 0
+      } ],
+      "sortPreference" : "",
+      "disableThrottle" : false
+    },
+    "currentUniqueKey" : 4,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.vmem.vmpage_io.swap.in AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_3_4')", "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.vmem.vmpage_io.swap.out AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_3_4')" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_14=id(report=1);find(query='(sf_metric:vmpage_io.swap.in AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:vmem) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');find(query='(sf_metric:vmpage_io.swap.out AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:vmem) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
+  "sf_description" : "page swaps/sec",
+  "sf_type" : "Chart",
+  "sf_throttledProgramText" : "",
+  "marshallId" : 23,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "Memory Paging",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 3,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_14=id(report=1);find(query='(sf_metric:vmpage_io.swap.in AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:vmem) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');find(query='(sf_metric:vmpage_io.swap.out AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:vmem) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')"
+}, {
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 18,
+    "allPlotConstructs" : [ ],
+    "chartType" : "area",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "type" : "property",
+        "property" : "plugin",
+        "propertyValue" : "signalfx-metadata",
+        "query" : "plugin:\"signalfx-metadata\"",
+        "value" : "signalfx-metadata",
+        "NOT" : false,
+        "displayName" : "signalfx-metadata"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "CPU utilization (%)",
+      "seriesData" : {
+        "metric" : "cpu.utilization",
+        "regExStyle" : null
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "name" : "New Plot",
+      "type" : "plot",
+      "invisible" : false,
+      "transient" : true,
+      "dataManipulations" : [ ],
+      "yAxisIndex" : 0,
+      "queryItems" : [ ],
+      "metricDefinition" : { },
+      "seriesData" : { },
+      "uniqueKey" : 6,
+      "focusNext" : false
+    } ],
+    "uiHelperValue" : "##CHARTID##_18",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "max" : 110,
+        "min" : 0,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0",
+        "label" : "%"
+      } ],
+      "sortPreference" : ""
+    },
+    "currentUniqueKey" : 7,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.aggregation.cpu-average.cpu.idle AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('aws_Name')->_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_0_5');_SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);find(query='(sf_metric:cpu.utilization AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:signalfx\\\\-metadata))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_18 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18')",
+  "sf_description" : "",
+  "sf_type" : "Chart",
+  "sf_throttledProgramText" : "",
+  "marshallId" : 24,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "CPU %",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);find(query='(sf_metric:cpu.utilization AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:signalfx\\\\-metadata))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18')"
+}, {
+  "sf_chart" : "Memory",
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 13,
+    "allPlotConstructs" : [ ],
+    "chartType" : "area",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "memory",
+        "propertyValue" : "memory",
+        "NOT" : false,
+        "query" : "plugin:memory",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "free",
+      "seriesData" : {
+        "metric" : "memory.free"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#05ce00",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "memory",
+        "propertyValue" : "memory",
+        "NOT" : false,
+        "query" : "plugin:memory",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "used by processes",
+      "seriesData" : {
+        "metric" : "memory.used"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#e9008a",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "memory",
+        "propertyValue" : "memory",
+        "NOT" : false,
+        "query" : "plugin:memory",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 3,
+      "name" : "buffer cache",
+      "seriesData" : {
+        "metric" : "memory.buffered"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "memory",
+        "propertyValue" : "memory",
+        "NOT" : false,
+        "query" : "plugin:memory",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 4,
+      "name" : "file/page cache",
+      "seriesData" : {
+        "metric" : "memory.cached"
+      },
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#999999",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "type" : "property",
+        "property" : "host",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "displayName" : "integration-test-zookeeper-3.4.6-0"
+      }, {
+        "iconClass" : "icon-properties",
+        "type" : "property",
+        "property" : "plugin",
+        "propertyValue" : "memory",
+        "query" : "plugin:memory",
+        "value" : "memory",
+        "NOT" : false,
+        "displayName" : "memory"
+      } ],
+      "uniqueKey" : 5,
+      "name" : "memory.* - Sum",
+      "seriesData" : {
+        "metric" : "memory.*",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { },
+      "configuration" : {
+        "rollupPolicy" : null
+      }
+    }, {
+      "name" : "(1 - A/E) * 100",
+      "type" : "ratio",
+      "invisible" : true,
+      "transient" : false,
+      "dataManipulations" : [ ],
+      "yAxisIndex" : 0,
+      "queryItems" : [ ],
+      "metricDefinition" : { },
+      "seriesData" : { },
+      "uniqueKey" : 7,
+      "focusNext" : false,
+      "valid" : true,
+      "expressionText" : "(1 - A/E) * 100"
+    }, {
+      "name" : "New Plot",
+      "type" : "plot",
+      "invisible" : false,
+      "transient" : true,
+      "dataManipulations" : [ ],
+      "yAxisIndex" : 0,
+      "queryItems" : [ ],
+      "metricDefinition" : { },
+      "seriesData" : { },
+      "uniqueKey" : 8,
+      "focusNext" : false
+    } ],
+    "uiHelperValue" : "##CHARTID##_13",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : true,
+      "useKMG2" : true,
+      "colorByMetric" : true,
+      "range" : -3600000,
+      "maxDecimalPlaces" : 3,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "bytes",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "-value",
+      "disableThrottle" : false
+    },
+    "currentUniqueKey" : 9,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.free AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3=id", "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.used AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK=[?B,?A,!OUT]{?B  /  (?A  +  ?B)  *  100->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('sf_source')->groupby('aws_Name')->stats:!mean->_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_2_3');_SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3->?B:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK;_SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_13_MACROBLOCK=[?A,?E,!OUT]{(1  -  ?A / ?E)  *  100->!OUT};find(query='(sf_metric:memory.free AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:memory.used AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:memory.buffered AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_3_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:memory.cached AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_4_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:memory.* AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_5_13;_SF_PLOT_KEY_##CHARTID##_7_13_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_7_13->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');_SF_PLOT_KEY_##CHARTID##_1_13->?A:_SF_PLOT_KEY_##CHARTID##_7_13_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_13->?E:_SF_PLOT_KEY_##CHARTID##_7_13_MACROBLOCK",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 4,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 1000,
+  "sf_throttledProgramText" : "",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_13_MACROBLOCK=[?A,?E,!OUT]{(1  -  ?A / ?E)  *  100->!OUT};find(query='(sf_metric:memory.free AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:memory.used AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:memory.buffered AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_3_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:memory.cached AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_4_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:memory.* AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_5_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_5_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');_SF_PLOT_KEY_##CHARTID##_7_13_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_7_13->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');_SF_PLOT_KEY_##CHARTID##_1_13->?A:_SF_PLOT_KEY_##CHARTID##_7_13_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_13->?E:_SF_PLOT_KEY_##CHARTID##_7_13_MACROBLOCK",
+  "marshallId" : 25,
+  "marshallMemberOf" : [ 16 ]
+}, {
+  "sf_chart" : "Disk Used %",
+  "sf_uiModel" : {
+    "revisionNumber" : 13,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "type" : "property",
+        "property" : "plugin",
+        "propertyValue" : "signalfx-metadata",
+        "query" : "plugin:\"signalfx-metadata\"",
+        "value" : "signalfx-metadata",
+        "NOT" : false,
+        "displayName" : "signalfx-metadata"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "",
+      "seriesData" : {
+        "metric" : "disk.utilization",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "AUTO"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 4,
+      "name" : "",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "ratio",
+      "valid" : true,
+      "metricDefinition" : { },
+      "expressionText" : "A"
+    }, {
+      "name" : "New Plot",
+      "type" : "plot",
+      "invisible" : false,
+      "transient" : true,
+      "dataManipulations" : [ ],
+      "yAxisIndex" : 0,
+      "queryItems" : [ ],
+      "metricDefinition" : { },
+      "seriesData" : { },
+      "uniqueKey" : 6,
+      "focusNext" : false
+    } ],
+    "uiHelperValue" : "##CHARTID##_13",
+    "chartMode" : "list",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : true,
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "maxDecimalPlaces" : 3,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0",
+        "label" : "%"
+      } ],
+      "sortPreference" : "-value"
+    },
+    "relatedDetectors" : [ ],
+    "currentUniqueKey" : 7
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_13_MACROBLOCK=[?A,!OUT]{?A->!OUT};find(query='(sf_metric:disk.utilization AND _missing_:sf_programId) AND ((plugin:signalfx\\\\-metadata) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_13;_SF_PLOT_KEY_##CHARTID##_4_13_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_4_13->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');_SF_PLOT_KEY_##CHARTID##_1_13->?A:_SF_PLOT_KEY_##CHARTID##_4_13_MACROBLOCK",
+  "sf_cacheProgram" : true,
+  "sf_description" : "",
+  "sf_chartIndex" : 1459445557108,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 6000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_13_MACROBLOCK=[?A,!OUT]{?A->!OUT};find(query='(sf_metric:disk.utilization AND _missing_:sf_programId) AND ((plugin:signalfx\\\\-metadata) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');_SF_PLOT_KEY_##CHARTID##_4_13_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_4_13->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');_SF_PLOT_KEY_##CHARTID##_1_13->?A:_SF_PLOT_KEY_##CHARTID##_4_13_MACROBLOCK",
+  "marshallId" : 26,
+  "marshallMemberOf" : [ 16 ]
+}, {
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 18,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "interface",
+        "propertyValue" : "interface",
+        "NOT" : false,
+        "query" : "plugin:interface",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:eth*",
+        "propertyValue" : "eth*",
+        "NOT" : false,
+        "query" : "plugin_instance:eth*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "errors/sec",
+      "seriesData" : {
+        "metric" : "if_errors.rx"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : "DELTA_ROLLUP"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "interface",
+        "propertyValue" : "interface",
+        "NOT" : false,
+        "query" : "plugin:interface",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:eth*",
+        "propertyValue" : "eth*",
+        "NOT" : false,
+        "query" : "plugin_instance:eth*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "if_errors.tx",
+      "seriesData" : {
+        "metric" : "if_errors.tx"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : true,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : "DELTA_ROLLUP"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "interface errors/sec",
+      "valid" : true,
+      "seriesData" : { },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "ratio",
+      "expressionText" : "A + B",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "protocols",
+        "propertyValue" : "protocols",
+        "NOT" : false,
+        "query" : "plugin:protocols",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 4,
+      "name" : "retransmits/sec",
+      "seriesData" : {
+        "metric" : "protocol_counter.RetransSegs"
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "name" : "New Aggregation",
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 1,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : "DELTA_ROLLUP",
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 5,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_18",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "range" : -3600000,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "interface errors - RED",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      }, {
+        "max" : null,
+        "label" : "retransmits - BLUE",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        },
+        "min" : 0
+      } ],
+      "sortPreference" : ""
+    },
+    "currentUniqueKey" : 6,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.interface.*.if_errors.* AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_10_8')" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_18_MACROBLOCK=[?A,?B,!OUT]{?A  +  ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_4_18=id(report=1);find(query='(sf_metric:if_errors.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(rollup='DELTA_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_18;find(query='(sf_metric:if_errors.tx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(rollup='DELTA_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_18;_SF_PLOT_KEY_##CHARTID##_3_18_MACROBLOCK:!OUT->groupby()->stats:!sum->_SF_PLOT_KEY_##CHARTID##_3_18->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_1_18->?A:_SF_PLOT_KEY_##CHARTID##_3_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_18->?B:_SF_PLOT_KEY_##CHARTID##_3_18_MACROBLOCK;find(query='(sf_metric:protocol_counter.RetransSegs AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:protocols) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_18 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18')",
+  "sf_description" : "errors/sec",
+  "sf_type" : "Chart",
+  "sf_throttledProgramText" : "",
+  "marshallId" : 27,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "Network Errors",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 12,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_18_MACROBLOCK=[?A,?B,!OUT]{?A  +  ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_4_18=id(report=1);find(query='(sf_metric:if_errors.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(rollup='DELTA_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');find(query='(sf_metric:if_errors.tx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:eth*) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(rollup='DELTA_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_3_18_MACROBLOCK:!OUT->groupby()->stats:!sum->_SF_PLOT_KEY_##CHARTID##_3_18->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_1_18->?A:_SF_PLOT_KEY_##CHARTID##_3_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_18->?B:_SF_PLOT_KEY_##CHARTID##_3_18_MACROBLOCK;find(query='(sf_metric:protocol_counter.RetransSegs AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:protocols) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18')"
+}, {
+  "sf_chart" : "CPU Used %",
+  "sf_uiModel" : {
+    "sf_detectorDecorators" : [ ],
+    "allDetectorDecorators" : [ ],
+    "revisionNumber" : 19,
+    "allPlotConstructs" : [ ],
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "type" : "property",
+        "property" : "plugin",
+        "propertyValue" : "signalfx-metadata",
+        "query" : "plugin:\"signalfx-metadata\"",
+        "value" : "signalfx-metadata",
+        "NOT" : false,
+        "displayName" : "signalfx-metadata"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "cpu.utilization",
+      "seriesData" : {
+        "metric" : "cpu.utilization",
+        "regExStyle" : null
+      },
+      "sf_programText" : "",
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "valid" : false,
+      "metricDefinition" : { }
+    }, {
+      "name" : "New Plot",
+      "type" : "plot",
+      "invisible" : false,
+      "transient" : true,
+      "dataManipulations" : [ ],
+      "yAxisIndex" : 0,
+      "queryItems" : [ ],
+      "metricDefinition" : { },
+      "seriesData" : { },
+      "uniqueKey" : 6,
+      "focusNext" : false
+    } ],
+    "uiHelperValue" : "##CHARTID##_19",
+    "chartMode" : "single",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "max" : 110,
+        "min" : 0,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0",
+        "label" : "%"
+      } ],
+      "sortPreference" : "",
+      "maxDecimalPlaces" : 3
+    },
+    "relatedDetectors" : [ ],
+    "currentUniqueKey" : 7,
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.aggregation.cpu-average.cpu.idle AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('aws_Name')->_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_0_5');_SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK" ]
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_19=id(report=1);find(query='(sf_metric:cpu.utilization AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:signalfx\\\\-metadata))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_19 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19')",
+  "sf_cacheProgram" : false,
+  "sf_description" : "",
+  "sf_chartIndex" : 1459444857291,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 6000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_19=id(report=1);find(query='(sf_metric:cpu.utilization AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:signalfx\\\\-metadata))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_19 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19')",
+  "marshallId" : 28,
+  "marshallMemberOf" : [ 16 ]
+}, {
+  "sf_chart" : "TCP Connections",
+  "sf_uiModel" : {
+    "revisionNumber" : 4,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "protocols",
+        "propertyValue" : "protocols",
+        "NOT" : false,
+        "query" : "plugin:protocols",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "current",
+      "seriesData" : {
+        "metric" : "protocol_counter.CurrEstab"
+      },
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "rollupPolicy" : "MAX_ROLLUP",
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "protocols",
+        "propertyValue" : "protocols",
+        "NOT" : false,
+        "query" : "plugin:protocols",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "integration-test-zookeeper-3.4.6-0",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "NOT" : false,
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "property" : "host",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "new",
+      "seriesData" : {
+        "metric" : "protocol_counter.ActiveOpens"
+      },
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 1,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_4",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "range" : -3600000,
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "current conns - RED",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      }, {
+        "max" : null,
+        "label" : "new conns/sec - BLUE",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        },
+        "min" : 0
+      } ],
+      "sortPreference" : "",
+      "forcedResolution" : "0"
+    },
+    "currentUniqueKey" : 4
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_4=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_4=id(report=1);find(query='(sf_metric:protocol_counter.CurrEstab AND _missing_:sf_programId) AND ((plugin:protocols) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP') -> split -> _SF_PLOT_KEY_##CHARTID##_1_4 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_4');find(query='(sf_metric:protocol_counter.ActiveOpens AND _missing_:sf_programId) AND ((plugin:protocols) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_4 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_4')",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1442725445775,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 1000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_4=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_4=id(report=1);find(query='(sf_metric:protocol_counter.CurrEstab AND _missing_:sf_programId) AND ((plugin:protocols) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP') -> split -> _SF_PLOT_KEY_##CHARTID##_1_4 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_4');find(query='(sf_metric:protocol_counter.ActiveOpens AND _missing_:sf_programId) AND ((plugin:protocols) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_4 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_4')",
+  "marshallId" : 29,
+  "marshallMemberOf" : [ 16 ]
+} ]


### PR DESCRIPTION
1. There are now two sets of Infrastructure dashboards: CollectD
(without SFX plugin), and Collectd_SFX (collectd with signalfx plugin).

2. Updating utilization metrics for without SFX plugin. Collectd
(regular) now has the correct CPU math.

3. Updated discovery queries for Collectd (regular) to indicate display
only when SFX plugin is not present (looking for the absence of the
field called “host_metadata_version”).