### PR TITLE
Fix AMQ dashboards

### DIFF
--- a/CollectD/Page_ActiveMQ.json
+++ b/CollectD/Page_ActiveMQ.json
@@ -1,6775 +1,5800 @@
-[
-    {
-        "marshallScope": 2
-    },
-    {
-        "marshallId": 1,
-        "sf_type": "Service",
-        "sf_description": "Metrics about ActiveMQ.",
-        "sf_service": "ActiveMQ"
-    },
-    {
-        "sf_page": "ActiveMQ",
-        "marshallId": 2,
-        "marshallMemberOf": [
-            1
-        ],
-        "sf_type": "Page",
-        "sf_description": "Dashboards about ActiveMQ."
-    },
-    {
-        "marshallId": 3,
-        "sf_uiModel": {
-            "widgets": [
-                {
-                    "sizeX": 3,
-                    "sizeY": 1,
-                    "col": 0,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447246026552,
-                        "id": 1
-                    },
-                    "row": 0
-                },
-                {
-                    "sizeX": 3,
-                    "sizeY": 1,
-                    "col": 3,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447246066522,
-                        "id": 2
-                    },
-                    "row": 0
-                },
-                {
-                    "sizeX": 6,
-                    "sizeY": 1,
-                    "col": 6,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447245820404,
-                        "id": 3
-                    },
-                    "row": 0
-                },
-                {
-                    "sizeX": 6,
-                    "sizeY": 1,
-                    "col": 0,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447349536821,
-                        "id": 4
-                    },
-                    "row": 1
-                },
-                {
-                    "sizeX": 6,
-                    "sizeY": 1,
-                    "col": 6,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447349576637,
-                        "id": 5
-                    },
-                    "row": 1
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 0,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447247287312,
-                        "id": 6
-                    },
-                    "row": 2
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 4,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447247640442,
-                        "id": 7
-                    },
-                    "row": 2
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 8,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447349895298,
-                        "id": 8
-                    },
-                    "row": 2
-                },
-                {
-                    "sizeX": 6,
-                    "sizeY": 1,
-                    "col": 6,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447350148734,
-                        "id": 11
-                    },
-                    "row": 3
-                },
-                {
-                    "sizeX": 6,
-                    "sizeY": 1,
-                    "col": 0,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447350075823,
-                        "id": 13
-                    },
-                    "row": 3
-                }
-            ],
-            "version": 1
+[ {
+  "marshallScope" : 2
+}, {
+  "sf_description" : "Metrics about ActiveMQ.",
+  "sf_type" : "Service",
+  "sf_service" : "ActiveMQ",
+  "marshallId" : 1
+}, {
+  "sf_page" : "ActiveMQ",
+  "sf_description" : "Dashboards about ActiveMQ.",
+  "sf_type" : "Page",
+  "marshallId" : 2,
+  "marshallMemberOf" : [ 1 ]
+}, {
+  "sf_dashboard" : "ActiveMQ host",
+  "sf_uiModel" : {
+    "widgets" : [ {
+      "sizeX" : 3,
+      "sizeY" : 1,
+      "col" : 0,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447246026552,
+        "id" : 1
+      },
+      "row" : 0
+    }, {
+      "sizeX" : 3,
+      "sizeY" : 1,
+      "col" : 3,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447246066522,
+        "id" : 2
+      },
+      "row" : 0
+    }, {
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "col" : 6,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447245820404,
+        "id" : 3
+      },
+      "row" : 0
+    }, {
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "col" : 0,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447349536821,
+        "id" : 4
+      },
+      "row" : 1
+    }, {
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "col" : 6,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447349576637,
+        "id" : 5
+      },
+      "row" : 1
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 0,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447247287312,
+        "id" : 6
+      },
+      "row" : 2
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 4,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447247640442,
+        "id" : 7
+      },
+      "row" : 2
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 8,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447349895298,
+        "id" : 8
+      },
+      "row" : 2
+    }, {
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "col" : 6,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447350148734,
+        "id" : 11
+      },
+      "row" : 3
+    }, {
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "col" : 0,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447350075823,
+        "id" : 13
+      },
+      "row" : 3
+    } ],
+    "version" : 1
+  },
+  "sf_discoverySelectors" : [ "_exists_:host" ],
+  "sf_type" : "Dashboard",
+  "sf_discoveryQuery" : "sf_hostHasService:activemq",
+  "marshallId" : 3,
+  "marshallMemberOf" : [ 2 ]
+}, {
+  "sf_chart" : "Connections",
+  "sf_uiModel" : {
+    "revisionNumber" : 11,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "ActiveMQ_Host1",
+        "propertyValue" : "ActiveMQ_Host1",
+        "NOT" : false,
+        "query" : "host:ActiveMQ_Host1",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "plugin_instance:*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "Connection Count",
+      "seriesData" : {
+        "metric" : "counter.amq.TotalConnectionsCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_discoveryQuery": "sf_hostHasService:activemq",
-        "sf_discoverySelectors": [
-            "_exists_:host"
-        ],
-        "sf_type": "Dashboard",
-        "marshallMemberOf": [
-            2
-        ],
-        "sf_dashboard": "ActiveMQ host"
-    },
-    {
-        "marshallId": 4,
-        "sf_uiModel": {
-            "chartMode": "single",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "max": null,
-                        "min": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": ""
-            },
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_7",
-            "relatedDetectors": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "plugin_instance:*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "gauge.amq.topic.QueueSize - Count",
-                    "seriesData": {
-                        "metric": "gauge.amq.topic.QueueSize",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "COUNT",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "revisionNumber": 7
+        "fn" : {
+          "type" : "SCALE",
+          "options" : {
+            "scaleAmount" : 10
+          }
         },
-        "sf_description": "",
-        "sf_chartIndex": 1447246066522,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);find(query='(sf_metric:gauge.amq.topic.QueueSize AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_7 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);find(query='(sf_metric:gauge.amq.topic.QueueSize AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_7 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
-        "sf_discoveryQuery": "hostHasService:\"activemq\" AND _exists_:host",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "# Topics",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 10000,
-        "marshallMemberOf": [
-            3
-        ]
-    },
-    {
-        "marshallId": 5,
-        "sf_uiModel": {
-            "chartMode": "list",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "max": null,
-                        "min": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": "-value"
-            },
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_9",
-            "relatedDetectors": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "plugin_instance:*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "",
-                    "seriesData": {
-                        "metric": "gauge.amq.topic.ConsumerCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [
-                                        {
-                                            "value": "plugin_instance"
-                                        }
-                                    ],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "MEAN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "TOPN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "revisionNumber": 9
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "visualization" : "area",
+        "maxExtrapolations" : -1,
+        "colorOverride" : "#0077c2",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "rollupPolicy" : null,
+        "aliases" : { }
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "Connection Count 1-hr mean",
+      "seriesData" : { },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "transformation",
+          "options" : {
+            "amount" : 1,
+            "transformTimeRange" : "1h",
+            "unit" : "h"
+          }
         },
-        "sf_description": "",
-        "sf_chartIndex": 1447350148734,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);find(query='(sf_metric:gauge.amq.topic.ConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!mean -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);find(query='(sf_metric:gauge.amq.topic.ConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!mean -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9')",
-        "sf_discoveryQuery": "hostHasService:\"activemq\" AND _exists_:host",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Top 5 Topics by No. Consumers",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 10000,
-        "marshallMemberOf": [
-            3
-        ]
-    },
-    {
-        "marshallId": 6,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "plugin_instance:*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "Total Producer Count",
-                    "seriesData": {
-                        "metric": "gauge.amq.TotalProducerCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#0077c2",
-                        "visualization": "area",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "plugin_instance:*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "Mean Producers Count",
-                    "seriesData": {
-                        "metric": "gauge.amq.TotalProducerCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "transformation",
-                                "options": {
-                                    "amount": 1,
-                                    "transformTimeRange": "1h",
-                                    "unit": "h"
-                                }
-                            },
-                            "fn": {
-                                "type": "MEAN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#999999",
-                        "visualization": "area",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "currentUniqueKey": 4,
-            "uiHelperValue": "##CHARTID##_5",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": null,
-                        "max": null,
-                        "label": "Blue - Value, Grey - Mean",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": ""
-            },
-            "chartType": "line",
-            "revisionNumber": 5
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
         },
-        "sf_chartIndex": 1447349536821,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_5=id(report=1);find(query='(sf_metric:gauge.amq.TotalProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5');find(query='(sf_metric:gauge.amq.TotalProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_5=id(report=1);find(query='(sf_metric:gauge.amq.TotalProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_5 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5');find(query='(sf_metric:gauge.amq.TotalProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_5 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
-        "sf_discoveryQuery": "hostHasService:\"activemq\" AND _exists_:host",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Total Producers",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            3
-        ]
-    },
-    {
-        "marshallId": 7,
-        "sf_uiModel": {
-            "chartMode": "list",
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "plugin_instance:*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "",
-                    "seriesData": {
-                        "metric": "gauge.amq.queue.ProducerCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [
-                                        {
-                                            "value": "plugin_instance"
-                                        }
-                                    ],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "MEAN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "TOPN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_8",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "max": null,
-                        "min": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": "-value"
-            },
-            "chartType": "line",
-            "revisionNumber": 8
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#999999",
+        "visualization" : "area",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "aliases" : { }
+      },
+      "type" : "ratio",
+      "valid" : true,
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_11",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -7200000,
+      "maxDecimalPlaces" : 3,
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "# connections",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
         },
-        "sf_chartIndex": 1447247640442,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:gauge.amq.queue.ProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!mean -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:gauge.amq.queue.ProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!mean -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
-        "sf_discoveryQuery": "hostHasService:\"activemq\" AND _exists_:host",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Top 5 Queues by No. Producers",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 10000,
-        "marshallMemberOf": [
-            3
-        ]
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "",
+      "forcedResolution" : "0"
     },
-    {
-        "marshallId": 8,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "plugin_instance:*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "Connection Count",
-                    "seriesData": {
-                        "metric": "counter.amq.TotalConnectionsCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SCALE",
-                                "options": {
-                                    "scaleAmount": 10
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "visualization": "area",
-                        "maxExtrapolations": -1,
-                        "colorOverride": "#0077c2",
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION",
-                        "rollupPolicy": null,
-                        "aliases": {}
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "Connection Count 1-hr mean",
-                    "seriesData": {},
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "transformation",
-                                "options": {
-                                    "amount": 1,
-                                    "transformTimeRange": "1h",
-                                    "unit": "h"
-                                }
-                            },
-                            "fn": {
-                                "type": "MEAN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "expressionText": "A",
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#999999",
-                        "visualization": "area",
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION",
-                        "maxExtrapolations": -1,
-                        "aliases": {}
-                    },
-                    "type": "ratio",
-                    "valid": true,
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "currentUniqueKey": 7,
-            "uiHelperValue": "##CHARTID##_11",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -7200000,
-                "maxDecimalPlaces": 3,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": 0,
-                        "max": null,
-                        "label": "# connections",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": "",
-                "forcedResolution": "0"
-            },
-            "chartType": "line",
-            "revisionNumber": 11
+    "currentUniqueKey" : 7
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_3_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_11_MACROBLOCK=[?C,!OUT]{?C->!OUT};find(query='(sf_metric:counter.amq.TotalConnectionsCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> { ?in * 10 -> !out } -> _SF_PLOT_KEY_##CHARTID##_3_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_5_11_MACROBLOCK:!OUT->window(1h)->stats:!mean->_SF_PLOT_KEY_##CHARTID##_5_11->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_3_11->?C:_SF_PLOT_KEY_##CHARTID##_5_11_MACROBLOCK",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447245820404,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 1000,
+  "sf_discoveryQuery" : "hostHasService:\"activemq\" AND _exists_:host",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_3_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_11_MACROBLOCK=[?C,!OUT]{?C->!OUT};find(query='(sf_metric:counter.amq.TotalConnectionsCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> { ?in * 10 -> !out } -> _SF_PLOT_KEY_##CHARTID##_3_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_5_11_MACROBLOCK:!OUT->window(1h)->stats:!mean->_SF_PLOT_KEY_##CHARTID##_5_11->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_3_11->?C:_SF_PLOT_KEY_##CHARTID##_5_11_MACROBLOCK",
+  "marshallId" : 4,
+  "marshallMemberOf" : [ 3 ]
+}, {
+  "sf_chart" : "Total Producers",
+  "sf_uiModel" : {
+    "revisionNumber" : 5,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "ActiveMQ_Host1",
+        "propertyValue" : "ActiveMQ_Host1",
+        "NOT" : false,
+        "query" : "host:ActiveMQ_Host1",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "plugin_instance:*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "Total Producer Count",
+      "seriesData" : {
+        "metric" : "gauge.amq.TotalProducerCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "visualization" : "area",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "ActiveMQ_Host1",
+        "propertyValue" : "ActiveMQ_Host1",
+        "NOT" : false,
+        "query" : "host:ActiveMQ_Host1",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "plugin_instance:*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "Mean Producers Count",
+      "seriesData" : {
+        "metric" : "gauge.amq.TotalProducerCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "transformation",
+          "options" : {
+            "amount" : 1,
+            "transformTimeRange" : "1h",
+            "unit" : "h"
+          }
         },
-        "sf_chartIndex": 1447245820404,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_3_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_11_MACROBLOCK=[?C,!OUT]{?C->!OUT};find(query='(sf_metric:counter.amq.TotalConnectionsCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> { ?in * 10 -> !out } -> _SF_PLOT_KEY_##CHARTID##_3_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_5_11_MACROBLOCK:!OUT->window(1h)->stats:!mean->_SF_PLOT_KEY_##CHARTID##_5_11->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_3_11->?C:_SF_PLOT_KEY_##CHARTID##_5_11_MACROBLOCK",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_3_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_11_MACROBLOCK=[?C,!OUT]{?C->!OUT};find(query='(sf_metric:counter.amq.TotalConnectionsCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> { ?in * 10 -> !out } -> _SF_PLOT_KEY_##CHARTID##_3_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_5_11_MACROBLOCK:!OUT->window(1h)->stats:!mean->_SF_PLOT_KEY_##CHARTID##_5_11->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_3_11->?C:_SF_PLOT_KEY_##CHARTID##_5_11_MACROBLOCK",
-        "sf_discoveryQuery": "hostHasService:\"activemq\" AND _exists_:host",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Connections",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            3
-        ]
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#999999",
+        "visualization" : "area",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_5",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : null,
+        "max" : null,
+        "label" : "Blue - Value, Grey - Mean",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : ""
     },
-    {
-        "marshallId": 9,
-        "sf_uiModel": {
-            "chartMode": "single",
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "plugin_instance:*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "gauge.amq.queue.QueueSize - Count",
-                    "seriesData": {
-                        "metric": "gauge.amq.queue.QueueSize",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "COUNT",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_7",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "max": null,
-                        "min": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": ""
-            },
-            "chartType": "line",
-            "revisionNumber": 7
+    "currentUniqueKey" : 4
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_5=id(report=1);find(query='(sf_metric:gauge.amq.TotalProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5');find(query='(sf_metric:gauge.amq.TotalProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447349536821,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 1000,
+  "sf_discoveryQuery" : "hostHasService:\"activemq\" AND _exists_:host",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_5=id(report=1);find(query='(sf_metric:gauge.amq.TotalProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_5 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5');find(query='(sf_metric:gauge.amq.TotalProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_5 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
+  "marshallId" : 5,
+  "marshallMemberOf" : [ 3 ]
+}, {
+  "sf_chart" : "Top 5 Queues by size",
+  "sf_uiModel" : {
+    "revisionNumber" : 8,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "ActiveMQ_Host1",
+        "propertyValue" : "ActiveMQ_Host1",
+        "NOT" : false,
+        "query" : "host:ActiveMQ_Host1",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "plugin_instance:*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "",
+      "seriesData" : {
+        "metric" : "gauge.amq.queue.QueueSize",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_chartIndex": 1447246026552,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);find(query='(sf_metric:gauge.amq.queue.QueueSize AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_7 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);find(query='(sf_metric:gauge.amq.queue.QueueSize AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_7 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
-        "sf_discoveryQuery": "hostHasService:\"activemq\" AND _exists_:host",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "# Queues",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 10000,
-        "marshallMemberOf": [
-            3
-        ]
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "TOPN",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_8",
+    "chartMode" : "list",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "-value"
     },
-    {
-        "marshallId": 10,
-        "sf_uiModel": {
-            "chartMode": "list",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "max": null,
-                        "min": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": "-value"
-            },
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_9",
-            "relatedDetectors": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "plugin_instance:*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "",
-                    "seriesData": {
-                        "metric": "gauge.amq.topic.ProducerCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [
-                                        {
-                                            "value": "plugin_instance"
-                                        }
-                                    ],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "MEAN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "TOPN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "revisionNumber": 9
+    "currentUniqueKey" : 3
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:gauge.amq.queue.QueueSize AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!mean -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447247287312,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 10000,
+  "sf_discoveryQuery" : "hostHasService:\"activemq\" AND _exists_:host",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:gauge.amq.queue.QueueSize AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!mean -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
+  "marshallId" : 6,
+  "marshallMemberOf" : [ 3 ]
+}, {
+  "sf_uiModel" : {
+    "revisionNumber" : 7,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "ActiveMQ_Host1",
+        "propertyValue" : "ActiveMQ_Host1",
+        "NOT" : false,
+        "query" : "host:ActiveMQ_Host1",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "plugin_instance:*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "gauge.amq.topic.QueueSize - Count",
+      "seriesData" : {
+        "metric" : "gauge.amq.topic.QueueSize",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_description": "",
-        "sf_chartIndex": 1447350075823,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);find(query='(sf_metric:gauge.amq.topic.ProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!mean -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);find(query='(sf_metric:gauge.amq.topic.ProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!mean -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9')",
-        "sf_discoveryQuery": "hostHasService:\"activemq\" AND _exists_:host",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Top 5 Topics by No. Producers",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 10000,
-        "marshallMemberOf": [
-            3
-        ]
+        "fn" : {
+          "type" : "COUNT",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_7",
+    "chartMode" : "single",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : ""
     },
-    {
-        "marshallId": 11,
-        "sf_uiModel": {
-            "chartMode": "list",
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "plugin_instance:*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "",
-                    "seriesData": {
-                        "metric": "gauge.amq.queue.QueueSize",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [
-                                        {
-                                            "value": "plugin_instance"
-                                        }
-                                    ],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "MEAN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "TOPN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_8",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "max": null,
-                        "min": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": "-value"
-            },
-            "chartType": "line",
-            "revisionNumber": 8
+    "relatedDetectors" : [ ],
+    "currentUniqueKey" : 3
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);find(query='(sf_metric:gauge.amq.topic.QueueSize AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_7 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
+  "sf_description" : "",
+  "sf_type" : "Chart",
+  "marshallId" : 7,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "# Topics",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447246066522,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_discoveryQuery" : "hostHasService:\"activemq\" AND _exists_:host",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);find(query='(sf_metric:gauge.amq.topic.QueueSize AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_7 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')"
+}, {
+  "sf_uiModel" : {
+    "revisionNumber" : 8,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "ActiveMQ_Host1",
+        "propertyValue" : "ActiveMQ_Host1",
+        "NOT" : false,
+        "query" : "host:ActiveMQ_Host1",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "plugin_instance:*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "Total Consumer Count",
+      "seriesData" : {
+        "metric" : "gauge.amq.TotalConsumerCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "visualization" : "area",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "ActiveMQ_Host1",
+        "propertyValue" : "ActiveMQ_Host1",
+        "NOT" : false,
+        "query" : "host:ActiveMQ_Host1",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "plugin_instance:*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "Mean Consumer Count",
+      "seriesData" : {
+        "metric" : "gauge.amq.TotalConsumerCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "transformation",
+          "options" : {
+            "amount" : 1,
+            "transformTimeRange" : "1h",
+            "unit" : "h"
+          }
         },
-        "sf_chartIndex": 1447247287312,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:gauge.amq.queue.QueueSize AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!mean -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:gauge.amq.queue.QueueSize AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!mean -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
-        "sf_discoveryQuery": "hostHasService:\"activemq\" AND _exists_:host",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Top 5 Queues by size",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 10000,
-        "marshallMemberOf": [
-            3
-        ]
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#999999",
+        "visualization" : "area",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_8",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : null,
+        "max" : null,
+        "label" : "Blue - Value, Grey - Mean",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : ""
     },
-    {
-        "marshallId": 12,
-        "sf_uiModel": {
-            "chartMode": "list",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "max": null,
-                        "min": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": "-value"
-            },
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_8",
-            "relatedDetectors": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "plugin_instance:*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "",
-                    "seriesData": {
-                        "metric": "gauge.amq.queue.ConsumerCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [
-                                        {
-                                            "value": "plugin_instance"
-                                        }
-                                    ],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "MEAN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "TOPN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "revisionNumber": 8
+    "relatedDetectors" : [ ],
+    "currentUniqueKey" : 4
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_8=id(report=1);find(query='(sf_metric:gauge.amq.TotalConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8');find(query='(sf_metric:gauge.amq.TotalConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
+  "sf_description" : "",
+  "sf_type" : "Chart",
+  "marshallId" : 8,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Total Consumers",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447349576637,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_discoveryQuery" : "hostHasService:\"activemq\" AND _exists_:host",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_8=id(report=1);find(query='(sf_metric:gauge.amq.TotalConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_8 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8');find(query='(sf_metric:gauge.amq.TotalConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_8 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')"
+}, {
+  "sf_uiModel" : {
+    "revisionNumber" : 8,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "ActiveMQ_Host1",
+        "propertyValue" : "ActiveMQ_Host1",
+        "NOT" : false,
+        "query" : "host:ActiveMQ_Host1",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "plugin_instance:*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "",
+      "seriesData" : {
+        "metric" : "gauge.amq.queue.ConsumerCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_description": "",
-        "sf_chartIndex": 1447349895298,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:gauge.amq.queue.ConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!mean -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:gauge.amq.queue.ConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!mean -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
-        "sf_discoveryQuery": "hostHasService:\"activemq\" AND _exists_:host",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Top 5 Queues by No. Consumers",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 10000,
-        "marshallMemberOf": [
-            3
-        ]
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "TOPN",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_8",
+    "chartMode" : "list",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "-value"
     },
-    {
-        "marshallId": 13,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": null,
-                        "max": null,
-                        "label": "Blue - Value, Grey - Mean",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": ""
-            },
-            "currentUniqueKey": 4,
-            "uiHelperValue": "##CHARTID##_8",
-            "relatedDetectors": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "plugin_instance:*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "Total Consumer Count",
-                    "seriesData": {
-                        "metric": "gauge.amq.TotalConsumerCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#b04600",
-                        "visualization": "area",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "plugin_instance:*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "Mean Consumer Count",
-                    "seriesData": {
-                        "metric": "gauge.amq.TotalConsumerCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "transformation",
-                                "options": {
-                                    "amount": 1,
-                                    "transformTimeRange": "1h",
-                                    "unit": "h"
-                                }
-                            },
-                            "fn": {
-                                "type": "MEAN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#999999",
-                        "visualization": "area",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "revisionNumber": 8
+    "relatedDetectors" : [ ],
+    "currentUniqueKey" : 3
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:gauge.amq.queue.ConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!mean -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
+  "sf_description" : "",
+  "sf_type" : "Chart",
+  "marshallId" : 9,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Top 5 Queues by No. Consumers",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447349895298,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_discoveryQuery" : "hostHasService:\"activemq\" AND _exists_:host",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:gauge.amq.queue.ConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!mean -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')"
+}, {
+  "sf_uiModel" : {
+    "revisionNumber" : 9,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "ActiveMQ_Host1",
+        "propertyValue" : "ActiveMQ_Host1",
+        "NOT" : false,
+        "query" : "host:ActiveMQ_Host1",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "plugin_instance:*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "",
+      "seriesData" : {
+        "metric" : "gauge.amq.topic.ProducerCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_description": "",
-        "sf_chartIndex": 1447349576637,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_8=id(report=1);find(query='(sf_metric:gauge.amq.TotalConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8');find(query='(sf_metric:gauge.amq.TotalConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_8=id(report=1);find(query='(sf_metric:gauge.amq.TotalConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_8 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8');find(query='(sf_metric:gauge.amq.TotalConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_8 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
-        "sf_discoveryQuery": "hostHasService:\"activemq\" AND _exists_:host",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Total Consumers",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            3
-        ]
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "TOPN",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_9",
+    "chartMode" : "list",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "-value"
     },
-    {
-        "marshallId": 14,
-        "sf_uiModel": {
-            "widgets": [
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 0,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447929025809,
-                        "id": 1
-                    },
-                    "row": 0
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 8,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447934564134,
-                        "id": 3
-                    },
-                    "row": 0
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 4,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447935235603,
-                        "id": 2
-                    },
-                    "row": 0
-                },
-                {
-                    "sizeX": 6,
-                    "sizeY": 1,
-                    "col": 0,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447950345878,
-                        "id": 4
-                    },
-                    "row": 1
-                },
-                {
-                    "sizeX": 6,
-                    "sizeY": 1,
-                    "col": 6,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447950518622,
-                        "id": 5
-                    },
-                    "row": 1
-                },
-                {
-                    "sizeX": 6,
-                    "sizeY": 1,
-                    "col": 6,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447950450262,
-                        "id": 6
-                    },
-                    "row": 2
-                },
-                {
-                    "sizeX": 6,
-                    "sizeY": 1,
-                    "col": 0,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447950399179,
-                        "id": 7
-                    },
-                    "row": 2
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 4,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447945789747,
-                        "id": 8
-                    },
-                    "row": 3
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 0,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447938354316,
-                        "id": 9
-                    },
-                    "row": 3
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 8,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447946137085,
-                        "id": 10
-                    },
-                    "row": 3
-                }
-            ],
-            "version": 1
+    "relatedDetectors" : [ ],
+    "currentUniqueKey" : 3
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);find(query='(sf_metric:gauge.amq.topic.ProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!mean -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9')",
+  "sf_description" : "",
+  "sf_type" : "Chart",
+  "marshallId" : 10,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Top 5 Topics by No. Producers",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447350075823,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_discoveryQuery" : "hostHasService:\"activemq\" AND _exists_:host",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);find(query='(sf_metric:gauge.amq.topic.ProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!mean -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9')"
+}, {
+  "sf_uiModel" : {
+    "revisionNumber" : 9,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "ActiveMQ_Host1",
+        "propertyValue" : "ActiveMQ_Host1",
+        "NOT" : false,
+        "query" : "host:ActiveMQ_Host1",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "plugin_instance:*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "",
+      "seriesData" : {
+        "metric" : "gauge.amq.topic.ConsumerCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_discoveryQuery": "sf_hostHasService:activemq",
-        "sf_discoverySelectors": [
-            "sf_hostHasService:activemq"
-        ],
-        "sf_type": "Dashboard",
-        "marshallMemberOf": [
-            2
-        ],
-        "sf_dashboard": "ActiveMQ hosts"
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "TOPN",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_9",
+    "chartMode" : "list",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "-value"
     },
-    {
-        "marshallId": 15,
-        "sf_uiModel": {
-            "chartMode": "list",
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "host:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "host:*",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "plugin_instance:*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "",
-                    "seriesData": {
-                        "metric": "gauge.amq.TotalConsumerCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SCALE",
-                                "options": {
-                                    "scaleAmount": 10
-                                }
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [
-                                        {
-                                            "value": "host"
-                                        },
-                                        {
-                                            "value": "plugin_instance"
-                                        }
-                                    ],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "TOPN",
-                                "options": {
-                                    "count": 5
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "visualization": "area",
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "aliases": {}
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_8",
-            "relatedDetectors": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "stackedChart": true,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": null,
-                        "max": null,
-                        "label": "Connections",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": "-value"
-            },
-            "chartType": "line",
-            "revisionNumber": 8
+    "relatedDetectors" : [ ],
+    "currentUniqueKey" : 3
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);find(query='(sf_metric:gauge.amq.topic.ConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!mean -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9')",
+  "sf_description" : "",
+  "sf_type" : "Chart",
+  "marshallId" : 11,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Top 5 Topics by No. Consumers",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447350148734,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_discoveryQuery" : "hostHasService:\"activemq\" AND _exists_:host",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);find(query='(sf_metric:gauge.amq.topic.ConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!mean -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9')"
+}, {
+  "sf_chart" : "# Queues",
+  "sf_uiModel" : {
+    "revisionNumber" : 7,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "ActiveMQ_Host1",
+        "propertyValue" : "ActiveMQ_Host1",
+        "NOT" : false,
+        "query" : "host:ActiveMQ_Host1",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "plugin_instance:*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "gauge.amq.queue.QueueSize - Count",
+      "seriesData" : {
+        "metric" : "gauge.amq.queue.QueueSize",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_description": "",
-        "sf_chartIndex": 1447946137085,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:gauge.amq.TotalConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((hostHasService:activemq) AND (host:*) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> { ?in * 10 -> !out } -> groupby('host','plugin_instance') -> stats:!sum -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:gauge.amq.TotalConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((hostHasService:activemq) AND (host:*) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> { ?in * 10 -> !out } -> groupby('host','plugin_instance') -> stats:!sum -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Top Brokers by Consumers",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 10000,
-        "marshallMemberOf": [
-            14
-        ]
+        "fn" : {
+          "type" : "COUNT",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_7",
+    "chartMode" : "single",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : ""
     },
-    {
-        "marshallId": 16,
-        "sf_uiModel": {
-            "chartMode": "list",
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "host:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "host:*",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "plugin_instance:*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "",
-                    "seriesData": {
-                        "metric": "counter.amq.TotalConnectionsCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SCALE",
-                                "options": {
-                                    "scaleAmount": 10
-                                }
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [
-                                        {
-                                            "value": "host"
-                                        },
-                                        {
-                                            "value": "plugin_instance"
-                                        }
-                                    ],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "TOPN",
-                                "options": {
-                                    "count": 5
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "visualization": "area",
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "aliases": {}
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_6",
-            "relatedDetectors": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "stackedChart": true,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": null,
-                        "max": null,
-                        "label": "Connections",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": "-value"
-            },
-            "chartType": "line",
-            "revisionNumber": 6
+    "currentUniqueKey" : 3
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);find(query='(sf_metric:gauge.amq.queue.QueueSize AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_7 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447246026552,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 10000,
+  "sf_discoveryQuery" : "hostHasService:\"activemq\" AND _exists_:host",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);find(query='(sf_metric:gauge.amq.queue.QueueSize AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_7 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
+  "marshallId" : 12,
+  "marshallMemberOf" : [ 3 ]
+}, {
+  "sf_chart" : "Top 5 Queues by No. Producers",
+  "sf_uiModel" : {
+    "revisionNumber" : 8,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "ActiveMQ_Host1",
+        "propertyValue" : "ActiveMQ_Host1",
+        "NOT" : false,
+        "query" : "host:ActiveMQ_Host1",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "plugin_instance:*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "",
+      "seriesData" : {
+        "metric" : "gauge.amq.queue.ProducerCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_description": "",
-        "sf_chartIndex": 1447938354316,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_6=id(report=1);find(query='(sf_metric:counter.amq.TotalConnectionsCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((hostHasService:activemq) AND (host:*) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> { ?in * 10 -> !out } -> groupby('host','plugin_instance') -> stats:!sum -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_6 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_6=id(report=1);find(query='(sf_metric:counter.amq.TotalConnectionsCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((hostHasService:activemq) AND (host:*) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> { ?in * 10 -> !out } -> groupby('host','plugin_instance') -> stats:!sum -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_6 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Top Brokers by Connections",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 10000,
-        "marshallMemberOf": [
-            14
-        ]
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "TOPN",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_8",
+    "chartMode" : "list",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "-value"
     },
-    {
-        "marshallId": 17,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "host:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "host:*",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "plugin_instance:*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "Producers",
-                    "seriesData": {
-                        "metric": "gauge.amq.TotalProducerCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "visualization": "area",
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "aliases": {}
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_8",
-            "relatedDetectors": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "stackedChart": true,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": null,
-                        "max": null,
-                        "label": "Producers",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": ""
-            },
-            "chartType": "line",
-            "revisionNumber": 8
+    "currentUniqueKey" : 3
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:gauge.amq.queue.ProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!mean -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447247640442,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 10000,
+  "sf_discoveryQuery" : "hostHasService:\"activemq\" AND _exists_:host",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:gauge.amq.queue.ProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!mean -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
+  "marshallId" : 13,
+  "marshallMemberOf" : [ 3 ]
+}, {
+  "sf_dashboard" : "ActiveMQ topic",
+  "sf_uiModel" : {
+    "widgets" : [ {
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447335811040,
+        "id" : 1
+      },
+      "sizeX" : 4,
+      "col" : 0,
+      "row" : 0
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 4,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447336395145,
+        "id" : 2
+      },
+      "row" : 0
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 8,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447436942365,
+        "id" : 3
+      },
+      "row" : 0
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 8,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447336111972,
+        "id" : 5
+      },
+      "row" : 1
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 4,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447347835572,
+        "id" : 6
+      },
+      "row" : 1
+    }, {
+      "sizeX" : 4,
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447335362192,
+        "id" : 7
+      },
+      "type" : "chart",
+      "col" : 0,
+      "row" : 1
+    } ],
+    "version" : 1
+  },
+  "sf_discoverySelectors" : [ "_exists_:plugin_instance" ],
+  "sf_description" : "",
+  "sf_type" : "Dashboard",
+  "sf_discoveryQuery" : "plugin:GenericJMX AND sf_hostHasService:activemq AND sf_metric:*.topic.*",
+  "marshallId" : 14,
+  "marshallMemberOf" : [ 2 ]
+}, {
+  "sf_chart" : "# Messages InFlight",
+  "sf_uiModel" : {
+    "revisionNumber" : 6,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "broker1-TEST.TOPIC1",
+        "propertyValue" : "broker1-TEST.TOPIC1",
+        "NOT" : false,
+        "query" : "plugin_instance:\"broker1-TEST.TOPIC1\"",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "Mean InFlightCount",
+      "seriesData" : {
+        "metric" : "gauge.amq.topic.InFlightCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "transformation",
+          "options" : {
+            "amount" : 1,
+            "transformTimeRange" : "1h",
+            "unit" : "h"
+          }
         },
-        "sf_description": "",
-        "sf_chartIndex": 1447950399179,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:gauge.amq.TotalProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:*) AND (plugin_instance:*) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:gauge.amq.TotalProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:*) AND (plugin_instance:*) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_8 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Total Producers",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            14
-        ]
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#999999",
+        "visualization" : "area",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "broker1-TEST.TOPIC1",
+        "propertyValue" : "broker1-TEST.TOPIC1",
+        "NOT" : false,
+        "query" : "plugin_instance:\"broker1-TEST.TOPIC1\"",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "InFlightCount",
+      "seriesData" : {
+        "metric" : "gauge.amq.topic.InFlightCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "visualization" : "area",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_6",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : null,
+        "max" : null,
+        "label" : "Blue - Value, Grey - Mean",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : ""
     },
-    {
-        "marshallId": 18,
-        "sf_uiModel": {
-            "chartMode": "list",
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "host:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "host:*",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "plugin_instance:*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "",
-                    "seriesData": {
-                        "metric": "gauge.amq.TotalEnqueueCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [
-                                        {
-                                            "value": "host"
-                                        }
-                                    ],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "COUNT",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_4",
-            "chartconfig": {
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "max": null,
-                        "min": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": "-value"
-            },
-            "chartType": "line",
-            "revisionNumber": 4
+    "currentUniqueKey" : 4
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_6=id(report=1);find(query='(sf_metric:gauge.amq.topic.InFlightCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_6 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');find(query='(sf_metric:gauge.amq.topic.InFlightCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_6 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6')",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447436942365,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 1000,
+  "sf_discoveryQuery" : "hostHasService:\"activemq\" AND _exists_:host",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_6=id(report=1);find(query='(sf_metric:gauge.amq.topic.InFlightCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_6 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');find(query='(sf_metric:gauge.amq.topic.InFlightCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_6 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6')",
+  "marshallId" : 15,
+  "marshallMemberOf" : [ 14 ]
+}, {
+  "sf_uiModel" : {
+    "revisionNumber" : 11,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "broker1-TEST.TOPIC1",
+        "propertyValue" : "broker1-TEST.TOPIC1",
+        "NOT" : false,
+        "query" : "plugin_instance:\"broker1-TEST.TOPIC1\"",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "Average Enqueue Time",
+      "seriesData" : {
+        "metric" : "gauge.amq.topic.AverageEnqueueTime",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "visualization" : "line",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_11",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
         },
-        "sf_chartIndex": 1447934564134,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_4=id(report=1);find(query='(sf_metric:gauge.amq.TotalEnqueueCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:*) AND (plugin_instance:*) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_4 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_4')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_4=id(report=1);find(query='(sf_metric:gauge.amq.TotalEnqueueCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:*) AND (plugin_instance:*) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_4 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_4')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "# Brokers per Host",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 10000,
-        "marshallMemberOf": [
-            14
-        ]
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : ""
     },
-    {
-        "marshallId": 19,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "host:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "host:*",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "plugin_instance:*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "Messages",
-                    "seriesData": {
-                        "metric": "gauge.amq.TotalMessageCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "visualization": "area",
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "aliases": {}
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_10",
-            "relatedDetectors": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "stackedChart": true,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": null,
-                        "max": null,
-                        "label": "Messages",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": ""
-            },
-            "chartType": "line",
-            "revisionNumber": 10
+    "relatedDetectors" : [ ],
+    "currentUniqueKey" : 3
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);find(query='(sf_metric:gauge.amq.topic.AverageEnqueueTime AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11')",
+  "sf_type" : "Chart",
+  "sf_throttledProgramText" : "",
+  "marshallId" : 16,
+  "marshallMemberOf" : [ 14 ],
+  "sf_chart" : "Avg. Enqueue Time",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447336111972,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_discoveryQuery" : "hostHasService:\"activemq\" AND _exists_:host",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);find(query='(sf_metric:gauge.amq.topic.AverageEnqueueTime AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11')"
+}, {
+  "sf_uiModel" : {
+    "revisionNumber" : 9,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "broker1-TEST.TOPIC1",
+        "propertyValue" : "broker1-TEST.TOPIC1",
+        "NOT" : false,
+        "query" : "plugin_instance:\"broker1-TEST.TOPIC1\"",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "gauge.amq.topic.ExpiredCount",
+      "seriesData" : {
+        "metric" : "gauge.amq.topic.ExpiredCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_9",
+    "chartMode" : "single",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
         },
-        "sf_description": "",
-        "sf_chartIndex": 1447950518622,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_10=id(report=1);find(query='(sf_metric:gauge.amq.TotalMessageCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:*) AND (plugin_instance:*) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_10=id(report=1);find(query='(sf_metric:gauge.amq.TotalMessageCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:*) AND (plugin_instance:*) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10')",
-        "sf_discoveryQuery": "hostHasService:activemq AND plugin:GenericJMX AND _exists_:host AND _exists_:plugin_instance",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Total Messages",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            14
-        ]
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : ""
     },
-    {
-        "marshallId": 20,
-        "sf_uiModel": {
-            "chartMode": "single",
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "host:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "host:*",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "plugin_instance:*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "gauge.amq.TotalEnqueueCount - Mean by host - Count",
-                    "seriesData": {
-                        "metric": "gauge.amq.TotalEnqueueCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [
-                                        {
-                                            "value": "host"
-                                        }
-                                    ],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "MEAN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "COUNT",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_9",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "max": null,
-                        "min": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": ""
-            },
-            "chartType": "line",
-            "revisionNumber": 9
+    "relatedDetectors" : [ ],
+    "currentUniqueKey" : 3
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);find(query='(sf_metric:gauge.amq.topic.ExpiredCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9')",
+  "sf_type" : "Chart",
+  "sf_throttledProgramText" : "",
+  "marshallId" : 17,
+  "marshallMemberOf" : [ 14 ],
+  "sf_chart" : "# Expired",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447336395145,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_discoveryQuery" : "hostHasService:\"activemq\" AND _exists_:host",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);find(query='(sf_metric:gauge.amq.topic.ExpiredCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9')"
+}, {
+  "sf_uiModel" : {
+    "revisionNumber" : 6,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "broker1-TEST.TOPIC1",
+        "propertyValue" : "broker1-TEST.TOPIC1",
+        "NOT" : false,
+        "query" : "plugin_instance:\"broker1-TEST.TOPIC1\"",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "gauge.amq.topic.EnqueueCount",
+      "seriesData" : {
+        "metric" : "gauge.amq.topic.EnqueueCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_6",
+    "chartMode" : "single",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
         },
-        "sf_chartIndex": 1447929025809,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);find(query='(sf_metric:gauge.amq.TotalEnqueueCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((hostHasService:activemq) AND (host:*) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!mean -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);find(query='(sf_metric:gauge.amq.TotalEnqueueCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((hostHasService:activemq) AND (host:*) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!mean -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "# Hosts",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 10000,
-        "marshallMemberOf": [
-            14
-        ]
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : ""
     },
-    {
-        "marshallId": 21,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "host:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "host:*",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "plugin_instance:*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "Connections",
-                    "seriesData": {
-                        "metric": "counter.amq.TotalConnectionsCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SCALE",
-                                "options": {
-                                    "scaleAmount": 10
-                                }
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "visualization": "area",
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "aliases": {}
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_8",
-            "relatedDetectors": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "stackedChart": true,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": null,
-                        "max": null,
-                        "label": "Connections",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": ""
-            },
-            "chartType": "line",
-            "revisionNumber": 8
+    "relatedDetectors" : [ ],
+    "currentUniqueKey" : 3
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_6=id(report=1);find(query='(sf_metric:gauge.amq.topic.EnqueueCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_6 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6')",
+  "sf_type" : "Chart",
+  "sf_throttledProgramText" : "",
+  "marshallId" : 18,
+  "marshallMemberOf" : [ 14 ],
+  "sf_chart" : "# Enqueued",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447335811040,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_discoveryQuery" : "hostHasService:\"activemq\" AND _exists_:host",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_6=id(report=1);find(query='(sf_metric:gauge.amq.topic.EnqueueCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_6 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6')"
+}, {
+  "sf_uiModel" : {
+    "revisionNumber" : 13,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "ActiveMQ_Host1",
+        "propertyValue" : "ActiveMQ_Host1",
+        "NOT" : false,
+        "query" : "host:ActiveMQ_Host1",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "Mean Producer Count",
+      "seriesData" : {
+        "metric" : "gauge.amq.topic.ProducerCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "transformation",
+          "options" : {
+            "amount" : 1,
+            "transformTimeRange" : "1h",
+            "unit" : "h"
+          }
         },
-        "sf_description": "",
-        "sf_chartIndex": 1447950345878,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:counter.amq.TotalConnectionsCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:*) AND (plugin_instance:*) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> { ?in * 10 -> !out } -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:counter.amq.TotalConnectionsCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:*) AND (plugin_instance:*) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> { ?in * 10 -> !out } -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_8 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Total Connections",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            14
-        ]
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#999999",
+        "visualization" : "area",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "ActiveMQ_Host1",
+        "propertyValue" : "ActiveMQ_Host1",
+        "NOT" : false,
+        "query" : "host:ActiveMQ_Host1",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "Producer Count",
+      "seriesData" : {
+        "metric" : "gauge.amq.topic.ProducerCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "visualization" : "area",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_13",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : false,
+      "colorByMetric" : false,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : null,
+        "max" : null,
+        "label" : "Blue - Value, Grey - Mean",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : ""
     },
-    {
-        "marshallId": 22,
-        "sf_uiModel": {
-            "chartMode": "list",
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "host:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "host:*",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "plugin_instance:*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "",
-                    "seriesData": {
-                        "metric": "gauge.amq.TotalProducerCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SCALE",
-                                "options": {
-                                    "scaleAmount": 10
-                                }
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [
-                                        {
-                                            "value": "host"
-                                        },
-                                        {
-                                            "value": "plugin_instance"
-                                        }
-                                    ],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "TOPN",
-                                "options": {
-                                    "count": 5
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "visualization": "area",
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "aliases": {}
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_7",
-            "relatedDetectors": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "stackedChart": true,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": null,
-                        "max": null,
-                        "label": "Connections",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": "-value"
-            },
-            "chartType": "line",
-            "revisionNumber": 7
+    "relatedDetectors" : [ ],
+    "currentUniqueKey" : 4
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_13=id(report=1);find(query='(sf_metric:gauge.amq.topic.ProducerCount AND _missing_:sf_programId) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:gauge.amq.topic.ProducerCount AND _missing_:sf_programId) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')",
+  "sf_type" : "Chart",
+  "sf_throttledProgramText" : "",
+  "marshallId" : 19,
+  "marshallMemberOf" : [ 14 ],
+  "sf_chart" : "Producers",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447335362192,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_discoveryQuery" : "hostHasService:\"activemq\" AND _exists_:host",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_13=id(report=1);find(query='(sf_metric:gauge.amq.topic.ProducerCount AND _missing_:sf_programId) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:gauge.amq.topic.ProducerCount AND _missing_:sf_programId) AND ((host:ActiveMQ_Host1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')"
+}, {
+  "sf_uiModel" : {
+    "revisionNumber" : 14,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "broker1-TEST.TOPIC1",
+        "propertyValue" : "broker1-TEST.TOPIC1",
+        "NOT" : false,
+        "query" : "plugin_instance:\"broker1-TEST.TOPIC1\"",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "Mean Consumer Count",
+      "seriesData" : {
+        "metric" : "gauge.amq.topic.ConsumerCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "transformation",
+          "options" : {
+            "amount" : 1,
+            "transformTimeRange" : "1h",
+            "unit" : "h"
+          }
         },
-        "sf_description": "",
-        "sf_chartIndex": 1447945789747,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);find(query='(sf_metric:gauge.amq.TotalProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((hostHasService:activemq) AND (host:*) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> { ?in * 10 -> !out } -> groupby('host','plugin_instance') -> stats:!sum -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_7 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);find(query='(sf_metric:gauge.amq.TotalProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((hostHasService:activemq) AND (host:*) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> { ?in * 10 -> !out } -> groupby('host','plugin_instance') -> stats:!sum -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_7 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Top Brokers by Producers",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 10000,
-        "marshallMemberOf": [
-            14
-        ]
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#999999",
+        "visualization" : "area",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "broker1-TEST.TOPIC1",
+        "propertyValue" : "broker1-TEST.TOPIC1",
+        "NOT" : false,
+        "query" : "plugin_instance:\"broker1-TEST.TOPIC1\"",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "Consumer Count",
+      "seriesData" : {
+        "metric" : "gauge.amq.topic.ConsumerCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "visualization" : "area",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_14",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : false,
+      "colorByMetric" : false,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : null,
+        "max" : null,
+        "label" : "Red - Value, Grey - Mean",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : ""
     },
-    {
-        "marshallId": 23,
-        "sf_uiModel": {
-            "chartMode": "single",
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "host:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "host:*",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "plugin_instance:*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "gauge.amq.TotalEnqueueCount - Count by host - Sum",
-                    "seriesData": {
-                        "metric": "gauge.amq.TotalEnqueueCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [
-                                        {
-                                            "value": "host"
-                                        }
-                                    ],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "COUNT",
-                                "options": {}
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_11",
-            "relatedDetectors": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "max": null,
-                        "min": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": ""
-            },
-            "chartType": "line",
-            "revisionNumber": 11
+    "relatedDetectors" : [ ],
+    "currentUniqueKey" : 4
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_14=id(report=1);find(query='(sf_metric:gauge.amq.topic.ConsumerCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');find(query='(sf_metric:gauge.amq.topic.ConsumerCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
+  "sf_description" : "",
+  "sf_type" : "Chart",
+  "sf_throttledProgramText" : "",
+  "marshallId" : 20,
+  "marshallMemberOf" : [ 14 ],
+  "sf_chart" : "Consumers",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447347835572,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_discoveryQuery" : "hostHasService:\"activemq\" AND _exists_:host",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_14=id(report=1);find(query='(sf_metric:gauge.amq.topic.ConsumerCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');find(query='(sf_metric:gauge.amq.topic.ConsumerCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')"
+}, {
+  "sf_dashboard" : "ActiveMQ queue",
+  "sf_uiModel" : {
+    "widgets" : [ {
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447335811040,
+        "id" : 1
+      },
+      "sizeX" : 4,
+      "col" : 0,
+      "row" : 0
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 4,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447335862932,
+        "id" : 2
+      },
+      "row" : 0
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 8,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447336395145,
+        "id" : 3
+      },
+      "row" : 0
+    }, {
+      "sizeX" : 6,
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447335008261,
+        "id" : 4
+      },
+      "type" : "chart",
+      "col" : 0,
+      "row" : 1
+    }, {
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "col" : 6,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447436962814,
+        "id" : 5
+      },
+      "row" : 1
+    }, {
+      "sizeX" : 4,
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447335362192,
+        "id" : 7
+      },
+      "type" : "chart",
+      "col" : 0,
+      "row" : 2
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 8,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447336111972,
+        "id" : 8
+      },
+      "row" : 2
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 4,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447347835572,
+        "id" : 9
+      },
+      "row" : 2
+    } ],
+    "version" : 1
+  },
+  "sf_discoverySelectors" : [ "_exists_:plugin_instance" ],
+  "sf_description" : "",
+  "sf_type" : "Dashboard",
+  "sf_discoveryQuery" : "plugin:GenericJMX AND sf_hostHasService:activemq AND sf_metric:*.queue.*",
+  "marshallId" : 21,
+  "marshallMemberOf" : [ 2 ]
+}, {
+  "sf_chart" : "# Expired",
+  "sf_uiModel" : {
+    "revisionNumber" : 8,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "broker1-TEST.FOO",
+        "propertyValue" : "broker1-TEST.FOO",
+        "NOT" : false,
+        "query" : "plugin_instance:\"broker1-TEST.FOO\"",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "gauge.amq.queue.ExpiredCount",
+      "seriesData" : {
+        "metric" : "gauge.amq.queue.ExpiredCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_8",
+    "chartMode" : "single",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
         },
-        "sf_description": "",
-        "sf_chartIndex": 1447935235603,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);find(query='(sf_metric:gauge.amq.TotalEnqueueCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:*) AND (plugin_instance:*) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!count -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);find(query='(sf_metric:gauge.amq.TotalEnqueueCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:*) AND (plugin_instance:*) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!count -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "# Brokers",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 10000,
-        "marshallMemberOf": [
-            14
-        ]
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : ""
     },
-    {
-        "marshallId": 24,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "host:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "host:*",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin_instance:*",
-                            "propertyValue": "*",
-                            "NOT": false,
-                            "query": "plugin_instance:*",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "Consumers",
-                    "seriesData": {
-                        "metric": "gauge.amq.TotalConsumerCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "visualization": "area",
-                        "maxExtrapolations": -1,
-                        "colorOverride": "#b04600",
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION",
-                        "rollupPolicy": null,
-                        "aliases": {}
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_8",
-            "relatedDetectors": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "stackedChart": true,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": null,
-                        "max": null,
-                        "label": "Consumers",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": ""
-            },
-            "chartType": "line",
-            "revisionNumber": 8
+    "currentUniqueKey" : 3
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:gauge.amq.queue.ExpiredCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447336395145,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 10000,
+  "sf_discoveryQuery" : "hostHasService:\"activemq\" AND _exists_:host",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:gauge.amq.queue.ExpiredCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_8 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
+  "marshallId" : 22,
+  "marshallMemberOf" : [ 21 ]
+}, {
+  "sf_uiModel" : {
+    "revisionNumber" : 13,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "broker1-TEST.FOO",
+        "propertyValue" : "broker1-TEST.FOO",
+        "NOT" : false,
+        "query" : "plugin_instance:\"broker1-TEST.FOO\"",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "Mean Consumer Count",
+      "seriesData" : {
+        "metric" : "gauge.amq.queue.ConsumerCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "transformation",
+          "options" : {
+            "amount" : 1,
+            "transformTimeRange" : "1h",
+            "unit" : "h"
+          }
         },
-        "sf_description": "",
-        "sf_chartIndex": 1447950450262,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:gauge.amq.TotalConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:*) AND (plugin_instance:*) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:gauge.amq.TotalConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:*) AND (plugin_instance:*) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_8 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Total Consumers",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            14
-        ]
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#999999",
+        "visualization" : "area",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "broker1-TEST.FOO",
+        "propertyValue" : "broker1-TEST.FOO",
+        "NOT" : false,
+        "query" : "plugin_instance:\"broker1-TEST.FOO\"",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "Consumer Count",
+      "seriesData" : {
+        "metric" : "gauge.amq.queue.ConsumerCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "visualization" : "area",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_13",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : false,
+      "colorByMetric" : false,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : null,
+        "max" : null,
+        "label" : "Red - Value, Grey - Mean",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : ""
     },
-    {
-        "marshallId": 25,
-        "sf_uiModel": {
-            "widgets": [
-                {
-                    "sizeX": 6,
-                    "sizeY": 1,
-                    "col": 0,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447977808908,
-                        "id": 1
-                    },
-                    "row": 0
-                },
-                {
-                    "sizeX": 6,
-                    "sizeY": 1,
-                    "col": 6,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447979280106,
-                        "id": 7
-                    },
-                    "row": 0
-                },
-                {
-                    "sizeX": 6,
-                    "sizeY": 1,
-                    "col": 0,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447860257774,
-                        "id": 4
-                    },
-                    "row": 1
-                },
-                {
-                    "sizeX": 6,
-                    "sizeY": 1,
-                    "col": 6,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447860278623,
-                        "id": 3
-                    },
-                    "row": 2
-                },
-                {
-                    "sizeX": 6,
-                    "sizeY": 1,
-                    "col": 0,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447976655506,
-                        "id": 6
-                    },
-                    "row": 2
-                },
-                {
-                    "sizeX": 6,
-                    "sizeY": 1,
-                    "col": 6,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447976683093,
-                        "id": 5
-                    },
-                    "row": 3
-                }
-            ],
-            "version": 1
+    "relatedDetectors" : [ ],
+    "currentUniqueKey" : 4
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_13=id(report=1);find(query='(sf_metric:gauge.amq.queue.ConsumerCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:gauge.amq.queue.ConsumerCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')",
+  "sf_description" : "",
+  "sf_type" : "Chart",
+  "marshallId" : 23,
+  "marshallMemberOf" : [ 21 ],
+  "sf_chart" : "Consumers",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447347835572,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_discoveryQuery" : "hostHasService:\"activemq\" AND _exists_:host",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_13=id(report=1);find(query='(sf_metric:gauge.amq.queue.ConsumerCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:gauge.amq.queue.ConsumerCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')"
+}, {
+  "sf_uiModel" : {
+    "revisionNumber" : 6,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "broker1-TEST.FOO",
+        "propertyValue" : "broker1-TEST.FOO",
+        "NOT" : false,
+        "query" : "plugin_instance:\"broker1-TEST.FOO\"",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "Mean InFlightCount",
+      "seriesData" : {
+        "metric" : "gauge.amq.queue.InFlightCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "transformation",
+          "options" : {
+            "amount" : 1,
+            "transformTimeRange" : "1h",
+            "unit" : "h"
+          }
         },
-        "sf_discoveryQuery": "sf_hostHasService:amq.message.age",
-        "sf_discoverySelectors": [
-            "_exists_:topic",
-            "sf_hostHasService:amq.message.age",
-            "_exists_:queue",
-            "_exists_:broker",
-            "plugin:amq.message.age"
-        ],
-        "sf_type": "Dashboard",
-        "marshallMemberOf": [
-            2
-        ],
-        "sf_dashboard": "ActiveMQ message age"
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#999999",
+        "visualization" : "area",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "broker1-TEST.FOO",
+        "propertyValue" : "broker1-TEST.FOO",
+        "NOT" : false,
+        "query" : "plugin_instance:\"broker1-TEST.FOO\"",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "InFlightCount",
+      "seriesData" : {
+        "metric" : "gauge.amq.queue.InFlightCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "visualization" : "area",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_6",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : null,
+        "max" : null,
+        "label" : "Blue - Value, Grey - Mean",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : ""
     },
-    {
-        "marshallId": 26,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "stackedChart": false,
-                "axisPrecision": null,
-                "useKMG2": false,
-                "range": -7200000,
-                "colorByMetric": false,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": 0,
-                        "max": null,
-                        "label": "ms",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    },
-                    {
-                        "max": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "title": {
-                            "text": ""
-                        },
-                        "min": 0
-                    }
-                ],
-                "sortPreference": "",
-                "disableThrottle": false
-            },
-            "currentUniqueKey": 5,
-            "uiHelperValue": "##CHARTID##_28",
-            "relatedDetectors": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "amq.message.age",
-                            "propertyValue": "amq.message.age",
-                            "NOT": false,
-                            "query": "plugin:amq.message.age",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "Max. message age",
-                    "seriesData": {
-                        "metric": "message.age.maximum",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [
-                                        {
-                                            "value": "queue"
-                                        }
-                                    ],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "MAX",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "visualization": "line",
-                        "maxExtrapolations": -1,
-                        "colorOverride": null,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION",
-                        "rollupPolicy": null,
-                        "aliases": {}
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "amq.message.age",
-                            "propertyValue": "amq.message.age",
-                            "NOT": false,
-                            "query": "plugin:amq.message.age",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "Max. message age",
-                    "seriesData": {
-                        "metric": "message.age.maximum",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [
-                                        {
-                                            "value": "topic"
-                                        }
-                                    ],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "MAX",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "visualization": "line",
-                        "maxExtrapolations": -1,
-                        "colorOverride": null,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION",
-                        "rollupPolicy": null,
-                        "aliases": {}
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "revisionNumber": 28
+    "relatedDetectors" : [ ],
+    "currentUniqueKey" : 4
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_6=id(report=1);find(query='(sf_metric:gauge.amq.queue.InFlightCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_6 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');find(query='(sf_metric:gauge.amq.queue.InFlightCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_6 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6')",
+  "sf_description" : "",
+  "sf_type" : "Chart",
+  "marshallId" : 24,
+  "marshallMemberOf" : [ 21 ],
+  "sf_chart" : "# Messages InFlight",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447436962814,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_discoveryQuery" : "hostHasService:\"activemq\" AND _exists_:host",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_6=id(report=1);find(query='(sf_metric:gauge.amq.queue.InFlightCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_6 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');find(query='(sf_metric:gauge.amq.queue.InFlightCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_6 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6')"
+}, {
+  "sf_chart" : "Avg. Enqueue Time",
+  "sf_uiModel" : {
+    "revisionNumber" : 10,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "broker1-TEST.FOO",
+        "propertyValue" : "broker1-TEST.FOO",
+        "NOT" : false,
+        "query" : "plugin_instance:\"broker1-TEST.FOO\"",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "Average Enqueue Time",
+      "seriesData" : {
+        "metric" : "gauge.amq.queue.AverageEnqueueTime",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "visualization" : "line",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_10",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
         },
-        "sf_description": "",
-        "sf_chartIndex": 1447976683093,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_2_28=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_28=id(report=1);find(query='(sf_metric:message.age.maximum AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('queue') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_2_28 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_28',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_28');find(query='(sf_metric:message.age.maximum AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('topic') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_3_28 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_28',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_28')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_2_28=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_28=id(report=1);find(query='(sf_metric:message.age.maximum AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('queue') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_2_28 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_28',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_28');find(query='(sf_metric:message.age.maximum AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('topic') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_3_28 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_28',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_28')",
-        "sf_discoveryQuery": "plugin:amq.message.age AND _exists_:host AND _exists_:broker AND _exists_:queue",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Max. by Queue",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            25
-        ]
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : ""
     },
-    {
-        "marshallId": 27,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "stackedChart": false,
-                "axisPrecision": null,
-                "useKMG2": false,
-                "range": -7200000,
-                "colorByMetric": false,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": 0,
-                        "max": null,
-                        "label": "ms",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    },
-                    {
-                        "max": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "title": {
-                            "text": ""
-                        },
-                        "min": 0
-                    }
-                ],
-                "sortPreference": "",
-                "disableThrottle": false
-            },
-            "currentUniqueKey": 4,
-            "uiHelperValue": "##CHARTID##_26",
-            "relatedDetectors": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "amq.message.age",
-                            "propertyValue": "amq.message.age",
-                            "NOT": false,
-                            "query": "plugin:amq.message.age",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "Max. message age",
-                    "seriesData": {
-                        "metric": "message.age.maximum",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [
-                                        {
-                                            "value": "broker"
-                                        }
-                                    ],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "MAX",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "visualization": "line",
-                        "maxExtrapolations": -1,
-                        "colorOverride": null,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION",
-                        "rollupPolicy": null,
-                        "aliases": {}
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "revisionNumber": 26
+    "currentUniqueKey" : 3
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_10=id(report=1);find(query='(sf_metric:gauge.amq.queue.AverageEnqueueTime AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10')",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447336111972,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 1000,
+  "sf_discoveryQuery" : "hostHasService:\"activemq\" AND _exists_:host",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_10=id(report=1);find(query='(sf_metric:gauge.amq.queue.AverageEnqueueTime AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10')",
+  "marshallId" : 25,
+  "marshallMemberOf" : [ 21 ]
+}, {
+  "sf_chart" : "Queue Size",
+  "sf_uiModel" : {
+    "revisionNumber" : 16,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "broker1-TEST.FOO",
+        "propertyValue" : "broker1-TEST.FOO",
+        "NOT" : false,
+        "query" : "plugin_instance:\"broker1-TEST.FOO\"",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "Mean Queue Size",
+      "seriesData" : {
+        "metric" : "gauge.amq.queue.QueueSize",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "transformation",
+          "options" : {
+            "amount" : 1,
+            "transformTimeRange" : "1h",
+            "unit" : "h"
+          }
         },
-        "sf_description": "",
-        "sf_chartIndex": 1447976655506,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_2_26=id(report=1);find(query='(sf_metric:message.age.maximum AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('broker') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_2_26 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_2_26=id(report=1);find(query='(sf_metric:message.age.maximum AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('broker') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_2_26 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26')",
-        "sf_discoveryQuery": "plugin:amq.message.age AND _exists_:host AND _exists_:broker AND _exists_:queue",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Max. by Broker",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            25
-        ]
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#999999",
+        "visualization" : "area",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "broker1-TEST.FOO",
+        "propertyValue" : "broker1-TEST.FOO",
+        "NOT" : false,
+        "query" : "plugin_instance:\"broker1-TEST.FOO\"",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "Queue Size",
+      "seriesData" : {
+        "metric" : "gauge.amq.queue.QueueSize",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "visualization" : "area",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_16",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : false,
+      "axisPrecision" : null,
+      "useKMG2" : false,
+      "range" : -7200000,
+      "colorByMetric" : false,
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "Red - Value, Grey - Mean",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      }, {
+        "max" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        },
+        "min" : 0
+      } ],
+      "sortPreference" : "",
+      "disableThrottle" : false
     },
-    {
-        "marshallId": 28,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "stackedChart": false,
-                "axisPrecision": null,
-                "useKMG2": false,
-                "range": -7200000,
-                "colorByMetric": false,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": 0,
-                        "max": null,
-                        "label": "ms",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    },
-                    {
-                        "max": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "title": {
-                            "text": ""
-                        },
-                        "min": 0
-                    }
-                ],
-                "sortPreference": "",
-                "disableThrottle": false
-            },
-            "currentUniqueKey": 6,
-            "uiHelperValue": "##CHARTID##_24",
-            "relatedDetectors": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "amq.message.age",
-                            "propertyValue": "amq.message.age",
-                            "NOT": false,
-                            "query": "plugin:amq.message.age",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "Avg. message age",
-                    "seriesData": {
-                        "metric": "message.age.average",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "visualization": "line",
-                        "maxExtrapolations": -1,
-                        "colorOverride": null,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION",
-                        "rollupPolicy": null,
-                        "aliases": {}
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "revisionNumber": 24
+    "currentUniqueKey" : 4
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_16=id(report=1);find(query='(sf_metric:gauge.amq.queue.QueueSize AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_16 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');find(query='(sf_metric:gauge.amq.queue.QueueSize AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_16 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16')",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447335008261,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 1000,
+  "sf_discoveryQuery" : "hostHasService:\"activemq\" AND _exists_:host",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_16=id(report=1);find(query='(sf_metric:gauge.amq.queue.QueueSize AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_16 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');find(query='(sf_metric:gauge.amq.queue.QueueSize AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_16 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16')",
+  "marshallId" : 26,
+  "marshallMemberOf" : [ 21 ]
+}, {
+  "sf_chart" : "Producers",
+  "sf_uiModel" : {
+    "revisionNumber" : 12,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "broker1-TEST.FOO",
+        "propertyValue" : "broker1-TEST.FOO",
+        "NOT" : false,
+        "query" : "plugin_instance:\"broker1-TEST.FOO\"",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "Mean Producer Count",
+      "seriesData" : {
+        "metric" : "gauge.amq.queue.ProducerCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "transformation",
+          "options" : {
+            "amount" : 1,
+            "transformTimeRange" : "1h",
+            "unit" : "h"
+          }
         },
-        "sf_description": "",
-        "sf_chartIndex": 1447860257774,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_2_24=id(report=1);find(query='(sf_metric:message.age.average AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_24 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_2_24=id(report=1);find(query='(sf_metric:message.age.average AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_24 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24')",
-        "sf_discoveryQuery": "plugin:\"amq.message.age\" AND _exists_:host",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Avg. Message Age",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            25
-        ]
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#999999",
+        "visualization" : "area",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "broker1-TEST.FOO",
+        "propertyValue" : "broker1-TEST.FOO",
+        "NOT" : false,
+        "query" : "plugin_instance:\"broker1-TEST.FOO\"",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "Producer Count",
+      "seriesData" : {
+        "metric" : "gauge.amq.queue.ProducerCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "visualization" : "area",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_12",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : false,
+      "colorByMetric" : false,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : null,
+        "max" : null,
+        "label" : "Blue - Value, Grey - Mean",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : ""
     },
-    {
-        "marshallId": 29,
-        "sf_uiModel": {
-            "chartMode": "list",
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "sf-icon-property",
-                            "value": "amq.message.age",
-                            "propertyValue": "amq.message.age",
-                            "NOT": false,
-                            "query": "plugin:amq.message.age",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "seriesData": {
-                        "metric": "message.age.maximum",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [
-                                        {
-                                            "value": "queue"
-                                        }
-                                    ],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "MAX",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "name": "Maximum age of messages (ms)"
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "sf-icon-property",
-                            "value": "amq.message.age",
-                            "propertyValue": "amq.message.age",
-                            "NOT": false,
-                            "query": "plugin:amq.message.age",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "seriesData": {
-                        "metric": "message.age.maximum",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [
-                                        {
-                                            "value": "topic"
-                                        }
-                                    ],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "MAX",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "name": "Maximum age of messages (ms)"
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "sf-icon-property",
-                            "value": "amq.message.age",
-                            "propertyValue": "amq.message.age",
-                            "NOT": false,
-                            "query": "sf_hostHasService:amq.message.age",
-                            "property": "sf_hostHasService",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 3,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "currentUniqueKey": 4,
-            "uiHelperValue": "##CHARTID##_7",
-            "relatedDetectors": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "sortPreference": "-value",
-                "range": -7200000,
-                "maxDecimalPlaces": 3,
-                "yAxisConfigurations": [
-                    {
-                        "max": null,
-                        "min": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "id": "yAxis0"
-                    }
-                ],
-                "useKMG2": false
-            },
-            "chartType": "line",
-            "revisionNumber": 7
+    "currentUniqueKey" : 4
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_12=id(report=1);find(query='(sf_metric:gauge.amq.queue.ProducerCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');find(query='(sf_metric:gauge.amq.queue.ProducerCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447335362192,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 1000,
+  "sf_discoveryQuery" : "hostHasService:\"activemq\" AND _exists_:host",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_12=id(report=1);find(query='(sf_metric:gauge.amq.queue.ProducerCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');find(query='(sf_metric:gauge.amq.queue.ProducerCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
+  "marshallId" : 27,
+  "marshallMemberOf" : [ 21 ]
+}, {
+  "sf_uiModel" : {
+    "revisionNumber" : 6,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "broker1-TEST.FOO",
+        "propertyValue" : "broker1-TEST.FOO",
+        "NOT" : false,
+        "query" : "plugin_instance:\"broker1-TEST.FOO\"",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "gauge.amq.queue.DequeueCount",
+      "seriesData" : {
+        "metric" : "gauge.amq.queue.DequeueCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_6",
+    "chartMode" : "single",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
         },
-        "sf_description": "",
-        "sf_chartIndex": 1447979280106,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_7=id(report=1);find(query='(sf_metric:message.age.maximum AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('queue') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_7 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');find(query='(sf_metric:message.age.maximum AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('topic') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_2_7 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_7=id(report=1);find(query='(sf_metric:message.age.maximum AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('queue') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_7 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');find(query='(sf_metric:message.age.maximum AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('topic') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_2_7 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Queues and topics with oldest messages",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 10000,
-        "marshallMemberOf": [
-            25
-        ]
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : ""
     },
-    {
-        "marshallId": 30,
-        "sf_uiModel": {
-            "chartMode": "single",
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "sf-icon-property",
-                            "value": "amq.message.age",
-                            "propertyValue": "amq.message.age",
-                            "NOT": false,
-                            "query": "plugin:amq.message.age",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "seriesData": {
-                        "metric": "message.age.maximum",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "MAX",
-                                "options": {}
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SCALE",
-                                "options": {
-                                    "scaleAmount": 0.001
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "name": "Average age of messages (sec)"
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "currentUniqueKey": 4,
-            "uiHelperValue": "##CHARTID##_7",
-            "relatedDetectors": [],
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "sortPreference": "",
-                "range": -7200000,
-                "maxDecimalPlaces": 3,
-                "updateInterval": "",
-                "yAxisConfigurations": [
-                    {
-                        "max": null,
-                        "min": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "id": "yAxis0"
-                    }
-                ],
-                "useKMG2": false
-            },
-            "chartType": "line",
-            "revisionNumber": 7
+    "relatedDetectors" : [ ],
+    "currentUniqueKey" : 3
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_6=id(report=1);find(query='(sf_metric:gauge.amq.queue.DequeueCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_6 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6')",
+  "sf_description" : "",
+  "sf_type" : "Chart",
+  "marshallId" : 28,
+  "marshallMemberOf" : [ 21 ],
+  "sf_chart" : "# Dequeued",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447335862932,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_discoveryQuery" : "hostHasService:\"activemq\" AND _exists_:host",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_6=id(report=1);find(query='(sf_metric:gauge.amq.queue.DequeueCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_6 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6')"
+}, {
+  "sf_chart" : "# Enqueued",
+  "sf_uiModel" : {
+    "revisionNumber" : 5,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "broker1-TEST.FOO",
+        "propertyValue" : "broker1-TEST.FOO",
+        "NOT" : false,
+        "query" : "plugin_instance:\"broker1-TEST.FOO\"",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "type" : "property",
+        "property" : "hostHasService",
+        "propertyValue" : "activemq",
+        "query" : "hostHasService:activemq",
+        "value" : "activemq",
+        "NOT" : false,
+        "displayName" : "activemq"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "gauge.amq.queue.EnqueueCount",
+      "seriesData" : {
+        "metric" : "gauge.amq.queue.EnqueueCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_5",
+    "chartMode" : "single",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
         },
-        "sf_description": "",
-        "sf_chartIndex": 1447977808908,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);find(query='(sf_metric:message.age.maximum AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!max -> { ?in * 0.001 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_7 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);find(query='(sf_metric:message.age.maximum AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!max -> { ?in * 0.001 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_7 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
-        "sf_discoveryQuery": "plugin:amq.message.age AND _exists_:host AND _exists_:broker AND _exists_:queue",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Age of oldest message (sec)",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 10000,
-        "marshallMemberOf": [
-            25
-        ]
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : ""
     },
-    {
-        "marshallId": 31,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "stackedChart": false,
-                "axisPrecision": null,
-                "useKMG2": false,
-                "range": -7200000,
-                "colorByMetric": false,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": 0,
-                        "max": null,
-                        "label": "ms",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    },
-                    {
-                        "max": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "title": {
-                            "text": ""
-                        },
-                        "min": 0
-                    }
-                ],
-                "sortPreference": "",
-                "disableThrottle": false
-            },
-            "currentUniqueKey": 4,
-            "uiHelperValue": "##CHARTID##_25",
-            "relatedDetectors": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "amq.message.age",
-                            "propertyValue": "amq.message.age",
-                            "NOT": false,
-                            "query": "plugin:amq.message.age",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "Max. message age",
-                    "seriesData": {
-                        "metric": "message.age.maximum",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "visualization": "line",
-                        "maxExtrapolations": -1,
-                        "colorOverride": null,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION",
-                        "rollupPolicy": null,
-                        "aliases": {}
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "revisionNumber": 25
+    "currentUniqueKey" : 3
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);find(query='(sf_metric:gauge.amq.queue.EnqueueCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.FOO) AND (plugin:GenericJMX) AND (hostHasService:activemq))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447335811040,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 10000,
+  "sf_discoveryQuery" : "hostHasService:\"activemq\" AND _exists_:host",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);find(query='(sf_metric:gauge.amq.queue.EnqueueCount AND _missing_:sf_programId) AND ((plugin_instance:broker1\\\\-TEST.FOO) AND (plugin:GenericJMX) AND (hostHasService:activemq))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_5 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
+  "marshallId" : 29,
+  "marshallMemberOf" : [ 21 ]
+}, {
+  "sf_dashboard" : "ActiveMQ hosts",
+  "sf_uiModel" : {
+    "widgets" : [ {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 0,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447929025809,
+        "id" : 1
+      },
+      "row" : 0
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 8,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447934564134,
+        "id" : 3
+      },
+      "row" : 0
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 4,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447935235603,
+        "id" : 2
+      },
+      "row" : 0
+    }, {
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "col" : 0,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447950345878,
+        "id" : 4
+      },
+      "row" : 1
+    }, {
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "col" : 6,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447950518622,
+        "id" : 5
+      },
+      "row" : 1
+    }, {
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "col" : 6,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447950450262,
+        "id" : 6
+      },
+      "row" : 2
+    }, {
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "col" : 0,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447950399179,
+        "id" : 7
+      },
+      "row" : 2
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 4,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447945789747,
+        "id" : 8
+      },
+      "row" : 3
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 0,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447938354316,
+        "id" : 9
+      },
+      "row" : 3
+    }, {
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "col" : 8,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447946137085,
+        "id" : 10
+      },
+      "row" : 3
+    } ],
+    "version" : 1
+  },
+  "sf_discoverySelectors" : [ "sf_hostHasService:activemq" ],
+  "sf_type" : "Dashboard",
+  "sf_discoveryQuery" : "sf_hostHasService:activemq",
+  "marshallId" : 30,
+  "marshallMemberOf" : [ 2 ]
+}, {
+  "sf_chart" : "Top Brokers by Producers",
+  "sf_uiModel" : {
+    "revisionNumber" : 7,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "host:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "host:*",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "plugin_instance:*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "",
+      "seriesData" : {
+        "metric" : "gauge.amq.TotalProducerCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_description": "",
-        "sf_chartIndex": 1447860278623,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_2_25=id(report=1);find(query='(sf_metric:message.age.maximum AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_25 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_25',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_25')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_2_25=id(report=1);find(query='(sf_metric:message.age.maximum AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_25 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_25',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_25')",
-        "sf_discoveryQuery": "plugin:\"amq.message.age\" AND _exists_:host",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Max. Message age",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            25
-        ]
+        "fn" : {
+          "type" : "SCALE",
+          "options" : {
+            "scaleAmount" : 10
+          }
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            }, {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "TOPN",
+          "options" : {
+            "count" : 5
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "visualization" : "area",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "aliases" : { }
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_7",
+    "chartMode" : "list",
+    "relatedDetectors" : [ ],
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : true,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : null,
+        "max" : null,
+        "label" : "Connections",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "-value"
     },
-    {
-        "marshallId": 32,
-        "sf_uiModel": {
-            "widgets": [
-                {
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447335811040,
-                        "id": 1
-                    },
-                    "sizeX": 4,
-                    "col": 0,
-                    "row": 0
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 4,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447335862932,
-                        "id": 2
-                    },
-                    "row": 0
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 8,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447336395145,
-                        "id": 3
-                    },
-                    "row": 0
-                },
-                {
-                    "sizeX": 6,
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447335008261,
-                        "id": 4
-                    },
-                    "type": "chart",
-                    "col": 0,
-                    "row": 1
-                },
-                {
-                    "sizeX": 6,
-                    "sizeY": 1,
-                    "col": 6,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447436962814,
-                        "id": 5
-                    },
-                    "row": 1
-                },
-                {
-                    "sizeX": 4,
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447335362192,
-                        "id": 7
-                    },
-                    "type": "chart",
-                    "col": 0,
-                    "row": 2
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 8,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447336111972,
-                        "id": 8
-                    },
-                    "row": 2
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 4,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447347835572,
-                        "id": 9
-                    },
-                    "row": 2
-                }
-            ],
-            "version": 1
+    "currentUniqueKey" : 3
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);find(query='(sf_metric:gauge.amq.TotalProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((hostHasService:activemq) AND (host:*) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> { ?in * 10 -> !out } -> groupby('host','plugin_instance') -> stats:!sum -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_7 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
+  "sf_cacheProgram" : false,
+  "sf_description" : "",
+  "sf_chartIndex" : 1447945789747,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 10000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);find(query='(sf_metric:gauge.amq.TotalProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((hostHasService:activemq) AND (host:*) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> { ?in * 10 -> !out } -> groupby('host','plugin_instance') -> stats:!sum -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_7 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
+  "marshallId" : 31,
+  "marshallMemberOf" : [ 30 ]
+}, {
+  "sf_chart" : "Total Consumers",
+  "sf_uiModel" : {
+    "revisionNumber" : 8,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "host:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "host:*",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "plugin_instance:*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "Consumers",
+      "seriesData" : {
+        "metric" : "gauge.amq.TotalConsumerCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_description": "",
-        "sf_discoveryQuery": "plugin:GenericJMX AND sf_hostHasService:activemq AND sf_metric:*.queue.*",
-        "sf_discoverySelectors": [
-            "_exists_:plugin_instance"
-        ],
-        "sf_type": "Dashboard",
-        "marshallMemberOf": [
-            2
-        ],
-        "sf_dashboard": "ActiveMQ one queue"
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "visualization" : "area",
+        "maxExtrapolations" : -1,
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "rollupPolicy" : null,
+        "aliases" : { }
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_8",
+    "chartMode" : "graph",
+    "relatedDetectors" : [ ],
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : true,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : null,
+        "max" : null,
+        "label" : "Consumers",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : ""
     },
-    {
-        "marshallId": 33,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "broker1-TEST.FOO",
-                            "propertyValue": "broker1-TEST.FOO",
-                            "NOT": false,
-                            "query": "plugin_instance:\"broker1-TEST.FOO\"",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "Mean Producer Count",
-                    "seriesData": {
-                        "metric": "gauge.amq.queue.ProducerCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "transformation",
-                                "options": {
-                                    "amount": 1,
-                                    "transformTimeRange": "1h",
-                                    "unit": "h"
-                                }
-                            },
-                            "fn": {
-                                "type": "MEAN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#999999",
-                        "visualization": "area",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "broker1-TEST.FOO",
-                            "propertyValue": "broker1-TEST.FOO",
-                            "NOT": false,
-                            "query": "plugin_instance:\"broker1-TEST.FOO\"",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "Producer Count",
-                    "seriesData": {
-                        "metric": "gauge.amq.queue.ProducerCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#0077c2",
-                        "visualization": "area",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "currentUniqueKey": 4,
-            "uiHelperValue": "##CHARTID##_11",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "stackedChart": false,
-                "colorByMetric": false,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": null,
-                        "max": null,
-                        "label": "Blue - Value, Grey - Mean",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": ""
-            },
-            "chartType": "line",
-            "revisionNumber": 11
+    "currentUniqueKey" : 3
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:gauge.amq.TotalConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:*) AND (plugin_instance:*) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
+  "sf_cacheProgram" : false,
+  "sf_description" : "",
+  "sf_chartIndex" : 1447950450262,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 1000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:gauge.amq.TotalConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:*) AND (plugin_instance:*) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_8 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
+  "marshallId" : 32,
+  "marshallMemberOf" : [ 30 ]
+}, {
+  "sf_uiModel" : {
+    "revisionNumber" : 10,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "host:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "host:*",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "plugin_instance:*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "Messages",
+      "seriesData" : {
+        "metric" : "gauge.amq.TotalMessageCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_chartIndex": 1447335362192,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_11=id(report=1);find(query='(sf_metric:gauge.amq.queue.ProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');find(query='(sf_metric:gauge.amq.queue.ProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_11=id(report=1);find(query='(sf_metric:gauge.amq.queue.ProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');find(query='(sf_metric:gauge.amq.queue.ProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11')",
-        "sf_discoveryQuery": "hostHasService:\"activemq\" AND _exists_:host",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Producers",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            32
-        ]
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "visualization" : "area",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "aliases" : { }
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_10",
+    "chartMode" : "graph",
+    "relatedDetectors" : [ ],
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : true,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : null,
+        "max" : null,
+        "label" : "Messages",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : ""
     },
-    {
-        "marshallId": 34,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "broker1-TEST.FOO",
-                            "propertyValue": "broker1-TEST.FOO",
-                            "NOT": false,
-                            "query": "plugin_instance:\"broker1-TEST.FOO\"",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "Average Enqueue Time",
-                    "seriesData": {
-                        "metric": "gauge.amq.queue.AverageEnqueueTime",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#b04600",
-                        "visualization": "line",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_9",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "max": null,
-                        "min": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": ""
-            },
-            "chartType": "line",
-            "revisionNumber": 9
+    "currentUniqueKey" : 3
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_10=id(report=1);find(query='(sf_metric:gauge.amq.TotalMessageCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:*) AND (plugin_instance:*) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10')",
+  "sf_description" : "",
+  "sf_type" : "Chart",
+  "marshallId" : 33,
+  "marshallMemberOf" : [ 30 ],
+  "sf_chart" : "Total Messages",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447950518622,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_discoveryQuery" : "hostHasService:activemq AND plugin:GenericJMX AND _exists_:host AND _exists_:plugin_instance",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_10=id(report=1);find(query='(sf_metric:gauge.amq.TotalMessageCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:*) AND (plugin_instance:*) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10')"
+}, {
+  "sf_chart" : "Top Brokers by Consumers",
+  "sf_uiModel" : {
+    "revisionNumber" : 8,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "host:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "host:*",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "plugin_instance:*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "",
+      "seriesData" : {
+        "metric" : "gauge.amq.TotalConsumerCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_chartIndex": 1447336111972,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);find(query='(sf_metric:gauge.amq.queue.AverageEnqueueTime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);find(query='(sf_metric:gauge.amq.queue.AverageEnqueueTime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9')",
-        "sf_discoveryQuery": "hostHasService:\"activemq\" AND _exists_:host",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Avg. Enqueue Time",
-        "sf_jobResolution": 1000,
-        "sf_disallowCachedProgram": true,
-        "marshallMemberOf": [
-            32
-        ]
+        "fn" : {
+          "type" : "SCALE",
+          "options" : {
+            "scaleAmount" : 10
+          }
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            }, {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "TOPN",
+          "options" : {
+            "count" : 5
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "visualization" : "area",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "aliases" : { }
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_8",
+    "chartMode" : "list",
+    "relatedDetectors" : [ ],
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : true,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : null,
+        "max" : null,
+        "label" : "Connections",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "-value"
     },
-    {
-        "marshallId": 35,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "stackedChart": false,
-                "colorByMetric": false,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": null,
-                        "max": null,
-                        "label": "Red - Value, Grey - Mean",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": ""
-            },
-            "currentUniqueKey": 4,
-            "uiHelperValue": "##CHARTID##_12",
-            "relatedDetectors": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "broker1-TEST.FOO",
-                            "propertyValue": "broker1-TEST.FOO",
-                            "NOT": false,
-                            "query": "plugin_instance:\"broker1-TEST.FOO\"",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "Mean Consumer Count",
-                    "seriesData": {
-                        "metric": "gauge.amq.queue.ConsumerCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "transformation",
-                                "options": {
-                                    "amount": 1,
-                                    "transformTimeRange": "1h",
-                                    "unit": "h"
-                                }
-                            },
-                            "fn": {
-                                "type": "MEAN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#999999",
-                        "visualization": "area",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "broker1-TEST.FOO",
-                            "propertyValue": "broker1-TEST.FOO",
-                            "NOT": false,
-                            "query": "plugin_instance:\"broker1-TEST.FOO\"",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "Consumer Count",
-                    "seriesData": {
-                        "metric": "gauge.amq.queue.ConsumerCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#b04600",
-                        "visualization": "area",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "revisionNumber": 12
+    "currentUniqueKey" : 3
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:gauge.amq.TotalConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((hostHasService:activemq) AND (host:*) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> { ?in * 10 -> !out } -> groupby('host','plugin_instance') -> stats:!sum -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
+  "sf_cacheProgram" : false,
+  "sf_description" : "",
+  "sf_chartIndex" : 1447946137085,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 10000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:gauge.amq.TotalConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((hostHasService:activemq) AND (host:*) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> { ?in * 10 -> !out } -> groupby('host','plugin_instance') -> stats:!sum -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
+  "marshallId" : 34,
+  "marshallMemberOf" : [ 30 ]
+}, {
+  "sf_chart" : "Total Producers",
+  "sf_uiModel" : {
+    "revisionNumber" : 8,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "host:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "host:*",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "plugin_instance:*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "Producers",
+      "seriesData" : {
+        "metric" : "gauge.amq.TotalProducerCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_description": "",
-        "sf_chartIndex": 1447347835572,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_12=id(report=1);find(query='(sf_metric:gauge.amq.queue.ConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');find(query='(sf_metric:gauge.amq.queue.ConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_12=id(report=1);find(query='(sf_metric:gauge.amq.queue.ConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');find(query='(sf_metric:gauge.amq.queue.ConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
-        "sf_discoveryQuery": "hostHasService:\"activemq\" AND _exists_:host",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Consumers",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            32
-        ]
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "visualization" : "area",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "aliases" : { }
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_8",
+    "chartMode" : "graph",
+    "relatedDetectors" : [ ],
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : true,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : null,
+        "max" : null,
+        "label" : "Producers",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : ""
     },
-    {
-        "marshallId": 36,
-        "sf_uiModel": {
-            "chartMode": "single",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "max": null,
-                        "min": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": ""
-            },
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_5",
-            "relatedDetectors": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "broker1-TEST.FOO",
-                            "propertyValue": "broker1-TEST.FOO",
-                            "NOT": false,
-                            "query": "plugin_instance:\"broker1-TEST.FOO\"",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "gauge.amq.queue.DequeueCount",
-                    "seriesData": {
-                        "metric": "gauge.amq.queue.DequeueCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#0077c2",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "revisionNumber": 5
+    "currentUniqueKey" : 3
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:gauge.amq.TotalProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:*) AND (plugin_instance:*) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
+  "sf_cacheProgram" : false,
+  "sf_description" : "",
+  "sf_chartIndex" : 1447950399179,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 1000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:gauge.amq.TotalProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:*) AND (plugin_instance:*) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_8 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
+  "marshallId" : 35,
+  "marshallMemberOf" : [ 30 ]
+}, {
+  "sf_chart" : "Top Brokers by Connections",
+  "sf_uiModel" : {
+    "revisionNumber" : 6,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "host:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "host:*",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "plugin_instance:*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "",
+      "seriesData" : {
+        "metric" : "counter.amq.TotalConnectionsCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_description": "",
-        "sf_chartIndex": 1447335862932,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);find(query='(sf_metric:gauge.amq.queue.DequeueCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);find(query='(sf_metric:gauge.amq.queue.DequeueCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_5 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
-        "sf_discoveryQuery": "hostHasService:\"activemq\" AND _exists_:host",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "# Dequeued",
-        "sf_jobResolution": 10000,
-        "sf_disallowCachedProgram": true,
-        "marshallMemberOf": [
-            32
-        ]
+        "fn" : {
+          "type" : "SCALE",
+          "options" : {
+            "scaleAmount" : 10
+          }
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            }, {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "TOPN",
+          "options" : {
+            "count" : 5
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "visualization" : "area",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "aliases" : { }
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_6",
+    "chartMode" : "list",
+    "relatedDetectors" : [ ],
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : true,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : null,
+        "max" : null,
+        "label" : "Connections",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "-value"
     },
-    {
-        "marshallId": 37,
-        "sf_uiModel": {
-            "chartMode": "single",
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "broker1-TEST.FOO",
-                            "propertyValue": "broker1-TEST.FOO",
-                            "NOT": false,
-                            "query": "plugin_instance:\"broker1-TEST.FOO\"",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "gauge.amq.queue.ExpiredCount",
-                    "seriesData": {
-                        "metric": "gauge.amq.queue.ExpiredCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#0077c2",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_7",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "max": null,
-                        "min": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": ""
-            },
-            "chartType": "line",
-            "revisionNumber": 7
+    "currentUniqueKey" : 3
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_6=id(report=1);find(query='(sf_metric:counter.amq.TotalConnectionsCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((hostHasService:activemq) AND (host:*) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> { ?in * 10 -> !out } -> groupby('host','plugin_instance') -> stats:!sum -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_6 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6')",
+  "sf_cacheProgram" : false,
+  "sf_description" : "",
+  "sf_chartIndex" : 1447938354316,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 10000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_6=id(report=1);find(query='(sf_metric:counter.amq.TotalConnectionsCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((hostHasService:activemq) AND (host:*) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> { ?in * 10 -> !out } -> groupby('host','plugin_instance') -> stats:!sum -> groupby() -> groupby() -> select(count=5):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_6 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6')",
+  "marshallId" : 36,
+  "marshallMemberOf" : [ 30 ]
+}, {
+  "sf_chart" : "# Brokers per Host",
+  "sf_uiModel" : {
+    "revisionNumber" : 4,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "host:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "host:*",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "plugin_instance:*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "",
+      "seriesData" : {
+        "metric" : "gauge.amq.TotalEnqueueCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_chartIndex": 1447336395145,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);find(query='(sf_metric:gauge.amq.queue.ExpiredCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_7 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);find(query='(sf_metric:gauge.amq.queue.ExpiredCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_7 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
-        "sf_discoveryQuery": "hostHasService:\"activemq\" AND _exists_:host",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "# Expired",
-        "sf_jobResolution": 10000,
-        "sf_disallowCachedProgram": true,
-        "marshallMemberOf": [
-            32
-        ]
+        "fn" : {
+          "type" : "COUNT",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_4",
+    "chartMode" : "list",
+    "chartconfig" : {
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : "-value"
     },
-    {
-        "marshallId": 38,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": null,
-                        "max": null,
-                        "label": "Blue - Value, Grey - Mean",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": ""
-            },
-            "currentUniqueKey": 4,
-            "uiHelperValue": "##CHARTID##_5",
-            "relatedDetectors": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "broker1-TEST.FOO",
-                            "propertyValue": "broker1-TEST.FOO",
-                            "NOT": false,
-                            "query": "plugin_instance:\"broker1-TEST.FOO\"",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "Mean InFlightCount",
-                    "seriesData": {
-                        "metric": "gauge.amq.queue.InFlightCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "transformation",
-                                "options": {
-                                    "amount": 1,
-                                    "transformTimeRange": "1h",
-                                    "unit": "h"
-                                }
-                            },
-                            "fn": {
-                                "type": "MEAN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#999999",
-                        "visualization": "area",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "broker1-TEST.FOO",
-                            "propertyValue": "broker1-TEST.FOO",
-                            "NOT": false,
-                            "query": "plugin_instance:\"broker1-TEST.FOO\"",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "InFlightCount",
-                    "seriesData": {
-                        "metric": "gauge.amq.queue.InFlightCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#0077c2",
-                        "visualization": "area",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "revisionNumber": 5
+    "currentUniqueKey" : 3
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_4=id(report=1);find(query='(sf_metric:gauge.amq.TotalEnqueueCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:*) AND (plugin_instance:*) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_4 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_4')",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447934564134,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 10000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_4=id(report=1);find(query='(sf_metric:gauge.amq.TotalEnqueueCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:*) AND (plugin_instance:*) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_4 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_4')",
+  "marshallId" : 37,
+  "marshallMemberOf" : [ 30 ]
+}, {
+  "sf_chart" : "# Hosts",
+  "sf_uiModel" : {
+    "revisionNumber" : 9,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "host:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "host:*",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "plugin_instance:*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "gauge.amq.TotalEnqueueCount - Mean by host - Count",
+      "seriesData" : {
+        "metric" : "gauge.amq.TotalEnqueueCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_description": "",
-        "sf_chartIndex": 1447436962814,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_5=id(report=1);find(query='(sf_metric:gauge.amq.queue.InFlightCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5');find(query='(sf_metric:gauge.amq.queue.InFlightCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_5=id(report=1);find(query='(sf_metric:gauge.amq.queue.InFlightCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_5 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5');find(query='(sf_metric:gauge.amq.queue.InFlightCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_5 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
-        "sf_discoveryQuery": "hostHasService:\"activemq\" AND _exists_:host",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "# Messages InFlight",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            32
-        ]
+        "fn" : {
+          "type" : "MEAN",
+          "options" : { }
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "COUNT",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_9",
+    "chartMode" : "single",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : ""
     },
-    {
-        "marshallId": 39,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "broker1-TEST.FOO",
-                            "propertyValue": "broker1-TEST.FOO",
-                            "NOT": false,
-                            "query": "plugin_instance:\"broker1-TEST.FOO\"",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "Mean Queue Size",
-                    "seriesData": {
-                        "metric": "gauge.amq.queue.QueueSize",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "transformation",
-                                "options": {
-                                    "amount": 1,
-                                    "transformTimeRange": "1h",
-                                    "unit": "h"
-                                }
-                            },
-                            "fn": {
-                                "type": "MEAN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#999999",
-                        "visualization": "area",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "broker1-TEST.FOO",
-                            "propertyValue": "broker1-TEST.FOO",
-                            "NOT": false,
-                            "query": "plugin_instance:\"broker1-TEST.FOO\"",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "Queue Size",
-                    "seriesData": {
-                        "metric": "gauge.amq.queue.QueueSize",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#b04600",
-                        "visualization": "area",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "currentUniqueKey": 4,
-            "uiHelperValue": "##CHARTID##_15",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "stackedChart": false,
-                "axisPrecision": null,
-                "useKMG2": false,
-                "range": -7200000,
-                "colorByMetric": false,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": 0,
-                        "max": null,
-                        "label": "Red - Value, Grey - Mean",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    },
-                    {
-                        "max": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "title": {
-                            "text": ""
-                        },
-                        "min": 0
-                    }
-                ],
-                "sortPreference": "",
-                "disableThrottle": false
-            },
-            "chartType": "line",
-            "revisionNumber": 15
+    "currentUniqueKey" : 3
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);find(query='(sf_metric:gauge.amq.TotalEnqueueCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((hostHasService:activemq) AND (host:*) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!mean -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9')",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447929025809,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 10000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);find(query='(sf_metric:gauge.amq.TotalEnqueueCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((hostHasService:activemq) AND (host:*) AND (plugin_instance:*) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!mean -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9')",
+  "marshallId" : 38,
+  "marshallMemberOf" : [ 30 ]
+}, {
+  "sf_chart" : "Total Connections",
+  "sf_uiModel" : {
+    "revisionNumber" : 8,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "host:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "host:*",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "plugin_instance:*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "Connections",
+      "seriesData" : {
+        "metric" : "counter.amq.TotalConnectionsCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_chartIndex": 1447335008261,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_15=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_15=id(report=1);find(query='(sf_metric:gauge.amq.queue.QueueSize AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_15 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_15',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_15');find(query='(sf_metric:gauge.amq.queue.QueueSize AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_15 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_15',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_15')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_15=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_15=id(report=1);find(query='(sf_metric:gauge.amq.queue.QueueSize AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_15 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_15',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_15');find(query='(sf_metric:gauge.amq.queue.QueueSize AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_15 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_15',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_15')",
-        "sf_discoveryQuery": "hostHasService:\"activemq\" AND _exists_:host",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Queue Size",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            32
-        ]
+        "fn" : {
+          "type" : "SCALE",
+          "options" : {
+            "scaleAmount" : 10
+          }
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "visualization" : "area",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "rollupPolicy" : null,
+        "maxExtrapolations" : -1,
+        "aliases" : { }
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_8",
+    "chartMode" : "graph",
+    "relatedDetectors" : [ ],
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : true,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : null,
+        "max" : null,
+        "label" : "Connections",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : ""
     },
-    {
-        "marshallId": 40,
-        "sf_uiModel": {
-            "chartMode": "single",
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "broker1-TEST.FOO",
-                            "propertyValue": "broker1-TEST.FOO",
-                            "NOT": false,
-                            "query": "plugin_instance:\"broker1-TEST.FOO\"",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "gauge.amq.queue.EnqueueCount",
-                    "seriesData": {
-                        "metric": "gauge.amq.queue.EnqueueCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#0077c2",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_4",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "max": null,
-                        "min": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": ""
-            },
-            "chartType": "line",
-            "revisionNumber": 4
+    "currentUniqueKey" : 3
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:counter.amq.TotalConnectionsCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:*) AND (plugin_instance:*) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> { ?in * 10 -> !out } -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
+  "sf_cacheProgram" : false,
+  "sf_description" : "",
+  "sf_chartIndex" : 1447950345878,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 1000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:counter.amq.TotalConnectionsCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:*) AND (plugin_instance:*) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> { ?in * 10 -> !out } -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_8 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
+  "marshallId" : 39,
+  "marshallMemberOf" : [ 30 ]
+}, {
+  "sf_chart" : "# Brokers",
+  "sf_uiModel" : {
+    "revisionNumber" : 11,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "host:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "host:*",
+        "property" : "host",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "plugin_instance:*",
+        "propertyValue" : "*",
+        "NOT" : false,
+        "query" : "plugin_instance:*",
+        "property" : "plugin_instance",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "activemq",
+        "propertyValue" : "activemq",
+        "NOT" : false,
+        "query" : "hostHasService:activemq",
+        "property" : "hostHasService",
+        "type" : "property"
+      }, {
+        "iconClass" : "icon-properties",
+        "value" : "GenericJMX",
+        "propertyValue" : "GenericJMX",
+        "NOT" : false,
+        "query" : "plugin:GenericJMX",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "gauge.amq.TotalEnqueueCount - Count by host - Sum",
+      "seriesData" : {
+        "metric" : "gauge.amq.TotalEnqueueCount",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_chartIndex": 1447335811040,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_4=id(report=1);find(query='(sf_metric:gauge.amq.queue.EnqueueCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_4 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_4')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_4=id(report=1);find(query='(sf_metric:gauge.amq.queue.EnqueueCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.FOO) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_4 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_4')",
-        "sf_discoveryQuery": "hostHasService:\"activemq\" AND _exists_:host",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "# Enqueued",
-        "sf_jobResolution": 10000,
-        "sf_disallowCachedProgram": true,
-        "marshallMemberOf": [
-            32
-        ]
+        "fn" : {
+          "type" : "COUNT",
+          "options" : { }
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "SUM",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_11",
+    "chartMode" : "single",
+    "relatedDetectors" : [ ],
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -7200000,
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "sortPreference" : ""
     },
-    {
-        "marshallId": 41,
-        "sf_uiModel": {
-            "widgets": [
-                {
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447335811040,
-                        "id": 1
-                    },
-                    "sizeX": 4,
-                    "col": 0,
-                    "row": 0
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 4,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447336395145,
-                        "id": 2
-                    },
-                    "row": 0
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 8,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447436942365,
-                        "id": 3
-                    },
-                    "row": 0
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 8,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447336111972,
-                        "id": 5
-                    },
-                    "row": 1
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 4,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447347835572,
-                        "id": 6
-                    },
-                    "row": 1
-                },
-                {
-                    "sizeX": 4,
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1447335362192,
-                        "id": 7
-                    },
-                    "type": "chart",
-                    "col": 0,
-                    "row": 1
-                }
-            ],
-            "version": 1
+    "currentUniqueKey" : 3
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);find(query='(sf_metric:gauge.amq.TotalEnqueueCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:*) AND (plugin_instance:*) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!count -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11')",
+  "sf_cacheProgram" : false,
+  "sf_description" : "",
+  "sf_chartIndex" : 1447935235603,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 10000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);find(query='(sf_metric:gauge.amq.TotalEnqueueCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:*) AND (plugin_instance:*) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!count -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11')",
+  "marshallId" : 40,
+  "marshallMemberOf" : [ 30 ]
+}, {
+  "sf_dashboard" : "ActiveMQ message age",
+  "sf_uiModel" : {
+    "widgets" : [ {
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "col" : 0,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447977808908,
+        "id" : 1
+      },
+      "row" : 0
+    }, {
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "col" : 6,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447979280106,
+        "id" : 7
+      },
+      "row" : 0
+    }, {
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "col" : 0,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447860257774,
+        "id" : 4
+      },
+      "row" : 1
+    }, {
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "col" : 6,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447860278623,
+        "id" : 3
+      },
+      "row" : 2
+    }, {
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "col" : 0,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447976655506,
+        "id" : 6
+      },
+      "row" : 2
+    }, {
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "col" : 6,
+      "type" : "chart",
+      "options" : {
+        "type" : "chart",
+        "name" : "",
+        "chartIndex" : 1447976683093,
+        "id" : 5
+      },
+      "row" : 3
+    } ],
+    "version" : 1
+  },
+  "sf_discoverySelectors" : [ "_exists_:topic", "sf_hostHasService:amq.message.age", "_exists_:queue", "_exists_:broker", "plugin:amq.message.age" ],
+  "sf_type" : "Dashboard",
+  "sf_discoveryQuery" : "sf_hostHasService:amq.message.age",
+  "marshallId" : 41,
+  "marshallMemberOf" : [ 2 ]
+}, {
+  "sf_uiModel" : {
+    "revisionNumber" : 26,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "amq.message.age",
+        "propertyValue" : "amq.message.age",
+        "NOT" : false,
+        "query" : "plugin:amq.message.age",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "Max. message age",
+      "seriesData" : {
+        "metric" : "message.age.maximum",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "broker"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_description": "",
-        "sf_discoveryQuery": "plugin:GenericJMX AND sf_hostHasService:activemq AND sf_metric:*.topic.*",
-        "sf_discoverySelectors": [
-            "_exists_:plugin_instance"
-        ],
-        "sf_type": "Dashboard",
-        "marshallMemberOf": [
-            2
-        ],
-        "sf_dashboard": "ActiveMQ topic"
+        "fn" : {
+          "type" : "MAX",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "visualization" : "line",
+        "maxExtrapolations" : -1,
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "rollupPolicy" : null,
+        "aliases" : { }
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_26",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : false,
+      "axisPrecision" : null,
+      "useKMG2" : false,
+      "range" : -7200000,
+      "colorByMetric" : false,
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "ms",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      }, {
+        "max" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        },
+        "min" : 0
+      } ],
+      "sortPreference" : "",
+      "disableThrottle" : false
     },
-    {
-        "marshallId": 42,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "stackedChart": false,
-                "colorByMetric": false,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": null,
-                        "max": null,
-                        "label": "Blue - Value, Grey - Mean",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": ""
-            },
-            "currentUniqueKey": 4,
-            "uiHelperValue": "##CHARTID##_12",
-            "relatedDetectors": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "broker1-TEST.TOPIC1",
-                            "propertyValue": "broker1-TEST.TOPIC1",
-                            "NOT": false,
-                            "query": "plugin_instance:\"broker1-TEST.TOPIC1\"",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "Mean Producer Count",
-                    "seriesData": {
-                        "metric": "gauge.amq.topic.ProducerCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "transformation",
-                                "options": {
-                                    "amount": 1,
-                                    "transformTimeRange": "1h",
-                                    "unit": "h"
-                                }
-                            },
-                            "fn": {
-                                "type": "MEAN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#999999",
-                        "visualization": "area",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "broker1-TEST.TOPIC1",
-                            "propertyValue": "broker1-TEST.TOPIC1",
-                            "NOT": false,
-                            "query": "plugin_instance:\"broker1-TEST.TOPIC1\"",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "Producer Count",
-                    "seriesData": {
-                        "metric": "gauge.amq.topic.ProducerCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#0077c2",
-                        "visualization": "area",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "revisionNumber": 12
+    "relatedDetectors" : [ ],
+    "currentUniqueKey" : 4
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_2_26=id(report=1);find(query='(sf_metric:message.age.maximum AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('broker') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_2_26 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26')",
+  "sf_description" : "",
+  "sf_type" : "Chart",
+  "marshallId" : 42,
+  "marshallMemberOf" : [ 41 ],
+  "sf_chart" : "Max. by Broker",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447976655506,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_discoveryQuery" : "plugin:amq.message.age AND _exists_:host AND _exists_:broker AND _exists_:queue",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_2_26=id(report=1);find(query='(sf_metric:message.age.maximum AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('broker') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_2_26 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26')"
+}, {
+  "sf_chart" : "Queues and topics with oldest messages",
+  "sf_uiModel" : {
+    "revisionNumber" : 7,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "value" : "amq.message.age",
+        "propertyValue" : "amq.message.age",
+        "NOT" : false,
+        "query" : "plugin:amq.message.age",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "seriesData" : {
+        "metric" : "message.age.maximum",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "queue"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_chartIndex": 1447335362192,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_12=id(report=1);find(query='(sf_metric:gauge.amq.topic.ProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');find(query='(sf_metric:gauge.amq.topic.ProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_12=id(report=1);find(query='(sf_metric:gauge.amq.topic.ProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');find(query='(sf_metric:gauge.amq.topic.ProducerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
-        "sf_discoveryQuery": "hostHasService:\"activemq\" AND _exists_:host",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Producers",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            41
-        ],
-        "sf_throttledProgramText": ""
+        "fn" : {
+          "type" : "MAX",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "name" : "Maximum age of messages (ms)"
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "value" : "amq.message.age",
+        "propertyValue" : "amq.message.age",
+        "NOT" : false,
+        "query" : "plugin:amq.message.age",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "seriesData" : {
+        "metric" : "message.age.maximum",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "topic"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "MAX",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "name" : "Maximum age of messages (ms)"
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "value" : "amq.message.age",
+        "propertyValue" : "amq.message.age",
+        "NOT" : false,
+        "query" : "sf_hostHasService:amq.message.age",
+        "property" : "sf_hostHasService",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 3,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_7",
+    "chartMode" : "list",
+    "relatedDetectors" : [ ],
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "sortPreference" : "-value",
+      "range" : -7200000,
+      "maxDecimalPlaces" : 3,
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "useKMG2" : false
     },
-    {
-        "marshallId": 43,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "broker1-TEST.TOPIC1",
-                            "propertyValue": "broker1-TEST.TOPIC1",
-                            "NOT": false,
-                            "query": "plugin_instance:\"broker1-TEST.TOPIC1\"",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "Mean InFlightCount",
-                    "seriesData": {
-                        "metric": "gauge.amq.topic.InFlightCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "transformation",
-                                "options": {
-                                    "amount": 1,
-                                    "transformTimeRange": "1h",
-                                    "unit": "h"
-                                }
-                            },
-                            "fn": {
-                                "type": "MEAN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#999999",
-                        "visualization": "area",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "broker1-TEST.TOPIC1",
-                            "propertyValue": "broker1-TEST.TOPIC1",
-                            "NOT": false,
-                            "query": "plugin_instance:\"broker1-TEST.TOPIC1\"",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "InFlightCount",
-                    "seriesData": {
-                        "metric": "gauge.amq.topic.InFlightCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#0077c2",
-                        "visualization": "area",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "currentUniqueKey": 4,
-            "uiHelperValue": "##CHARTID##_5",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": null,
-                        "max": null,
-                        "label": "Blue - Value, Grey - Mean",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": ""
-            },
-            "chartType": "line",
-            "revisionNumber": 5
+    "currentUniqueKey" : 4
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_7=id(report=1);find(query='(sf_metric:message.age.maximum AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('queue') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_7 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');find(query='(sf_metric:message.age.maximum AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('topic') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_2_7 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
+  "sf_cacheProgram" : false,
+  "sf_description" : "",
+  "sf_chartIndex" : 1447979280106,
+  "sf_jobMaxDelay" : 0,
+  "sf_type" : "Chart",
+  "sf_jobResolution" : 10000,
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_7=id(report=1);find(query='(sf_metric:message.age.maximum AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('queue') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_7 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');find(query='(sf_metric:message.age.maximum AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('topic') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_2_7 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
+  "marshallId" : 43,
+  "marshallMemberOf" : [ 41 ]
+}, {
+  "sf_uiModel" : {
+    "revisionNumber" : 25,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "amq.message.age",
+        "propertyValue" : "amq.message.age",
+        "NOT" : false,
+        "query" : "plugin:amq.message.age",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "Max. message age",
+      "seriesData" : {
+        "metric" : "message.age.maximum",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "visualization" : "line",
+        "maxExtrapolations" : -1,
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "rollupPolicy" : null,
+        "aliases" : { }
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_25",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : false,
+      "axisPrecision" : null,
+      "useKMG2" : false,
+      "range" : -7200000,
+      "colorByMetric" : false,
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "ms",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
         },
-        "sf_chartIndex": 1447436942365,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_5=id(report=1);find(query='(sf_metric:gauge.amq.topic.InFlightCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5');find(query='(sf_metric:gauge.amq.topic.InFlightCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_5=id(report=1);find(query='(sf_metric:gauge.amq.topic.InFlightCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_5 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5');find(query='(sf_metric:gauge.amq.topic.InFlightCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_5 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
-        "sf_discoveryQuery": "hostHasService:\"activemq\" AND _exists_:host",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "# Messages InFlight",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            41
-        ]
+        "id" : "yAxis0"
+      }, {
+        "max" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        },
+        "min" : 0
+      } ],
+      "sortPreference" : "",
+      "disableThrottle" : false
     },
-    {
-        "marshallId": 44,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "stackedChart": false,
-                "colorByMetric": false,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": null,
-                        "max": null,
-                        "label": "Red - Value, Grey - Mean",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": ""
-            },
-            "currentUniqueKey": 4,
-            "uiHelperValue": "##CHARTID##_13",
-            "relatedDetectors": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "broker1-TEST.TOPIC1",
-                            "propertyValue": "broker1-TEST.TOPIC1",
-                            "NOT": false,
-                            "query": "plugin_instance:\"broker1-TEST.TOPIC1\"",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "Mean Consumer Count",
-                    "seriesData": {
-                        "metric": "gauge.amq.topic.ConsumerCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "transformation",
-                                "options": {
-                                    "amount": 1,
-                                    "transformTimeRange": "1h",
-                                    "unit": "h"
-                                }
-                            },
-                            "fn": {
-                                "type": "MEAN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#999999",
-                        "visualization": "area",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "broker1-TEST.TOPIC1",
-                            "propertyValue": "broker1-TEST.TOPIC1",
-                            "NOT": false,
-                            "query": "plugin_instance:\"broker1-TEST.TOPIC1\"",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "Consumer Count",
-                    "seriesData": {
-                        "metric": "gauge.amq.topic.ConsumerCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#b04600",
-                        "visualization": "area",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "revisionNumber": 13
+    "relatedDetectors" : [ ],
+    "currentUniqueKey" : 4
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_2_25=id(report=1);find(query='(sf_metric:message.age.maximum AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_25 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_25',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_25')",
+  "sf_description" : "",
+  "sf_type" : "Chart",
+  "marshallId" : 44,
+  "marshallMemberOf" : [ 41 ],
+  "sf_chart" : "Max. Message age",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447860278623,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_discoveryQuery" : "plugin:\"amq.message.age\" AND _exists_:host",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_2_25=id(report=1);find(query='(sf_metric:message.age.maximum AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_25 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_25',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_25')"
+}, {
+  "sf_uiModel" : {
+    "revisionNumber" : 7,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "value" : "amq.message.age",
+        "propertyValue" : "amq.message.age",
+        "NOT" : false,
+        "query" : "plugin:amq.message.age",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "seriesData" : {
+        "metric" : "message.age.maximum",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_description": "",
-        "sf_chartIndex": 1447347835572,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_13=id(report=1);find(query='(sf_metric:gauge.amq.topic.ConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:gauge.amq.topic.ConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_13=id(report=1);find(query='(sf_metric:gauge.amq.topic.ConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> window(1h) -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:gauge.amq.topic.ConsumerCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')",
-        "sf_discoveryQuery": "hostHasService:\"activemq\" AND _exists_:host",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Consumers",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            41
-        ],
-        "sf_throttledProgramText": ""
+        "fn" : {
+          "type" : "MAX",
+          "options" : { }
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "SCALE",
+          "options" : {
+            "scaleAmount" : 0.001
+          }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "type" : "plot",
+      "name" : "Average age of messages (sec)"
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_7",
+    "chartMode" : "single",
+    "relatedDetectors" : [ ],
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "sortPreference" : "",
+      "range" : -7200000,
+      "maxDecimalPlaces" : 3,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "name" : "yAxis0",
+        "id" : "yAxis0"
+      } ],
+      "useKMG2" : false
     },
-    {
-        "marshallId": 45,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "max": null,
-                        "min": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": ""
-            },
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_10",
-            "relatedDetectors": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "broker1-TEST.TOPIC1",
-                            "propertyValue": "broker1-TEST.TOPIC1",
-                            "NOT": false,
-                            "query": "plugin_instance:\"broker1-TEST.TOPIC1\"",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "Average Enqueue Time",
-                    "seriesData": {
-                        "metric": "gauge.amq.topic.AverageEnqueueTime",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#b04600",
-                        "visualization": "line",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "revisionNumber": 10
+    "currentUniqueKey" : 4
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);find(query='(sf_metric:message.age.maximum AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!max -> { ?in * 0.001 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_7 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
+  "sf_description" : "",
+  "sf_type" : "Chart",
+  "marshallId" : 45,
+  "marshallMemberOf" : [ 41 ],
+  "sf_chart" : "Age of oldest message (sec)",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447977808908,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_discoveryQuery" : "plugin:amq.message.age AND _exists_:host AND _exists_:broker AND _exists_:queue",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);find(query='(sf_metric:message.age.maximum AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!max -> { ?in * 0.001 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_7 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')"
+}, {
+  "sf_uiModel" : {
+    "revisionNumber" : 28,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "amq.message.age",
+        "propertyValue" : "amq.message.age",
+        "NOT" : false,
+        "query" : "plugin:amq.message.age",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "Max. message age",
+      "seriesData" : {
+        "metric" : "message.age.maximum",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "queue"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
         },
-        "sf_chartIndex": 1447336111972,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_10=id(report=1);find(query='(sf_metric:gauge.amq.topic.AverageEnqueueTime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_10=id(report=1);find(query='(sf_metric:gauge.amq.topic.AverageEnqueueTime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10')",
-        "sf_discoveryQuery": "hostHasService:\"activemq\" AND _exists_:host",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Avg. Enqueue Time",
-        "sf_jobResolution": 1000,
-        "sf_disallowCachedProgram": true,
-        "marshallMemberOf": [
-            41
-        ],
-        "sf_throttledProgramText": ""
+        "fn" : {
+          "type" : "MAX",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "visualization" : "line",
+        "maxExtrapolations" : -1,
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "rollupPolicy" : null,
+        "aliases" : { }
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "amq.message.age",
+        "propertyValue" : "amq.message.age",
+        "NOT" : false,
+        "query" : "plugin:amq.message.age",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 2,
+      "name" : "Max. message age",
+      "seriesData" : {
+        "metric" : "message.age.maximum",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "topic"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          }
+        },
+        "fn" : {
+          "type" : "MAX",
+          "options" : { }
+        },
+        "showMe" : false
+      } ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "visualization" : "line",
+        "maxExtrapolations" : -1,
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "rollupPolicy" : null,
+        "aliases" : { }
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 3,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_28",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : false,
+      "axisPrecision" : null,
+      "useKMG2" : false,
+      "range" : -7200000,
+      "colorByMetric" : false,
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "ms",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "id" : "yAxis0"
+      }, {
+        "max" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        },
+        "min" : 0
+      } ],
+      "sortPreference" : "",
+      "disableThrottle" : false
     },
-    {
-        "marshallId": 46,
-        "sf_uiModel": {
-            "chartMode": "single",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "max": null,
-                        "min": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": ""
-            },
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_8",
-            "relatedDetectors": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "broker1-TEST.TOPIC1",
-                            "propertyValue": "broker1-TEST.TOPIC1",
-                            "NOT": false,
-                            "query": "plugin_instance:\"broker1-TEST.TOPIC1\"",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "gauge.amq.topic.ExpiredCount",
-                    "seriesData": {
-                        "metric": "gauge.amq.topic.ExpiredCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#0077c2",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "revisionNumber": 8
+    "relatedDetectors" : [ ],
+    "currentUniqueKey" : 5
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_2_28=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_28=id(report=1);find(query='(sf_metric:message.age.maximum AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('queue') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_2_28 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_28',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_28');find(query='(sf_metric:message.age.maximum AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('topic') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_3_28 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_28',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_28')",
+  "sf_description" : "",
+  "sf_type" : "Chart",
+  "marshallId" : 46,
+  "marshallMemberOf" : [ 41 ],
+  "sf_chart" : "Max. by Queue",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447976683093,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_discoveryQuery" : "plugin:amq.message.age AND _exists_:host AND _exists_:broker AND _exists_:queue",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_2_28=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_28=id(report=1);find(query='(sf_metric:message.age.maximum AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('queue') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_2_28 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_28',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_28');find(query='(sf_metric:message.age.maximum AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('topic') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_3_28 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_28',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_28')"
+}, {
+  "sf_uiModel" : {
+    "revisionNumber" : 24,
+    "chartType" : "line",
+    "allPlots" : [ {
+      "queryItems" : [ {
+        "iconClass" : "icon-properties",
+        "value" : "amq.message.age",
+        "propertyValue" : "amq.message.age",
+        "NOT" : false,
+        "query" : "plugin:amq.message.age",
+        "property" : "plugin",
+        "type" : "property"
+      } ],
+      "uniqueKey" : 1,
+      "name" : "Avg. message age",
+      "seriesData" : {
+        "metric" : "message.age.average",
+        "regExStyle" : null
+      },
+      "dataManipulations" : [ ],
+      "transient" : false,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "configuration" : {
+        "visualization" : "line",
+        "maxExtrapolations" : -1,
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "rollupPolicy" : null,
+        "aliases" : { }
+      },
+      "type" : "plot",
+      "metricDefinition" : { }
+    }, {
+      "queryItems" : [ ],
+      "uniqueKey" : 2,
+      "name" : "New Plot",
+      "seriesData" : { },
+      "dataManipulations" : [ ],
+      "transient" : true,
+      "yAxisIndex" : 0,
+      "invisible" : false,
+      "focusNext" : false,
+      "type" : "plot",
+      "metricDefinition" : { }
+    } ],
+    "uiHelperValue" : "##CHARTID##_24",
+    "chartMode" : "graph",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "rangeEnd" : 0,
+      "absoluteStart" : null,
+      "stackedChart" : false,
+      "axisPrecision" : null,
+      "useKMG2" : false,
+      "range" : -7200000,
+      "colorByMetric" : false,
+      "yAxisConfigurations" : [ {
+        "name" : "yAxis0",
+        "min" : 0,
+        "max" : null,
+        "label" : "ms",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
         },
-        "sf_chartIndex": 1447336395145,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:gauge.amq.topic.ExpiredCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_8 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);find(query='(sf_metric:gauge.amq.topic.ExpiredCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_8 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
-        "sf_discoveryQuery": "hostHasService:\"activemq\" AND _exists_:host",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "# Expired",
-        "sf_jobResolution": 10000,
-        "sf_disallowCachedProgram": true,
-        "marshallMemberOf": [
-            41
-        ],
-        "sf_throttledProgramText": ""
+        "id" : "yAxis0"
+      }, {
+        "max" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        },
+        "min" : 0
+      } ],
+      "sortPreference" : "",
+      "disableThrottle" : false
     },
-    {
-        "marshallId": 47,
-        "sf_uiModel": {
-            "chartMode": "single",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -7200000,
-                "yAxisConfigurations": [
-                    {
-                        "max": null,
-                        "min": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": ""
-            },
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_5",
-            "relatedDetectors": [],
-            "allPlots": [
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "ActiveMQ_Host1",
-                            "propertyValue": "ActiveMQ_Host1",
-                            "NOT": false,
-                            "query": "host:ActiveMQ_Host1",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "broker1-TEST.TOPIC1",
-                            "propertyValue": "broker1-TEST.TOPIC1",
-                            "NOT": false,
-                            "query": "plugin_instance:\"broker1-TEST.TOPIC1\"",
-                            "property": "plugin_instance",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "activemq",
-                            "propertyValue": "activemq",
-                            "NOT": false,
-                            "query": "hostHasService:activemq",
-                            "property": "hostHasService",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "GenericJMX",
-                            "propertyValue": "GenericJMX",
-                            "NOT": false,
-                            "query": "plugin:GenericJMX",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "gauge.amq.topic.EnqueueCount",
-                    "seriesData": {
-                        "metric": "gauge.amq.topic.EnqueueCount",
-                        "regExStyle": null
-                    },
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#0077c2",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "metricDefinition": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "seriesData": {},
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "type": "plot",
-                    "metricDefinition": {}
-                }
-            ],
-            "chartType": "line",
-            "revisionNumber": 5
-        },
-        "sf_chartIndex": 1447335811040,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);find(query='(sf_metric:gauge.amq.topic.EnqueueCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);find(query='(sf_metric:gauge.amq.topic.EnqueueCount AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:ActiveMQ_Host1) AND (plugin_instance:broker1\\\\-TEST.TOPIC1) AND (hostHasService:activemq) AND (plugin:GenericJMX))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_5 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
-        "sf_discoveryQuery": "hostHasService:\"activemq\" AND _exists_:host",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "# Enqueued",
-        "sf_jobResolution": 10000,
-        "sf_disallowCachedProgram": true,
-        "marshallMemberOf": [
-            41
-        ],
-        "sf_throttledProgramText": ""
-    }
-]
+    "relatedDetectors" : [ ],
+    "currentUniqueKey" : 6
+  },
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_2_24=id(report=1);find(query='(sf_metric:message.age.average AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_24 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24')",
+  "sf_description" : "",
+  "sf_type" : "Chart",
+  "marshallId" : 47,
+  "marshallMemberOf" : [ 41 ],
+  "sf_chart" : "Avg. Message Age",
+  "sf_cacheProgram" : false,
+  "sf_chartIndex" : 1447860257774,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_discoveryQuery" : "plugin:\"amq.message.age\" AND _exists_:host",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_2_24=id(report=1);find(query='(sf_metric:message.age.average AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:amq.message.age))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_24 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24')"
+} ]


### PR DESCRIPTION
AMQ topic and queue dashboards required filtering by host in addition
to filtering by topic or queue, which in the new model of filtering
does not make sense. Removed this filter as plugin_instance is already
as specific as it needs to be.