### PR TITLE
Bug fixes

### DIFF
--- a/CollectD/Page_CollectD_SFX.json
+++ b/CollectD/Page_CollectD_SFX.json
@@ -181,621 +181,12 @@
 }, {
   "marshallId" : 4,
   "marshallMemberOf" : [ 3 ],
-  "sf_chart" : "Memory Paging",
-  "sf_chartIndex" : 3,
-  "sf_description" : "page swaps/sec",
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 1000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_14=id(report=1);find(query='(sf_metric:vmpage_io.swap.in AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:vmem) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');find(query='(sf_metric:vmpage_io.swap.out AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:vmem) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allDetectorDecorators" : [ ],
-    "allPlotConstructs" : [ ],
-    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.vmem.vmpage_io.swap.in AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_3_4')", "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.vmem.vmpage_io.swap.out AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_3_4')" ],
-    "allPlots" : [ {
-      "configuration" : {
-        "colorOverride" : "#b04600",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "DELTA_ROLLUP"
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "swapped in",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "vmem",
-        "query" : "plugin:vmem",
-        "type" : "property",
-        "value" : "vmem"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "host",
-        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
-        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
-        "type" : "property",
-        "value" : "integration-test-zookeeper-3.4.6-0"
-      } ],
-      "seriesData" : {
-        "metric" : "vmpage_io.swap.in"
-      },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "colorOverride" : "#0077c2",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "DELTA_ROLLUP"
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "swapped out",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "vmem",
-        "query" : "plugin:vmem",
-        "type" : "property",
-        "value" : "vmem"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "host",
-        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
-        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
-        "type" : "property",
-        "value" : "integration-test-zookeeper-3.4.6-0"
-      } ],
-      "seriesData" : {
-        "metric" : "vmpage_io.swap.out"
-      },
-      "sf_programText" : "find(refresh=300000,query='sf_metric:collectd.vmem.vmpage_io.swap.in AND sf_organizationID:BqDQY5OAAAA AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_BwzVGs0AEAA_2_2=id -> publish(defaultSource='_SF_PLOT_KEY_BwzVGs0AEAA_2_2',metric='_SF_PLOT_KEY_BwzVGs0AEAA_2_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='BwzVGs0AEAA_2')",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "valid" : false,
-      "yAxisIndex" : 1
-    }, {
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ {
-        "iconClass" : "sf-icon-property",
-        "query" : "aws_service:quantizer",
-        "type" : "property",
-        "value" : "Aws_service:quantizer"
-      } ],
-      "seriesData" : { },
-      "sf_programText" : "",
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 3,
-      "valid" : false,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "disableThrottle" : false,
-      "maxDecimalPlaces" : 3,
-      "range" : -7200000,
-      "rangeEnd" : 0,
-      "sortPreference" : "",
-      "stackedChart" : false,
-      "updateInterval" : "",
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "swapped in - RED",
-        "max" : null,
-        "min" : 0,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      }, {
-        "label" : "swapped out - BLUE",
-        "max" : null,
-        "min" : 0,
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "title" : {
-          "text" : ""
-        }
-      } ]
-    },
-    "currentUniqueKey" : 4,
-    "revisionNumber" : 14,
-    "sf_detectorDecorators" : [ ],
-    "uiHelperValue" : "##CHARTID##_14"
-  }
-}, {
-  "marshallId" : 5,
-  "marshallMemberOf" : [ 3 ],
-  "sf_chart" : "CPU Used %",
-  "sf_chartIndex" : 1459444857291,
-  "sf_description" : "",
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 10000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_19=id(report=1);find(query='(sf_metric:cpu.utilization AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:signalfx\\\\-metadata))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_19 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19')",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allDetectorDecorators" : [ ],
-    "allPlotConstructs" : [ ],
-    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.aggregation.cpu-average.cpu.idle AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('aws_Name')->_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_0_5');_SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK" ],
-    "allPlots" : [ {
-      "configuration" : {
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "cpu.utilization",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "host",
-        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
-        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
-        "type" : "property",
-        "value" : "integration-test-zookeeper-3.4.6-0"
-      }, {
-        "NOT" : false,
-        "displayName" : "signalfx-metadata",
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "signalfx-metadata",
-        "query" : "plugin:\"signalfx-metadata\"",
-        "type" : "property",
-        "value" : "signalfx-metadata"
-      } ],
-      "seriesData" : {
-        "metric" : "cpu.utilization",
-        "regExStyle" : null
-      },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "single",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "maxDecimalPlaces" : 3,
-      "range" : -7200000,
-      "rangeEnd" : 0,
-      "sortPreference" : "",
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "%",
-        "max" : 110,
-        "min" : 0,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 7,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 19,
-    "sf_detectorDecorators" : [ ],
-    "uiHelperValue" : "##CHARTID##_19"
-  }
-}, {
-  "marshallId" : 6,
-  "marshallMemberOf" : [ 3 ],
-  "sf_chart" : "Disk I/O",
-  "sf_chartIndex" : 5,
-  "sf_description" : "operations/sec",
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 1000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_18=id(report=1);A => find(query='(sf_metric:disk_ops.read AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:disk) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_18 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');C => find(query='(sf_metric:disk_ops.write AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:disk) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_18 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18')",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allDetectorDecorators" : [ ],
-    "allPlotConstructs" : [ ],
-    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.disk.*disk_ops.read AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_6_1_7=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_6_1_7',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_6_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_6_7')" ],
-    "allPlots" : [ {
-      "configuration" : {
-        "colorOverride" : "#b04600",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "read ops/sec",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "disk",
-        "query" : "plugin:disk",
-        "type" : "property",
-        "value" : "disk"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "host",
-        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
-        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
-        "type" : "property",
-        "value" : "integration-test-zookeeper-3.4.6-0"
-      } ],
-      "seriesData" : {
-        "metric" : "disk_ops.read"
-      },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "colorOverride" : "#0077c2",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "write ops/sec",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "disk",
-        "query" : "plugin:disk",
-        "type" : "property",
-        "value" : "disk"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "host",
-        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
-        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
-        "type" : "property",
-        "value" : "integration-test-zookeeper-3.4.6-0"
-      } ],
-      "seriesData" : {
-        "metric" : "disk_ops.write"
-      },
-      "sf_programText" : "find(query='(sf_metric:disk_ops.read AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_CGraATNAgAA_3_10=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGraATNAgAA_3_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGraATNAgAA_10')",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "valid" : false,
-      "yAxisIndex" : 1
-    }, {
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 3,
-      "valid" : false,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : true,
-      "range" : -7200000,
-      "rangeEnd" : 0,
-      "sortPreference" : "",
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "read ops - RED",
-        "max" : null,
-        "min" : 0,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      }, {
-        "label" : "write ops - BLUE",
-        "max" : null,
-        "min" : 0,
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "title" : {
-          "text" : ""
-        }
-      } ]
-    },
-    "currentUniqueKey" : 5,
-    "revisionNumber" : 18,
-    "sf_detectorDecorators" : [ ],
-    "uiHelperValue" : "##CHARTID##_18"
-  }
-}, {
-  "marshallId" : 7,
-  "marshallMemberOf" : [ 3 ],
-  "sf_chart" : "Memory Used %",
-  "sf_chartIndex" : 1459445051615,
-  "sf_description" : "",
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 10000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_17=id(report=1);find(query='(sf_metric:memory.utilization AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:signalfx\\\\-metadata))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_17 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17')",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allDetectorDecorators" : [ ],
-    "allPlotConstructs" : [ ],
-    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.free AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3=id", "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.used AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK=[?B,?A,!OUT]{?B  /  (?A  +  ?B)  *  100->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('sf_source')->groupby('aws_Name')->stats:!mean->_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_2_3');_SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3->?B:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK;_SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK" ],
-    "allPlots" : [ {
-      "configuration" : {
-        "colorOverride" : "#05ce00",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "free",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "host",
-        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
-        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
-        "type" : "property",
-        "value" : "integration-test-zookeeper-3.4.6-0"
-      }, {
-        "NOT" : false,
-        "displayName" : "signalfx-metadata",
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "signalfx-metadata",
-        "query" : "plugin:\"signalfx-metadata\"",
-        "type" : "property",
-        "value" : "signalfx-metadata"
-      } ],
-      "seriesData" : {
-        "metric" : "memory.utilization",
-        "regExStyle" : null
-      },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "single",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : true,
-      "disableThrottle" : false,
-      "maxDecimalPlaces" : 3,
-      "range" : -7200000,
-      "rangeEnd" : 0,
-      "sortPreference" : "-value",
-      "stackedChart" : true,
-      "updateInterval" : "",
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "%",
-        "max" : null,
-        "min" : 0,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 9,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 17,
-    "sf_detectorDecorators" : [ ],
-    "uiHelperValue" : "##CHARTID##_17"
-  }
-}, {
-  "marshallId" : 8,
-  "marshallMemberOf" : [ 3 ],
-  "sf_chart" : "CPU %",
-  "sf_chartIndex" : 1,
-  "sf_description" : "",
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 1000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);find(query='(sf_metric:cpu.utilization AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:signalfx\\\\-metadata))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_18 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18')",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allDetectorDecorators" : [ ],
-    "allPlotConstructs" : [ ],
-    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.aggregation.cpu-average.cpu.idle AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('aws_Name')->_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_0_5');_SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK" ],
-    "allPlots" : [ {
-      "configuration" : {
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "CPU utilization (%)",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "host",
-        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
-        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
-        "type" : "property",
-        "value" : "integration-test-zookeeper-3.4.6-0"
-      }, {
-        "NOT" : false,
-        "displayName" : "signalfx-metadata",
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "signalfx-metadata",
-        "query" : "plugin:\"signalfx-metadata\"",
-        "type" : "property",
-        "value" : "signalfx-metadata"
-      } ],
-      "seriesData" : {
-        "metric" : "cpu.utilization",
-        "regExStyle" : null
-      },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "area",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "range" : -7200000,
-      "rangeEnd" : 0,
-      "sortPreference" : "",
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "%",
-        "max" : 110,
-        "min" : 0,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 7,
-    "revisionNumber" : 18,
-    "sf_detectorDecorators" : [ ],
-    "uiHelperValue" : "##CHARTID##_18"
-  }
-}, {
-  "marshallId" : 9,
-  "marshallMemberOf" : [ 3 ],
   "sf_chart" : "Network I/O",
   "sf_chartIndex" : 8,
   "sf_description" : "bits/sec",
   "sf_jobMaxDelay" : 0,
   "sf_jobResolution" : 1000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_19=id(report=1);find(query='(sf_metric:if_octets.rx AND _missing_:sf_programId) AND ((plugin_instance:e*) AND (plugin:interface) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_19 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');find(query='(sf_metric:if_octets.tx AND _missing_:sf_programId) AND ((plugin_instance:e*) AND (plugin:interface) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_2_19 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19')",
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_21=id(report=1);find(query='(sf_metric:if_octets.rx AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin_instance:e*) AND (plugin:interface) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_21 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');find(query='(sf_metric:if_octets.tx AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin_instance:e*) AND (plugin:interface) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_2_21 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21')",
   "sf_type" : "Chart",
   "sf_uiModel" : {
     "allDetectorDecorators" : [ ],
@@ -803,8 +194,9 @@
     "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.interface*.if_octets.rx AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> ?a:math(b=8):!product -> _SF_PLOT_KEY_SYNTH_CHART_ID_7_1_6=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_7_1_6',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_7_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_7_6')" ],
     "allPlots" : [ {
       "configuration" : {
+        "aliases" : { },
         "colorOverride" : "#b04600",
-        "extrapolationPolicy" : "AUTO",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
         "maxExtrapolations" : -1,
         "rollupPolicy" : null
       },
@@ -865,8 +257,9 @@
       "yAxisIndex" : 0
     }, {
       "configuration" : {
+        "aliases" : { },
         "colorOverride" : "#0077c2",
-        "extrapolationPolicy" : "AUTO",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
         "maxExtrapolations" : -1,
         "rollupPolicy" : null
       },
@@ -926,6 +319,11 @@
       "valid" : false,
       "yAxisIndex" : 1
     }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
       "dataManipulations" : [ ],
       "focusNext" : false,
       "invisible" : false,
@@ -945,11 +343,11 @@
       "absoluteEnd" : null,
       "absoluteStart" : null,
       "colorByMetric" : true,
-      "forcedResolution" : "0",
       "range" : -7200000,
       "rangeEnd" : 0,
       "sortPreference" : "",
       "updateInterval" : "",
+      "useKMG2" : true,
       "yAxisConfigurations" : [ {
         "id" : "yAxis0",
         "label" : "input bits/s - RED",
@@ -974,538 +372,12 @@
       } ]
     },
     "currentUniqueKey" : 4,
-    "revisionNumber" : 19,
-    "sf_detectorDecorators" : [ ],
-    "uiHelperValue" : "##CHARTID##_19"
-  }
-}, {
-  "marshallId" : 10,
-  "marshallMemberOf" : [ 3 ],
-  "sf_chart" : "Load Average",
-  "sf_chartIndex" : 2,
-  "sf_description" : "",
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 10000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_14=id(report=1);A => find(query='(sf_metric:load.shortterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:load) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');B => find(query='(sf_metric:load.midterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:load) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');C => find(query='(sf_metric:load.longterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:load) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allDetectorDecorators" : [ ],
-    "allPlotConstructs" : [ ],
-    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.load.load.shortterm AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_1_5')" ],
-    "allPlots" : [ {
-      "configuration" : {
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "MEAN"
-        },
-        "name" : "New Aggregation",
-        "showMe" : false
-      } ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "01-min",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "load",
-        "query" : "plugin:load",
-        "type" : "property",
-        "value" : "load"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "host",
-        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
-        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
-        "type" : "property",
-        "value" : "integration-test-zookeeper-3.4.6-0"
-      } ],
-      "seriesData" : {
-        "metric" : "load.shortterm"
-      },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "MEAN"
-        },
-        "name" : "New Aggregation",
-        "showMe" : false
-      } ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "05-min",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "load",
-        "query" : "plugin:load",
-        "type" : "property",
-        "value" : "load"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "host",
-        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
-        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
-        "type" : "property",
-        "value" : "integration-test-zookeeper-3.4.6-0"
-      } ],
-      "seriesData" : {
-        "metric" : "load.midterm"
-      },
-      "sf_programText" : "find(query='(sf_metric:load.shortterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_CGraATAAcAA_2_10=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGraATAAcAA_2_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGraATAAcAA_10')",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "MEAN"
-        },
-        "name" : "New Aggregation",
-        "showMe" : false
-      } ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "15-min",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "load",
-        "query" : "plugin:load",
-        "type" : "property",
-        "value" : "load"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "host",
-        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
-        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
-        "type" : "property",
-        "value" : "integration-test-zookeeper-3.4.6-0"
-      } ],
-      "seriesData" : {
-        "metric" : "load.longterm"
-      },
-      "sf_programText" : "find(query='(sf_metric:load.shortterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_CGraATAAcAA_3_10=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGraATAAcAA_3_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGraATAAcAA_10')",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 3,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 4,
-      "valid" : false,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "list",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "maxDecimalPlaces" : 3,
-      "range" : -7200000,
-      "rangeEnd" : 0,
-      "sortPreference" : "+sf_metric",
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "max" : null,
-        "min" : 0,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 5,
-    "revisionNumber" : 14,
-    "sf_detectorDecorators" : [ ],
-    "uiHelperValue" : "##CHARTID##_14"
-  }
-}, {
-  "marshallId" : 11,
-  "marshallMemberOf" : [ 3 ],
-  "sf_chart" : "Disk Free %",
-  "sf_chartIndex" : 1433463909939,
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 10000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_8_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};find(query='(sf_metric:disk.utilization AND _missing_:sf_programId) AND ((plugin:signalfx\\\\-metadata) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_8;_SF_PLOT_KEY_##CHARTID##_3_8_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_8->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8');_SF_PLOT_KEY_##CHARTID##_1_8->?A:_SF_PLOT_KEY_##CHARTID##_3_8_MACROBLOCK",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlotConstructs" : [ ],
-    "allPlots" : [ {
-      "configuration" : {
-        "colorOverride" : "#b04600",
-        "extrapolationPolicy" : "AUTO",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "MEAN"
-        },
-        "showMe" : false
-      } ],
-      "focusNext" : false,
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "used bytes",
-      "queryItems" : [ {
-        "NOT" : false,
-        "displayName" : "signalfx-metadata",
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "signalfx-metadata",
-        "query" : "plugin:\"signalfx-metadata\"",
-        "type" : "property",
-        "value" : "signalfx-metadata"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "host",
-        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
-        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
-        "type" : "property",
-        "value" : "integration-test-zookeeper-3.4.6-0"
-      } ],
-      "seriesData" : {
-        "metric" : "disk.utilization",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "dataManipulations" : [ ],
-      "expressionText" : "100 - A",
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 2,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 3,
-      "valid" : false,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "list",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "maxDecimalPlaces" : 3,
-      "range" : -7200000,
-      "rangeEnd" : 0,
-      "sortPreference" : "+value",
-      "stackedChart" : true,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 6,
-    "revisionNumber" : 8,
-    "uiHelperValue" : "##CHARTID##_8"
-  }
-}, {
-  "marshallId" : 12,
-  "marshallMemberOf" : [ 3 ],
-  "sf_chart" : "Network Errors",
-  "sf_chartIndex" : 1465337015263,
-  "sf_description" : "errors/sec",
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 1000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK=[?A,?B,!OUT]{?A  +  ?B->!OUT};find(query='(sf_metric:if_errors.rx AND _missing_:sf_programId) AND ((plugin:interface) AND (plugin_instance:e*) AND (host:charlie\\\\-ubuntu14044))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> split -> _SF_PLOT_KEY_##CHARTID##_1_21;find(query='(sf_metric:if_errors.tx AND _missing_:sf_programId) AND ((plugin:interface) AND (plugin_instance:e*) AND (host:charlie\\\\-ubuntu14044))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> split -> _SF_PLOT_KEY_##CHARTID##_2_21;_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK:!OUT->groupby()->stats:!sum->_SF_PLOT_KEY_##CHARTID##_3_21->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_1_21->?A:_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_21->?B:_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allDetectorDecorators" : [ ],
-    "allPlotConstructs" : [ ],
-    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.interface.*.if_errors.* AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_10_8')" ],
-    "allPlots" : [ {
-      "configuration" : {
-        "rollupPolicy" : "DELTA_ROLLUP"
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "errors/sec",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "interface",
-        "query" : "plugin:interface",
-        "type" : "property",
-        "value" : "interface"
-      }, {
-        "NOT" : false,
-        "displayName" : "plugin_instance:e*",
-        "iconClass" : "icon-properties",
-        "property" : "plugin_instance",
-        "propertyValue" : "e*",
-        "query" : "plugin_instance:e*",
-        "type" : "property",
-        "value" : "plugin_instance:e*"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "host",
-        "propertyValue" : "charlie-ubuntu14044",
-        "query" : "host:\"charlie-ubuntu14044\"",
-        "type" : "property",
-        "value" : "host:\"charlie-ubuntu14044\""
-      } ],
-      "seriesData" : {
-        "metric" : "if_errors.rx"
-      },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "rollupPolicy" : "DELTA_ROLLUP"
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "if_errors.tx",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "interface",
-        "query" : "plugin:interface",
-        "type" : "property",
-        "value" : "interface"
-      }, {
-        "NOT" : false,
-        "displayName" : "plugin_instance:e*",
-        "iconClass" : "icon-properties",
-        "property" : "plugin_instance",
-        "propertyValue" : "e*",
-        "query" : "plugin_instance:e*",
-        "type" : "property",
-        "value" : "plugin_instance:e*"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "host",
-        "propertyValue" : "charlie-ubuntu14044",
-        "query" : "host:\"charlie-ubuntu14044\"",
-        "type" : "property",
-        "value" : "host:\"charlie-ubuntu14044\""
-      } ],
-      "seriesData" : {
-        "metric" : "if_errors.tx"
-      },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "colorOverride" : "#b04600",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "name" : "New Aggregation",
-        "showMe" : false
-      } ],
-      "expressionText" : "A + B",
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "interface errors/sec",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "host",
-        "propertyValue" : "charlie-ubuntu14044",
-        "query" : "host:\"charlie-ubuntu14044\"",
-        "type" : "property",
-        "value" : "host:\"charlie-ubuntu14044\""
-      } ],
-      "seriesData" : { },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 3,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 4,
-      "valid" : false,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : true,
-      "range" : -7200000,
-      "rangeEnd" : 0,
-      "sortPreference" : "",
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "interface errors - RED",
-        "max" : null,
-        "min" : 0,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      }, {
-        "label" : "retransmits - BLUE",
-        "max" : null,
-        "min" : 0,
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "title" : {
-          "text" : ""
-        }
-      } ]
-    },
-    "currentUniqueKey" : 6,
-    "relatedDetectors" : [ ],
     "revisionNumber" : 21,
     "sf_detectorDecorators" : [ ],
     "uiHelperValue" : "##CHARTID##_21"
   }
 }, {
-  "marshallId" : 13,
+  "marshallId" : 5,
   "marshallMemberOf" : [ 3 ],
   "sf_chart" : "Memory",
   "sf_chartIndex" : 4,
@@ -1860,7 +732,490 @@
     "uiHelperValue" : "##CHARTID##_21"
   }
 }, {
-  "marshallId" : 14,
+  "marshallId" : 6,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Memory Used %",
+  "sf_chartIndex" : 1459445051615,
+  "sf_description" : "",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_17=id(report=1);find(query='(sf_metric:memory.utilization AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:signalfx\\\\-metadata))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_17 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.free AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3=id", "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.used AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK=[?B,?A,!OUT]{?B  /  (?A  +  ?B)  *  100->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('sf_source')->groupby('aws_Name')->stats:!mean->_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_2_3');_SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3->?B:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK;_SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "colorOverride" : "#05ce00",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "free",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "type" : "property",
+        "value" : "integration-test-zookeeper-3.4.6-0"
+      }, {
+        "NOT" : false,
+        "displayName" : "signalfx-metadata",
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "signalfx-metadata",
+        "query" : "plugin:\"signalfx-metadata\"",
+        "type" : "property",
+        "value" : "signalfx-metadata"
+      } ],
+      "seriesData" : {
+        "metric" : "memory.utilization",
+        "regExStyle" : null
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "single",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "disableThrottle" : false,
+      "maxDecimalPlaces" : 3,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "-value",
+      "stackedChart" : true,
+      "updateInterval" : "",
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "%",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 9,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 17,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_17"
+  }
+}, {
+  "marshallId" : 7,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "CPU %",
+  "sf_chartIndex" : 1,
+  "sf_description" : "",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);find(query='(sf_metric:cpu.utilization AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:signalfx\\\\-metadata))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_18 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.aggregation.cpu-average.cpu.idle AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('aws_Name')->_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_0_5');_SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "CPU utilization (%)",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "type" : "property",
+        "value" : "integration-test-zookeeper-3.4.6-0"
+      }, {
+        "NOT" : false,
+        "displayName" : "signalfx-metadata",
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "signalfx-metadata",
+        "query" : "plugin:\"signalfx-metadata\"",
+        "type" : "property",
+        "value" : "signalfx-metadata"
+      } ],
+      "seriesData" : {
+        "metric" : "cpu.utilization",
+        "regExStyle" : null
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "%",
+        "max" : 110,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 7,
+    "revisionNumber" : 18,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_18"
+  }
+}, {
+  "marshallId" : 8,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Disk I/O",
+  "sf_chartIndex" : 5,
+  "sf_description" : "operations/sec",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_18=id(report=1);A => find(query='(sf_metric:disk_ops.read AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:disk) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_18 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');C => find(query='(sf_metric:disk_ops.write AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:disk) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_18 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.disk.*disk_ops.read AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_6_1_7=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_6_1_7',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_6_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_6_7')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "read ops/sec",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "disk",
+        "query" : "plugin:disk",
+        "type" : "property",
+        "value" : "disk"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "type" : "property",
+        "value" : "integration-test-zookeeper-3.4.6-0"
+      } ],
+      "seriesData" : {
+        "metric" : "disk_ops.read"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "write ops/sec",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "disk",
+        "query" : "plugin:disk",
+        "type" : "property",
+        "value" : "disk"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "type" : "property",
+        "value" : "integration-test-zookeeper-3.4.6-0"
+      } ],
+      "seriesData" : {
+        "metric" : "disk_ops.write"
+      },
+      "sf_programText" : "find(query='(sf_metric:disk_ops.read AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_CGraATNAgAA_3_10=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGraATNAgAA_3_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGraATNAgAA_10')",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 1
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "valid" : false,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "read ops - RED",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "label" : "write ops - BLUE",
+        "max" : null,
+        "min" : 0,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
+      } ]
+    },
+    "currentUniqueKey" : 5,
+    "revisionNumber" : 18,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_18"
+  }
+}, {
+  "marshallId" : 9,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Disk Free %",
+  "sf_chartIndex" : 1433463909939,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_8_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};find(query='(sf_metric:disk.utilization AND _missing_:sf_programId) AND ((plugin:signalfx\\\\-metadata) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_8;_SF_PLOT_KEY_##CHARTID##_3_8_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_8->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8');_SF_PLOT_KEY_##CHARTID##_1_8->?A:_SF_PLOT_KEY_##CHARTID##_3_8_MACROBLOCK",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlotConstructs" : [ ],
+    "allPlots" : [ {
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "used bytes",
+      "queryItems" : [ {
+        "NOT" : false,
+        "displayName" : "signalfx-metadata",
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "signalfx-metadata",
+        "query" : "plugin:\"signalfx-metadata\"",
+        "type" : "property",
+        "value" : "signalfx-metadata"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "type" : "property",
+        "value" : "integration-test-zookeeper-3.4.6-0"
+      } ],
+      "seriesData" : {
+        "metric" : "disk.utilization",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "expressionText" : "100 - A",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 2,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "valid" : false,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "list",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "maxDecimalPlaces" : 3,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "+value",
+      "stackedChart" : true,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 6,
+    "revisionNumber" : 8,
+    "uiHelperValue" : "##CHARTID##_8"
+  }
+}, {
+  "marshallId" : 10,
   "marshallMemberOf" : [ 3 ],
   "sf_chart" : "Total Network bits/sec",
   "sf_chartIndex" : 1459445812323,
@@ -2082,7 +1437,507 @@
     "uiHelperValue" : "##CHARTID##_28"
   }
 }, {
-  "marshallId" : 15,
+  "marshallId" : 11,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Load Average",
+  "sf_chartIndex" : 2,
+  "sf_description" : "",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_14=id(report=1);A => find(query='(sf_metric:load.shortterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:load) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');B => find(query='(sf_metric:load.midterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:load) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');C => find(query='(sf_metric:load.longterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:load) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.load.load.shortterm AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_1_5')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "name" : "New Aggregation",
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "01-min",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "load",
+        "query" : "plugin:load",
+        "type" : "property",
+        "value" : "load"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "type" : "property",
+        "value" : "integration-test-zookeeper-3.4.6-0"
+      } ],
+      "seriesData" : {
+        "metric" : "load.shortterm"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "name" : "New Aggregation",
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "05-min",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "load",
+        "query" : "plugin:load",
+        "type" : "property",
+        "value" : "load"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "type" : "property",
+        "value" : "integration-test-zookeeper-3.4.6-0"
+      } ],
+      "seriesData" : {
+        "metric" : "load.midterm"
+      },
+      "sf_programText" : "find(query='(sf_metric:load.shortterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_CGraATAAcAA_2_10=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGraATAAcAA_2_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGraATAAcAA_10')",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "name" : "New Aggregation",
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "15-min",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "load",
+        "query" : "plugin:load",
+        "type" : "property",
+        "value" : "load"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "type" : "property",
+        "value" : "integration-test-zookeeper-3.4.6-0"
+      } ],
+      "seriesData" : {
+        "metric" : "load.longterm"
+      },
+      "sf_programText" : "find(query='(sf_metric:load.shortterm AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_CGraATAAcAA_3_10=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGraATAAcAA_3_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGraATAAcAA_10')",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "valid" : false,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "list",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "maxDecimalPlaces" : 3,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "+sf_metric",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 5,
+    "revisionNumber" : 14,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_14"
+  }
+}, {
+  "marshallId" : 12,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "CPU Used %",
+  "sf_chartIndex" : 1459444857291,
+  "sf_description" : "",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_19=id(report=1);find(query='(sf_metric:cpu.utilization AND _missing_:sf_programId) AND ((host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0) AND (plugin:signalfx\\\\-metadata))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_19 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.aggregation.cpu-average.cpu.idle AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('aws_Name')->_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_0_5');_SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "cpu.utilization",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "type" : "property",
+        "value" : "integration-test-zookeeper-3.4.6-0"
+      }, {
+        "NOT" : false,
+        "displayName" : "signalfx-metadata",
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "signalfx-metadata",
+        "query" : "plugin:\"signalfx-metadata\"",
+        "type" : "property",
+        "value" : "signalfx-metadata"
+      } ],
+      "seriesData" : {
+        "metric" : "cpu.utilization",
+        "regExStyle" : null
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "single",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "maxDecimalPlaces" : 3,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "%",
+        "max" : 110,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 7,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 19,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_19"
+  }
+}, {
+  "marshallId" : 13,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Network Errors",
+  "sf_chartIndex" : 1465337015263,
+  "sf_description" : "errors/sec",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK=[?A,?B,!OUT]{?A  +  ?B->!OUT};find(query='(sf_metric:if_errors.rx AND _missing_:sf_programId) AND ((plugin:interface) AND (plugin_instance:e*) AND (host:charlie\\\\-ubuntu14044))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> split -> _SF_PLOT_KEY_##CHARTID##_1_21;find(query='(sf_metric:if_errors.tx AND _missing_:sf_programId) AND ((plugin:interface) AND (plugin_instance:e*) AND (host:charlie\\\\-ubuntu14044))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> split -> _SF_PLOT_KEY_##CHARTID##_2_21;_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK:!OUT->groupby()->stats:!sum->_SF_PLOT_KEY_##CHARTID##_3_21->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_1_21->?A:_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_21->?B:_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.interface.*.if_errors.* AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_10_8')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : "DELTA_ROLLUP"
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "errors/sec",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "interface",
+        "query" : "plugin:interface",
+        "type" : "property",
+        "value" : "interface"
+      }, {
+        "NOT" : false,
+        "displayName" : "plugin_instance:e*",
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "e*",
+        "query" : "plugin_instance:e*",
+        "type" : "property",
+        "value" : "plugin_instance:e*"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "charlie-ubuntu14044",
+        "query" : "host:\"charlie-ubuntu14044\"",
+        "type" : "property",
+        "value" : "host:\"charlie-ubuntu14044\""
+      } ],
+      "seriesData" : {
+        "metric" : "if_errors.rx"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : "DELTA_ROLLUP"
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "if_errors.tx",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "interface",
+        "query" : "plugin:interface",
+        "type" : "property",
+        "value" : "interface"
+      }, {
+        "NOT" : false,
+        "displayName" : "plugin_instance:e*",
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "e*",
+        "query" : "plugin_instance:e*",
+        "type" : "property",
+        "value" : "plugin_instance:e*"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "charlie-ubuntu14044",
+        "query" : "host:\"charlie-ubuntu14044\"",
+        "type" : "property",
+        "value" : "host:\"charlie-ubuntu14044\""
+      } ],
+      "seriesData" : {
+        "metric" : "if_errors.tx"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "name" : "New Aggregation",
+        "showMe" : false
+      } ],
+      "expressionText" : "A + B",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "interface errors/sec",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "charlie-ubuntu14044",
+        "query" : "host:\"charlie-ubuntu14044\"",
+        "type" : "property",
+        "value" : "host:\"charlie-ubuntu14044\""
+      } ],
+      "seriesData" : { },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "valid" : false,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "interface errors - RED",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "label" : "retransmits - BLUE",
+        "max" : null,
+        "min" : 0,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
+      } ]
+    },
+    "currentUniqueKey" : 6,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 21,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_21"
+  }
+}, {
+  "marshallId" : 14,
   "marshallMemberOf" : [ 3 ],
   "sf_chart" : "Disk Used %",
   "sf_chartIndex" : 1459445557108,
@@ -2203,6 +2058,158 @@
     "relatedDetectors" : [ ],
     "revisionNumber" : 13,
     "uiHelperValue" : "##CHARTID##_13"
+  }
+}, {
+  "marshallId" : 15,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Memory Paging",
+  "sf_chartIndex" : 3,
+  "sf_description" : "page swaps/sec",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_14=id(report=1);find(query='(sf_metric:vmpage_io.swap.in AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:vmem) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');find(query='(sf_metric:vmpage_io.swap.out AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:vmem) AND (host:integration\\\\-test\\\\-zookeeper\\\\-3.4.6\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.vmem.vmpage_io.swap.in AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_3_4')", "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.vmem.vmpage_io.swap.out AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_3_4')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "DELTA_ROLLUP"
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "swapped in",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "vmem",
+        "query" : "plugin:vmem",
+        "type" : "property",
+        "value" : "vmem"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "type" : "property",
+        "value" : "integration-test-zookeeper-3.4.6-0"
+      } ],
+      "seriesData" : {
+        "metric" : "vmpage_io.swap.in"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "DELTA_ROLLUP"
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "swapped out",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "vmem",
+        "query" : "plugin:vmem",
+        "type" : "property",
+        "value" : "vmem"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-zookeeper-3.4.6-0",
+        "query" : "host:\"integration-test-zookeeper-3.4.6-0\"",
+        "type" : "property",
+        "value" : "integration-test-zookeeper-3.4.6-0"
+      } ],
+      "seriesData" : {
+        "metric" : "vmpage_io.swap.out"
+      },
+      "sf_programText" : "find(refresh=300000,query='sf_metric:collectd.vmem.vmpage_io.swap.in AND sf_organizationID:BqDQY5OAAAA AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_BwzVGs0AEAA_2_2=id -> publish(defaultSource='_SF_PLOT_KEY_BwzVGs0AEAA_2_2',metric='_SF_PLOT_KEY_BwzVGs0AEAA_2_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='BwzVGs0AEAA_2')",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 1
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "query" : "aws_service:quantizer",
+        "type" : "property",
+        "value" : "Aws_service:quantizer"
+      } ],
+      "seriesData" : { },
+      "sf_programText" : "",
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "valid" : false,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "maxDecimalPlaces" : 3,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : false,
+      "updateInterval" : "",
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "swapped in - RED",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "label" : "swapped out - BLUE",
+        "max" : null,
+        "min" : 0,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
+      } ]
+    },
+    "currentUniqueKey" : 4,
+    "revisionNumber" : 14,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_14"
   }
 }, {
   "marshallId" : 16,
@@ -2350,1028 +2357,6 @@
   }
 }, {
   "marshallId" : 17,
-  "marshallMemberOf" : [ 16 ],
-  "sf_chart" : "Total Network Errors",
-  "sf_chartIndex" : 1465340609155,
-  "sf_description" : "errors/sec",
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 1000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_23=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_23=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_23=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_23_MACROBLOCK=[?A,?B,!OUT]{?A  +  ?B->!OUT};find(query='(sf_metric:if_errors.rx AND _missing_:sf_programId) AND ((plugin:interface) AND (plugin_instance:e*))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_23;find(query='(sf_metric:if_errors.tx AND _missing_:sf_programId) AND ((plugin:interface) AND (plugin_instance:e*))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_23;_SF_PLOT_KEY_##CHARTID##_3_23_MACROBLOCK:!OUT->groupby()->stats:!sum->_SF_PLOT_KEY_##CHARTID##_3_23->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');_SF_PLOT_KEY_##CHARTID##_1_23->?A:_SF_PLOT_KEY_##CHARTID##_3_23_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_23->?B:_SF_PLOT_KEY_##CHARTID##_3_23_MACROBLOCK",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allDetectorDecorators" : [ ],
-    "allPlotConstructs" : [ ],
-    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.interface.*.if_errors.* AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_10_8')" ],
-    "allPlots" : [ {
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "errors/sec",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "interface",
-        "query" : "plugin:interface",
-        "type" : "property",
-        "value" : "interface"
-      }, {
-        "NOT" : false,
-        "displayName" : "plugin_instance:e*",
-        "iconClass" : "icon-properties",
-        "property" : "plugin_instance",
-        "propertyValue" : "e*",
-        "query" : "plugin_instance:e*",
-        "type" : "property",
-        "value" : "plugin_instance:e*"
-      } ],
-      "seriesData" : {
-        "metric" : "if_errors.rx"
-      },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "if_errors.tx",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "interface",
-        "query" : "plugin:interface",
-        "type" : "property",
-        "value" : "interface"
-      }, {
-        "NOT" : false,
-        "displayName" : "plugin_instance:e*",
-        "iconClass" : "icon-properties",
-        "property" : "plugin_instance",
-        "propertyValue" : "e*",
-        "query" : "plugin_instance:e*",
-        "type" : "property",
-        "value" : "plugin_instance:e*"
-      } ],
-      "seriesData" : {
-        "metric" : "if_errors.tx"
-      },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "colorOverride" : "#b04600",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "name" : "New Aggregation",
-        "showMe" : false
-      } ],
-      "expressionText" : "A + B",
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "interface errors / sec",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 3,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 4,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : true,
-      "disableThrottle" : false,
-      "forcedResolution" : "0",
-      "range" : -7200000,
-      "rangeEnd" : 0,
-      "sortPreference" : "",
-      "stackedChart" : false,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "interface errors - RED",
-        "max" : null,
-        "min" : 0,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      }, {
-        "label" : "retransmits - BLUE",
-        "max" : null,
-        "min" : null,
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "title" : {
-          "text" : ""
-        }
-      } ]
-    },
-    "currentUniqueKey" : 7,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 23,
-    "sf_detectorDecorators" : [ ],
-    "uiHelperValue" : "##CHARTID##_23"
-  }
-}, {
-  "marshallId" : 18,
-  "marshallMemberOf" : [ 16 ],
-  "sf_chart" : "Top 5-min Load Avg",
-  "sf_chartIndex" : 2,
-  "sf_description" : "",
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 10000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);find(query='(sf_metric:load.midterm AND _missing_:sf_programId) AND ((plugin:load))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> window(1m) -> stats:!mean -> groupby('host') -> stats:!mean -> groupby() -> groupby() -> select(count=10):!top -> split -> _SF_PLOT_KEY_##CHARTID##_1_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allDetectorDecorators" : [ ],
-    "allPlotConstructs" : [ ],
-    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.load.load.shortterm AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_1_5')" ],
-    "allPlots" : [ {
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "amount" : 1,
-            "transformTimeRange" : "1m",
-            "unit" : "m"
-          },
-          "type" : "transformation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "MEAN"
-        },
-        "showMe" : false
-      }, {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "host"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "MEAN"
-        },
-        "name" : "New Aggregation",
-        "showMe" : false
-      }, {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "count" : 10
-          },
-          "type" : "TOPN"
-        },
-        "showMe" : false
-      } ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "load",
-        "query" : "plugin:load",
-        "type" : "property",
-        "value" : "load"
-      } ],
-      "seriesData" : {
-        "metric" : "load.midterm"
-      },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ {
-        "iconClass" : "sf-icon-property",
-        "query" : "aws_service:quantizer",
-        "type" : "property",
-        "value" : "Aws_service:quantizer"
-      } ],
-      "seriesData" : { },
-      "sf_programText" : "",
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "valid" : false,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "list",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "disableThrottle" : false,
-      "forcedResolution" : "0",
-      "maxDecimalPlaces" : 3,
-      "range" : -7200000,
-      "rangeEnd" : 0,
-      "sortPreference" : "-value",
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "max" : null,
-        "min" : 0,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 3,
-    "revisionNumber" : 13,
-    "sf_detectorDecorators" : [ ],
-    "uiHelperValue" : "##CHARTID##_13"
-  }
-}, {
-  "marshallId" : 19,
-  "marshallMemberOf" : [ 16 ],
-  "sf_chart" : "Top CPU %",
-  "sf_chartIndex" : 1433981315431,
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 10000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_19=id(report=1);find(query='(sf_metric:cpu.utilization AND _missing_:sf_programId) AND ((plugin:signalfx\\\\-metadata))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!mean -> window(1m) -> stats:!mean -> groupby() -> groupby() -> select(count=10):!top -> split -> _SF_PLOT_KEY_##CHARTID##_1_19 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19')",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allDetectorDecorators" : [ ],
-    "allPlotConstructs" : [ ],
-    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.aggregation.cpu-average.cpu.idle AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('aws_Name')->_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_0_5');_SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK" ],
-    "allPlots" : [ {
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "host"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "MEAN"
-        },
-        "name" : "New Aggregation",
-        "showMe" : false
-      }, {
-        "direction" : {
-          "options" : {
-            "amount" : 1,
-            "transformTimeRange" : "1m",
-            "unit" : "m"
-          },
-          "type" : "transformation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "MEAN"
-        },
-        "name" : "New Transform",
-        "showMe" : false
-      }, {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "count" : 10
-          },
-          "type" : "TOPN"
-        },
-        "showMe" : false
-      } ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "",
-      "queryItems" : [ {
-        "NOT" : false,
-        "displayName" : "signalfx-metadata",
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "signalfx-metadata",
-        "query" : "plugin:\"signalfx-metadata\"",
-        "type" : "property",
-        "value" : "signalfx-metadata"
-      } ],
-      "seriesData" : {
-        "metric" : "cpu.utilization",
-        "regExStyle" : null
-      },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "list",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "disableThrottle" : false,
-      "forcedResolution" : "0",
-      "hideDimensionsInList" : false,
-      "maxDecimalPlaces" : 3,
-      "range" : -7200000,
-      "rangeEnd" : 0,
-      "sortPreference" : "-value",
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "max" : 120,
-        "min" : 0,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 7,
-    "revisionNumber" : 19,
-    "sf_detectorDecorators" : [ ],
-    "uiHelperValue" : "##CHARTID##_19"
-  }
-}, {
-  "marshallId" : 20,
-  "marshallMemberOf" : [ 16 ],
-  "sf_chart" : "Top Mem Page Swaps/sec",
-  "sf_chartIndex" : 3,
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 10000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_12_MACROBLOCK=[?A,?B,!OUT]{?A + ?B->!OUT};find(query='(sf_metric:vmpage_io.swap.in AND _missing_:sf_programId) AND ((plugin:vmem))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_12;find(query='(sf_metric:vmpage_io.swap.out AND _missing_:sf_programId) AND ((plugin:vmem))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_12;_SF_PLOT_KEY_##CHARTID##_3_12_MACROBLOCK:!OUT->groupby('host')->stats:!mean->groupby()->groupby()->select(count=10):!top->split->_SF_PLOT_KEY_##CHARTID##_3_12->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');_SF_PLOT_KEY_##CHARTID##_1_12->?A:_SF_PLOT_KEY_##CHARTID##_3_12_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_12->?B:_SF_PLOT_KEY_##CHARTID##_3_12_MACROBLOCK",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allDetectorDecorators" : [ ],
-    "allPlotConstructs" : [ ],
-    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.vmem.vmpage_io.swap.in AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_3_4')", "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.vmem.vmpage_io.swap.out AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_3_4')" ],
-    "allPlots" : [ {
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "pages swapped in/sec",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "vmem",
-        "query" : "plugin:vmem",
-        "type" : "property",
-        "value" : "vmem"
-      } ],
-      "seriesData" : {
-        "metric" : "vmpage_io.swap.in"
-      },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "pages swapped out/sec",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "vmem",
-        "query" : "plugin:vmem",
-        "type" : "property",
-        "value" : "vmem"
-      } ],
-      "seriesData" : {
-        "metric" : "vmpage_io.swap.out"
-      },
-      "sf_programText" : "find(refresh=300000,query='sf_metric:collectd.vmem.vmpage_io.swap.in AND sf_organizationID:BqDQY5OAAAA AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_BwzVGs0AEAA_2_2=id -> publish(defaultSource='_SF_PLOT_KEY_BwzVGs0AEAA_2_2',metric='_SF_PLOT_KEY_BwzVGs0AEAA_2_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='BwzVGs0AEAA_2')",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "valid" : false,
-      "yAxisIndex" : 1
-    }, {
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "host"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "MEAN"
-        },
-        "name" : "New Aggregation",
-        "showMe" : false
-      }, {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "count" : 10
-          },
-          "type" : "TOPN"
-        },
-        "name" : "New Aggregation",
-        "showMe" : false
-      } ],
-      "expressionText" : "A+B",
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "",
-      "queryItems" : [ {
-        "iconClass" : "sf-icon-property",
-        "query" : "aws_service:quantizer",
-        "type" : "property",
-        "value" : "Aws_service:quantizer"
-      } ],
-      "seriesData" : { },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 3,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 4,
-      "valid" : false,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "list",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "range" : -7200000,
-      "rangeEnd" : 0,
-      "sortPreference" : "-value",
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      }, {
-        "max" : null,
-        "min" : null,
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "title" : {
-          "text" : ""
-        }
-      } ]
-    },
-    "currentUniqueKey" : 5,
-    "revisionNumber" : 12,
-    "sf_detectorDecorators" : [ ],
-    "uiHelperValue" : "##CHARTID##_12"
-  }
-}, {
-  "marshallId" : 21,
-  "marshallMemberOf" : [ 16 ],
-  "sf_chart" : "CPU %",
-  "sf_chartIndex" : 1,
-  "sf_description" : "percentile distribution",
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 1000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_26_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_3_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_26_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_4_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_26_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_5_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_6_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_26_MACROBLOCK=[?A,!OUT]{?A->!OUT};find(query='(sf_metric:cpu.utilization AND _missing_:sf_programId) AND ((plugin:signalfx\\\\-metadata))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_26;_SF_PLOT_KEY_##CHARTID##_2_26_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_2_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_2_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_1_26->?A:_SF_PLOT_KEY_##CHARTID##_2_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_26_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_3_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_1_26->?A:_SF_PLOT_KEY_##CHARTID##_3_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_26_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_4_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_1_26->?A:_SF_PLOT_KEY_##CHARTID##_4_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_5_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_1_26->?A:_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_26_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_6_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_1_26->?A:_SF_PLOT_KEY_##CHARTID##_6_26_MACROBLOCK",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allDetectorDecorators" : [ ],
-    "allPlotConstructs" : [ ],
-    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.aggregation.cpu-average.cpu.idle AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('aws_Name')->_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_0_5');_SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK" ],
-    "allPlots" : [ {
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "host"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "MEAN"
-        },
-        "name" : "New Aggregation",
-        "showMe" : false
-      } ],
-      "focusNext" : false,
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "cpu.utilization - Mean by host",
-      "queryItems" : [ {
-        "NOT" : false,
-        "displayName" : "signalfx-metadata",
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "signalfx-metadata",
-        "query" : "plugin:\"signalfx-metadata\"",
-        "type" : "property",
-        "value" : "signalfx-metadata"
-      } ],
-      "seriesData" : {
-        "metric" : "cpu.utilization",
-        "regExStyle" : null
-      },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#bd468d",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "MAX"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "A",
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "cpu %",
-      "queryItems" : [ {
-        "iconClass" : "sf-icon-property",
-        "query" : "aws_service:quantizer",
-        "type" : "property",
-        "value" : "Aws_service:quantizer"
-      } ],
-      "seriesData" : { },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 2,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "colorOverride" : "#05ce00",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "visualization" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "MIN"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "A",
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "min",
-      "queryItems" : [ {
-        "iconClass" : "sf-icon-property",
-        "query" : "aws_service:quantizer",
-        "type" : "property",
-        "value" : "Aws_service:quantizer"
-      } ],
-      "seriesData" : { },
-      "sf_programText" : "_SF_PLOT_KEY_CGrk08NAYAA_3_15_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_CGrk08NAYAA_3_15_MACROBLOCK:!OUT->_SF_PLOT_KEY_CGrk08NAYAA_3_15=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08NAYAA_3_15',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08NAYAA_15');_SF_PLOT_KEY_CGrk08NAYAA_1_15->?A:_SF_PLOT_KEY_CGrk08NAYAA_3_15_MACROBLOCK",
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 3,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "colorOverride" : "#00b9ff",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "visualization" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "percentile" : 10
-          },
-          "type" : "PERCENTILE"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "A",
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "p10",
-      "queryItems" : [ {
-        "iconClass" : "sf-icon-property",
-        "query" : "aws_service:quantizer",
-        "type" : "property",
-        "value" : "Aws_service:quantizer"
-      } ],
-      "seriesData" : { },
-      "sf_programText" : "_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_CGrk08NAYAA_4_19=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08NAYAA_4_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08NAYAA_19');_SF_PLOT_KEY_CGrk08NAYAA_3_19->?C:_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK",
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 4,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "colorOverride" : "#e5b312",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "visualization" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "percentile" : 50
-          },
-          "type" : "PERCENTILE"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "A",
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "median",
-      "queryItems" : [ {
-        "iconClass" : "sf-icon-property",
-        "query" : "aws_service:quantizer",
-        "type" : "property",
-        "value" : "Aws_service:quantizer"
-      } ],
-      "seriesData" : { },
-      "sf_programText" : "_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_CGrk08NAYAA_4_19=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08NAYAA_4_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08NAYAA_19');_SF_PLOT_KEY_CGrk08NAYAA_3_19->?C:_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK",
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 5,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "colorOverride" : "#f47e00",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "visualization" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "percentile" : 90
-          },
-          "type" : "PERCENTILE"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "A",
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "p90",
-      "queryItems" : [ {
-        "iconClass" : "sf-icon-property",
-        "query" : "aws_service:quantizer",
-        "type" : "property",
-        "value" : "Aws_service:quantizer"
-      } ],
-      "seriesData" : { },
-      "sf_programText" : "_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_CGrk08NAYAA_4_19=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08NAYAA_4_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08NAYAA_19');_SF_PLOT_KEY_CGrk08NAYAA_3_19->?C:_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK",
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 6,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 7,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "area",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "disableThrottle" : false,
-      "forcedResolution" : "0",
-      "range" : -7200000,
-      "rangeEnd" : 0,
-      "sortPreference" : "",
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "max" : 110,
-        "min" : 0,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 12,
-    "revisionNumber" : 26,
-    "sf_detectorDecorators" : [ ],
-    "uiHelperValue" : "##CHARTID##_26"
-  }
-}, {
-  "marshallId" : 22,
-  "marshallMemberOf" : [ 16 ],
-  "sf_chart" : "# Active Hosts",
-  "sf_chartIndex" : 13,
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 10000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);find(query='(sf_metric:memory.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allDetectorDecorators" : [ ],
-    "allPlotConstructs" : [ ],
-    "allPlots" : [ {
-      "configuration" : {
-        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION",
-        "maxExtrapolations" : 5,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "COUNT"
-        },
-        "name" : "New Aggregation",
-        "showMe" : false
-      } ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "cpu.idle - COUNT",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "memory",
-        "query" : "plugin:memory",
-        "type" : "property",
-        "value" : "memory"
-      } ],
-      "seriesData" : {
-        "metric" : "memory.free"
-      },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "sf_programText" : "",
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "valid" : false,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "single",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "disableThrottle" : false,
-      "maxDecimalPlaces" : 4,
-      "range" : -7200000,
-      "rangeEnd" : 0,
-      "sortPreference" : "",
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 4,
-    "revisionNumber" : 13,
-    "uiHelperValue" : "##CHARTID##_13"
-  }
-}, {
-  "marshallId" : 23,
   "marshallMemberOf" : [ 16 ],
   "sf_chart" : "Memory Used %",
   "sf_chartIndex" : 4,
@@ -3632,7 +2617,694 @@
     "uiHelperValue" : "##CHARTID##_18"
   }
 }, {
-  "marshallId" : 24,
+  "marshallId" : 18,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "Top 5-min Load Avg",
+  "sf_chartIndex" : 2,
+  "sf_description" : "",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);find(query='(sf_metric:load.midterm AND _missing_:sf_programId) AND ((plugin:load))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> window(1m) -> stats:!mean -> groupby('host') -> stats:!mean -> groupby() -> groupby() -> select(count=10):!top -> split -> _SF_PLOT_KEY_##CHARTID##_1_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.load.load.shortterm AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_1_5')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "amount" : 1,
+            "transformTimeRange" : "1m",
+            "unit" : "m"
+          },
+          "type" : "transformation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "name" : "New Aggregation",
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "count" : 10
+          },
+          "type" : "TOPN"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "load",
+        "query" : "plugin:load",
+        "type" : "property",
+        "value" : "load"
+      } ],
+      "seriesData" : {
+        "metric" : "load.midterm"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "query" : "aws_service:quantizer",
+        "type" : "property",
+        "value" : "Aws_service:quantizer"
+      } ],
+      "seriesData" : { },
+      "sf_programText" : "",
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "list",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "forcedResolution" : "0",
+      "maxDecimalPlaces" : 3,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "-value",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 3,
+    "revisionNumber" : 13,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_13"
+  }
+}, {
+  "marshallId" : 19,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "# Active Hosts",
+  "sf_chartIndex" : 13,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);find(query='(sf_metric:memory.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memory))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlots" : [ {
+      "configuration" : {
+        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION",
+        "maxExtrapolations" : 5,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "COUNT"
+        },
+        "name" : "New Aggregation",
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "cpu.idle - COUNT",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memory",
+        "query" : "plugin:memory",
+        "type" : "property",
+        "value" : "memory"
+      } ],
+      "seriesData" : {
+        "metric" : "memory.free"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "sf_programText" : "",
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "single",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "maxDecimalPlaces" : 4,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 4,
+    "revisionNumber" : 13,
+    "uiHelperValue" : "##CHARTID##_13"
+  }
+}, {
+  "marshallId" : 20,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "CPU %",
+  "sf_chartIndex" : 1,
+  "sf_description" : "percentile distribution",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_27=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_27=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_27_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_3_27=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_27_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_4_27=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_27_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_5_27=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_27_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_6_27=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_27_MACROBLOCK=[?A,!OUT]{?A->!OUT};find(query='(sf_metric:cpu.utilization AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:signalfx\\\\-metadata))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_27;_SF_PLOT_KEY_##CHARTID##_2_27_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_2_27->groupby() -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_2_27',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_27');_SF_PLOT_KEY_##CHARTID##_1_27->?A:_SF_PLOT_KEY_##CHARTID##_2_27_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_27_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_3_27->groupby() -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_27',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_27');_SF_PLOT_KEY_##CHARTID##_1_27->?A:_SF_PLOT_KEY_##CHARTID##_3_27_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_27_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_4_27->groupby() -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_27',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_27');_SF_PLOT_KEY_##CHARTID##_1_27->?A:_SF_PLOT_KEY_##CHARTID##_4_27_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_27_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_5_27->groupby() -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_27',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_27');_SF_PLOT_KEY_##CHARTID##_1_27->?A:_SF_PLOT_KEY_##CHARTID##_5_27_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_27_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_6_27->groupby() -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_27',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_27');_SF_PLOT_KEY_##CHARTID##_1_27->?A:_SF_PLOT_KEY_##CHARTID##_6_27_MACROBLOCK",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.aggregation.cpu-average.cpu.idle AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('aws_Name')->_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_0_5');_SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "name" : "New Aggregation",
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "cpu.utilization - Mean by host",
+      "queryItems" : [ {
+        "NOT" : false,
+        "displayName" : "signalfx-metadata",
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "signalfx-metadata",
+        "query" : "plugin:\"signalfx-metadata\"",
+        "type" : "property",
+        "value" : "signalfx-metadata"
+      } ],
+      "seriesData" : {
+        "metric" : "cpu.utilization",
+        "regExStyle" : null
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#bd468d",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MAX"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "max",
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "query" : "aws_service:quantizer",
+        "type" : "property",
+        "value" : "Aws_service:quantizer"
+      } ],
+      "seriesData" : { },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 2,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#05ce00",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "visualization" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MIN"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "min",
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "query" : "aws_service:quantizer",
+        "type" : "property",
+        "value" : "Aws_service:quantizer"
+      } ],
+      "seriesData" : { },
+      "sf_programText" : "_SF_PLOT_KEY_CGrk08NAYAA_3_15_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_CGrk08NAYAA_3_15_MACROBLOCK:!OUT->_SF_PLOT_KEY_CGrk08NAYAA_3_15=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08NAYAA_3_15',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08NAYAA_15');_SF_PLOT_KEY_CGrk08NAYAA_1_15->?A:_SF_PLOT_KEY_CGrk08NAYAA_3_15_MACROBLOCK",
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#00b9ff",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "visualization" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "percentile" : 10
+          },
+          "type" : "PERCENTILE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "p10",
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "query" : "aws_service:quantizer",
+        "type" : "property",
+        "value" : "Aws_service:quantizer"
+      } ],
+      "seriesData" : { },
+      "sf_programText" : "_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_CGrk08NAYAA_4_19=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08NAYAA_4_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08NAYAA_19');_SF_PLOT_KEY_CGrk08NAYAA_3_19->?C:_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK",
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 4,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#e5b312",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "visualization" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "percentile" : 50
+          },
+          "type" : "PERCENTILE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "median",
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "query" : "aws_service:quantizer",
+        "type" : "property",
+        "value" : "Aws_service:quantizer"
+      } ],
+      "seriesData" : { },
+      "sf_programText" : "_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_CGrk08NAYAA_4_19=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08NAYAA_4_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08NAYAA_19');_SF_PLOT_KEY_CGrk08NAYAA_3_19->?C:_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK",
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 5,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#f47e00",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "visualization" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "percentile" : 90
+          },
+          "type" : "PERCENTILE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "p90",
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "query" : "aws_service:quantizer",
+        "type" : "property",
+        "value" : "Aws_service:quantizer"
+      } ],
+      "seriesData" : { },
+      "sf_programText" : "_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_CGrk08NAYAA_4_19=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08NAYAA_4_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08NAYAA_19');_SF_PLOT_KEY_CGrk08NAYAA_3_19->?C:_SF_PLOT_KEY_CGrk08NAYAA_4_19_MACROBLOCK",
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 6,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 7,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "legendColumnConfiguration" : null,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : 110,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 12,
+    "revisionNumber" : 27,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_27"
+  }
+}, {
+  "marshallId" : 21,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "Top CPU %",
+  "sf_chartIndex" : 1433981315431,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_19=id(report=1);find(query='(sf_metric:cpu.utilization AND _missing_:sf_programId) AND ((plugin:signalfx\\\\-metadata))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!mean -> window(1m) -> stats:!mean -> groupby() -> groupby() -> select(count=10):!top -> split -> _SF_PLOT_KEY_##CHARTID##_1_19 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.aggregation.cpu-average.cpu.idle AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('aws_Name')->_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_0_5');_SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "name" : "New Aggregation",
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "amount" : 1,
+            "transformTimeRange" : "1m",
+            "unit" : "m"
+          },
+          "type" : "transformation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "name" : "New Transform",
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "count" : 10
+          },
+          "type" : "TOPN"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "",
+      "queryItems" : [ {
+        "NOT" : false,
+        "displayName" : "signalfx-metadata",
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "signalfx-metadata",
+        "query" : "plugin:\"signalfx-metadata\"",
+        "type" : "property",
+        "value" : "signalfx-metadata"
+      } ],
+      "seriesData" : {
+        "metric" : "cpu.utilization",
+        "regExStyle" : null
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "list",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "forcedResolution" : "0",
+      "hideDimensionsInList" : false,
+      "maxDecimalPlaces" : 3,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "-value",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : 120,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 7,
+    "revisionNumber" : 19,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_19"
+  }
+}, {
+  "marshallId" : 22,
   "marshallMemberOf" : [ 16 ],
   "sf_chart" : "Total Memory",
   "sf_chartIndex" : 1433972294516,
@@ -4123,7 +3795,178 @@
     "uiHelperValue" : "##CHARTID##_21"
   }
 }, {
-  "marshallId" : 25,
+  "marshallId" : 23,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "Top Mem Page Swaps/sec",
+  "sf_chartIndex" : 3,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_12_MACROBLOCK=[?A,?B,!OUT]{?A + ?B->!OUT};find(query='(sf_metric:vmpage_io.swap.in AND _missing_:sf_programId) AND ((plugin:vmem))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_12;find(query='(sf_metric:vmpage_io.swap.out AND _missing_:sf_programId) AND ((plugin:vmem))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_12;_SF_PLOT_KEY_##CHARTID##_3_12_MACROBLOCK:!OUT->groupby('host')->stats:!mean->groupby()->groupby()->select(count=10):!top->split->_SF_PLOT_KEY_##CHARTID##_3_12->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');_SF_PLOT_KEY_##CHARTID##_1_12->?A:_SF_PLOT_KEY_##CHARTID##_3_12_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_12->?B:_SF_PLOT_KEY_##CHARTID##_3_12_MACROBLOCK",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.vmem.vmpage_io.swap.in AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_3_4')", "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.vmem.vmpage_io.swap.out AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_3_4')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "pages swapped in/sec",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "vmem",
+        "query" : "plugin:vmem",
+        "type" : "property",
+        "value" : "vmem"
+      } ],
+      "seriesData" : {
+        "metric" : "vmpage_io.swap.in"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "pages swapped out/sec",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "vmem",
+        "query" : "plugin:vmem",
+        "type" : "property",
+        "value" : "vmem"
+      } ],
+      "seriesData" : {
+        "metric" : "vmpage_io.swap.out"
+      },
+      "sf_programText" : "find(refresh=300000,query='sf_metric:collectd.vmem.vmpage_io.swap.in AND sf_organizationID:BqDQY5OAAAA AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_BwzVGs0AEAA_2_2=id -> publish(defaultSource='_SF_PLOT_KEY_BwzVGs0AEAA_2_2',metric='_SF_PLOT_KEY_BwzVGs0AEAA_2_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='BwzVGs0AEAA_2')",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 1
+    }, {
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "name" : "New Aggregation",
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "count" : 10
+          },
+          "type" : "TOPN"
+        },
+        "name" : "New Aggregation",
+        "showMe" : false
+      } ],
+      "expressionText" : "A+B",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "",
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "query" : "aws_service:quantizer",
+        "type" : "property",
+        "value" : "Aws_service:quantizer"
+      } ],
+      "seriesData" : { },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "valid" : false,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "list",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "-value",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
+      } ]
+    },
+    "currentUniqueKey" : 5,
+    "revisionNumber" : 12,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_12"
+  }
+}, {
+  "marshallId" : 24,
   "marshallMemberOf" : [ 16 ],
   "sf_chart" : "Total Disk I/O Ops",
   "sf_chartIndex" : 6,
@@ -4279,6 +4122,221 @@
     "uiHelperValue" : "##CHARTID##_12"
   }
 }, {
+  "marshallId" : 25,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "Total Network I/O",
+  "sf_chartIndex" : 1433978780955,
+  "sf_description" : "bits/sec",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_15=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_15=id(report=1);find(query='(sf_metric:if_octets.tx AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:interface) AND (plugin_instance:e*))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_15 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_15',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_15');find(query='(sf_metric:if_octets.rx AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:interface) AND (plugin_instance:e*))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_2_15 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_15',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_15')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.disk.*disk_ops.write AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_5_6')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#0077c2",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "name" : "New Aggregation",
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "scaleAmount" : 8
+          },
+          "type" : "SCALE"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "transmitted bits/sec",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "interface",
+        "query" : "plugin:interface",
+        "type" : "property",
+        "value" : "interface"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "e*",
+        "query" : "plugin_instance:e*",
+        "type" : "property",
+        "value" : "plugin_instance:e*"
+      } ],
+      "seriesData" : {
+        "metric" : "if_octets.tx"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 1
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "name" : "New Aggregation",
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "scaleAmount" : 8
+          },
+          "type" : "SCALE"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "received bits/sec",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "interface",
+        "query" : "plugin:interface",
+        "type" : "property",
+        "value" : "interface"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "e*",
+        "query" : "plugin_instance:e*",
+        "type" : "property",
+        "value" : "plugin_instance:e*"
+      } ],
+      "seriesData" : {
+        "metric" : "if_octets.rx"
+      },
+      "sf_programText" : "find(query='(sf_metric:disk_ops.write AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_CGrk08YAgAA_3_9=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGrk08YAgAA_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08YAgAA_9')",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "valid" : false,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "legendColumnConfiguration" : null,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "showDots" : false,
+      "sortPreference" : "",
+      "updateInterval" : "",
+      "useKMG2" : true,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "received - RED",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "label" : "transmitted - BLUE",
+        "max" : null,
+        "min" : 0,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
+      } ]
+    },
+    "currentUniqueKey" : 5,
+    "revisionNumber" : 15,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_15"
+  }
+}, {
   "marshallId" : 26,
   "marshallMemberOf" : [ 16 ],
   "sf_chart" : "Total Disk Space",
@@ -4423,60 +4481,26 @@
 }, {
   "marshallId" : 27,
   "marshallMemberOf" : [ 16 ],
-  "sf_chart" : "Total Network I/O",
-  "sf_chartIndex" : 1433978780955,
-  "sf_description" : "bits/sec",
+  "sf_chart" : "Total Network Errors",
+  "sf_chartIndex" : 1465340609155,
+  "sf_description" : "errors/sec",
   "sf_jobMaxDelay" : 0,
   "sf_jobResolution" : 1000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_14=id(report=1);A => find(query='(sf_metric:if_octets.tx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:e*))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!sum -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');C => find(query='(sf_metric:if_octets.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:interface) AND (plugin_instance:e*))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!sum -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_3_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_23=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_23=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_23=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_23_MACROBLOCK=[?A,?B,!OUT]{?A  +  ?B->!OUT};find(query='(sf_metric:if_errors.rx AND _missing_:sf_programId) AND ((plugin:interface) AND (plugin_instance:e*))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_23;find(query='(sf_metric:if_errors.tx AND _missing_:sf_programId) AND ((plugin:interface) AND (plugin_instance:e*))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_23;_SF_PLOT_KEY_##CHARTID##_3_23_MACROBLOCK:!OUT->groupby()->stats:!sum->_SF_PLOT_KEY_##CHARTID##_3_23->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');_SF_PLOT_KEY_##CHARTID##_1_23->?A:_SF_PLOT_KEY_##CHARTID##_3_23_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_23->?B:_SF_PLOT_KEY_##CHARTID##_3_23_MACROBLOCK",
   "sf_type" : "Chart",
   "sf_uiModel" : {
     "allDetectorDecorators" : [ ],
     "allPlotConstructs" : [ ],
-    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.disk.*disk_ops.write AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_5_6')" ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.interface.*.if_errors.* AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_10_8')" ],
     "allPlots" : [ {
       "configuration" : {
-        "colorOverride" : "#0077c2",
-        "extrapolationPolicy" : "AUTO",
-        "maxExtrapolations" : -1,
         "rollupPolicy" : null
       },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "name" : "New Aggregation",
-        "showMe" : false
-      }, {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "scaleAmount" : 8
-          },
-          "type" : "SCALE"
-        },
-        "showMe" : false
-      } ],
+      "dataManipulations" : [ ],
       "focusNext" : false,
-      "invisible" : false,
+      "invisible" : true,
       "metricDefinition" : { },
-      "name" : "transmitted bits/sec",
+      "name" : "errors/sec",
       "queryItems" : [ {
         "NOT" : false,
         "iconClass" : "icon-properties",
@@ -4487,6 +4511,7 @@
         "value" : "interface"
       }, {
         "NOT" : false,
+        "displayName" : "plugin_instance:e*",
         "iconClass" : "icon-properties",
         "property" : "plugin_instance",
         "propertyValue" : "e*",
@@ -4495,20 +4520,55 @@
         "value" : "plugin_instance:e*"
       } ],
       "seriesData" : {
-        "metric" : "if_octets.tx"
+        "metric" : "if_errors.rx"
       },
       "sf_programText" : "",
       "transient" : false,
       "type" : "plot",
       "uniqueKey" : 1,
       "valid" : false,
-      "yAxisIndex" : 1
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "if_errors.tx",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "interface",
+        "query" : "plugin:interface",
+        "type" : "property",
+        "value" : "interface"
+      }, {
+        "NOT" : false,
+        "displayName" : "plugin_instance:e*",
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "e*",
+        "query" : "plugin_instance:e*",
+        "type" : "property",
+        "value" : "plugin_instance:e*"
+      } ],
+      "seriesData" : {
+        "metric" : "if_errors.tx"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 0
     }, {
       "configuration" : {
         "colorOverride" : "#b04600",
-        "extrapolationPolicy" : "AUTO",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
       },
       "dataManipulations" : [ {
         "direction" : {
@@ -4525,52 +4585,19 @@
         },
         "name" : "New Aggregation",
         "showMe" : false
-      }, {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "scaleAmount" : 8
-          },
-          "type" : "SCALE"
-        },
-        "showMe" : false
       } ],
+      "expressionText" : "A + B",
       "focusNext" : false,
       "invisible" : false,
       "metricDefinition" : { },
-      "name" : "received bits/sec",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "interface",
-        "query" : "plugin:interface",
-        "type" : "property",
-        "value" : "interface"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin_instance",
-        "propertyValue" : "e*",
-        "query" : "plugin_instance:e*",
-        "type" : "property",
-        "value" : "plugin_instance:e*"
-      } ],
-      "seriesData" : {
-        "metric" : "if_octets.rx"
-      },
-      "sf_programText" : "find(query='(sf_metric:disk_ops.write AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_CGrk08YAgAA_3_9=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGrk08YAgAA_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08YAgAA_9')",
+      "name" : "interface errors / sec",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "sf_programText" : "",
       "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "valid" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
       "yAxisIndex" : 0
     }, {
       "dataManipulations" : [ ],
@@ -4582,8 +4609,7 @@
       "seriesData" : { },
       "transient" : true,
       "type" : "plot",
-      "uniqueKey" : 3,
-      "valid" : false,
+      "uniqueKey" : 4,
       "yAxisIndex" : 0
     } ],
     "chartMode" : "graph",
@@ -4591,16 +4617,17 @@
     "chartconfig" : {
       "absoluteEnd" : null,
       "absoluteStart" : null,
-      "colorByMetric" : false,
+      "colorByMetric" : true,
       "disableThrottle" : false,
       "forcedResolution" : "0",
       "range" : -7200000,
       "rangeEnd" : 0,
       "sortPreference" : "",
+      "stackedChart" : false,
       "updateInterval" : "",
       "yAxisConfigurations" : [ {
         "id" : "yAxis0",
-        "label" : "received - RED",
+        "label" : "interface errors - RED",
         "max" : null,
         "min" : 0,
         "name" : "yAxis0",
@@ -4609,9 +4636,9 @@
           "low" : null
         }
       }, {
-        "label" : "transmitted - BLUE",
+        "label" : "retransmits - BLUE",
         "max" : null,
-        "min" : 0,
+        "min" : null,
         "plotlines" : {
           "high" : null,
           "low" : null
@@ -4621,9 +4648,10 @@
         }
       } ]
     },
-    "currentUniqueKey" : 5,
-    "revisionNumber" : 14,
+    "currentUniqueKey" : 7,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 23,
     "sf_detectorDecorators" : [ ],
-    "uiHelperValue" : "##CHARTID##_14"
+    "uiHelperValue" : "##CHARTID##_23"
   }
 } ]

--- a/CollectD/Page_Memcached.json
+++ b/CollectD/Page_Memcached.json
@@ -1,3572 +1,3147 @@
-[
-    {
-        "marshallScope": 3
-    },
-    {
-        "sf_tags": [
-            "inactive"
-        ],
-        "marshallId": 1,
-        "sf_tag": "inactive",
-        "sf_type": "Tag"
-    },
-    {
-        "marshallId": 2,
-        "sf_type": "Service",
-        "sf_description": "Metrics about Memcached.",
-        "sf_service": "Memcached"
-    },
-    {
-        "sf_page": "Memcached",
-        "marshallId": 3,
-        "marshallMemberOf": [
-            1,
-            2
-        ],
-        "sf_type": "Page",
-        "sf_description": "Dashboards about Memcached."
-    },
-    {
-        "marshallId": 4,
-        "sf_uiModel": {
-            "widgets": [
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 0,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1441373050363,
-                        "id": 1
-                    },
-                    "row": 0
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 4,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1441373221856,
-                        "id": 2
-                    },
-                    "row": 0
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 8,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1441391009454,
-                        "id": 3
-                    },
-                    "row": 0
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 8,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1441727951153,
-                        "id": 4
-                    },
-                    "row": 1
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 0,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1441396908169,
-                        "id": 5
-                    },
-                    "row": 1
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 4,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1442273162711,
-                        "id": 6
-                    },
-                    "row": 1
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 4,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1442274349331,
-                        "id": 7
-                    },
-                    "row": 2
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 8,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1441728333222,
-                        "id": 8
-                    },
-                    "row": 2
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 0,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1441728013972,
-                        "id": 9
-                    },
-                    "row": 2
-                }
-            ],
-            "version": 1
+[ {
+  "marshallScope" : 2
+}, {
+  "marshallId" : 1,
+  "sf_description" : "Metrics about Memcached.",
+  "sf_service" : "Memcached",
+  "sf_type" : "Service"
+}, {
+  "marshallId" : 2,
+  "marshallMemberOf" : [ 1 ],
+  "sf_description" : "Dashboards about Memcached.",
+  "sf_page" : "Memcached",
+  "sf_type" : "Page"
+}, {
+  "marshallId" : 3,
+  "marshallMemberOf" : [ 2 ],
+  "sf_dashboard" : "Memcached (a)",
+  "sf_description" : "",
+  "sf_discoveryQuery" : "plugin:memcached",
+  "sf_discoverySelectors" : [ "_exist_:aws_availability_zone", "plugin:memcached", "_exists_:aws_region", "sf_hostHasService:memcached", "_exists_:aws_instance_type" ],
+  "sf_type" : "Dashboard",
+  "sf_uiModel" : {
+    "version" : 1,
+    "widgets" : [ {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 1441223262678,
+        "id" : 1,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 0,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 4,
+      "options" : {
+        "chartIndex" : 1440940336928,
+        "id" : 3,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 0,
+      "sizeX" : 4,
+      "type" : "chart"
+    }, {
+      "col" : 8,
+      "options" : {
+        "chartIndex" : 1441336372648,
+        "id" : 2,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 0,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 1443646401273,
+        "id" : 4,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 1,
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 6,
+      "options" : {
+        "chartIndex" : 1443647088193,
+        "id" : 5,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 1,
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 6,
+      "options" : {
+        "chartIndex" : 1440941199061,
+        "id" : 7,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 2,
+      "type" : "chart"
+    }, {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 1440941141413,
+        "id" : 8,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 2,
+      "type" : "chart"
+    }, {
+      "col" : 8,
+      "options" : {
+        "chartIndex" : 1440941057408,
+        "id" : 9,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 3,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 4,
+      "options" : {
+        "chartIndex" : 1440941786425,
+        "id" : 10,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 3,
+      "sizeX" : 4,
+      "type" : "chart"
+    }, {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 1441289901282,
+        "id" : 11,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 3,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 1481839032004
+      },
+      "row" : 4,
+      "sizeX" : 6,
+      "sizeY" : 1
+    }, {
+      "col" : 6,
+      "options" : {
+        "chartIndex" : 1481839254910
+      },
+      "row" : 4,
+      "sizeX" : 6,
+      "sizeY" : 1
+    } ]
+  }
+}, {
+  "marshallId" : 4,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "% Cache Used",
+  "sf_chartIndex" : 1441289901282,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK=[?B,?A,!OUT]{?B / (?A + ?B)->!OUT};find(query='(sf_metric:df.cache.free AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_9;find(query='(sf_metric:df.cache.used AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_9;_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK:!OUT->{ ?in * 100 -> !out }->groupby()->stats:!mean->_SF_PLOT_KEY_##CHARTID##_3_9->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');_SF_PLOT_KEY_##CHARTID##_2_9->?B:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_9->?A:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "df.cache.free",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : "df.cache.free"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "df.cache.used",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : "df.cache.used"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
         },
-        "sf_discoveryQuery": "plugin:memcached AND _exists_:host",
-        "sf_discoverySelectors": [
-            "_exists_:host"
-        ],
-        "sf_type": "Dashboard",
-        "marshallMemberOf": [
-            3
-        ],
-        "sf_filterAlias" : {
-          "variables" : [
-            {
-              "dimension" : "host",
-              "alias" : "host",
-              "globalScope" : true,
-              "required" : true,
-              "description" : "Memcached server",
-              "restricted" : false,
-              "preferredSuggestions" : []
-            }
-          ]
+        "fn" : {
+          "options" : {
+            "scaleAmount" : 100
+          },
+          "type" : "SCALE"
         },
-        "sf_dashboard": "Memcached"
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "B/(A+B)",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "B/(A+B) - Scale:100 - Mean",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "single",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "forcedResolution" : "0",
+      "maxDecimalPlaces" : 3,
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "",
+        "max" : 100,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
     },
-    {
-        "marshallId": 5,
-        "sf_uiModel": {
-            "chartMode": "single",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "stackedChart": true,
-                "colorByMetric": false,
-                "range": -3600000,
-                "maxDecimalPlaces": 2,
-                "updateInterval": "",
-                "disableThrottle": false,
-                "yAxisConfigurations": [
-                    {
-                        "id": "yAxis0",
-                        "max": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "min": null
-                    }
-                ],
-                "sortPreference": "",
-                "forcedResolution": "0"
-            },
-            "currentUniqueKey": 5,
-            "uiHelperValue": "##CHARTID##_10",
-            "relatedDetectors": [],
-            "allPlots": [
-                {
-                    "metricDefinition": {},
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-memcached-1.4.14-0",
-                            "propertyValue": "integration-test-memcached-1.4.14-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-memcached-1.4.14-0\"",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin:memcached",
-                            "propertyValue": "memcached",
-                            "NOT": false,
-                            "query": "plugin:memcached",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "memcached_items.current",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "memcached_items.current"
-                    }
-                },
-                {
-                    "metricDefinition": {},
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-memcached-1.4.14-0",
-                            "propertyValue": "integration-test-memcached-1.4.14-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-memcached-1.4.14-0\"",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin:memcached",
-                            "propertyValue": "memcached",
-                            "NOT": false,
-                            "query": "plugin:memcached",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "memcached_items.current - Timeshift 1h",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "TIMESHIFT",
-                                "options": {
-                                    "milliseconds": 3600000
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "memcached_items.current"
-                    }
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "A/B-1",
-                    "valid": true,
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "metricDefinition": {},
-                    "type": "ratio",
-                    "expressionText": "A/B-1",
-                    "seriesData": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 4,
-                    "name": "New Plot",
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "metricDefinition": {},
-                    "type": "plot",
-                    "seriesData": {}
-                }
-            ],
-            "chartType": "line",
-            "revisionNumber": 10
+    "currentUniqueKey" : 5,
+    "revisionNumber" : 9,
+    "uiHelperValue" : "##CHARTID##_9"
+  }
+}, {
+  "marshallId" : 5,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Total Connections",
+  "sf_chartIndex" : 1440941786425,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_6=id(report=1);find(query='(sf_metric:memcached_connections.current AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_6 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
         },
-        "sf_description": "",
-        "sf_chartIndex": 1441396908169,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_10_MACROBLOCK=[?A,?B,!OUT]{?A / ?B - 1->!OUT};find(query='(sf_metric:memcached_items.current AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0) AND (plugin:memcached))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_10;find(query='(sf_metric:memcached_items.current AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0) AND (plugin:memcached))') -> fetch(offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_10;_SF_PLOT_KEY_##CHARTID##_3_10_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_10->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');_SF_PLOT_KEY_##CHARTID##_1_10->?A:_SF_PLOT_KEY_##CHARTID##_3_10_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_10->?B:_SF_PLOT_KEY_##CHARTID##_3_10_MACROBLOCK",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_10_MACROBLOCK=[?A,?B,!OUT]{?A / ?B - 1->!OUT};find(query='(sf_metric:memcached_items.current AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0) AND (plugin:memcached))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');find(query='(sf_metric:memcached_items.current AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0) AND (plugin:memcached))') -> fetch(offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');_SF_PLOT_KEY_##CHARTID##_3_10_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_10->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');_SF_PLOT_KEY_##CHARTID##_1_10->?A:_SF_PLOT_KEY_##CHARTID##_3_10_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_10->?B:_SF_PLOT_KEY_##CHARTID##_3_10_MACROBLOCK",
-        "sf_discoveryQuery": "plugin:memcached",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Items 1h Change %",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 10000,
-        "marshallMemberOf": [
-            4
-        ]
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "memcached_connections.current - Sum",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memcached",
+        "query" : "plugin:memcached",
+        "type" : "property",
+        "value" : "memcached"
+      } ],
+      "seriesData" : {
+        "metric" : "memcached_connections.current"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "single",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "forcedResolution" : "0",
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
     },
-    {
-        "marshallId": 6,
-        "sf_uiModel": {
-            "chartMode": "single",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -3600000,
-                "maxDecimalPlaces": 3,
-                "updateInterval": "",
-                "yAxisConfigurations": [
-                    {
-                        "id": "yAxis0",
-                        "max": 100,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "min": 0
-                    }
-                ],
-                "sortPreference": "",
-                "disableThrottle": false
-            },
-            "currentUniqueKey": 5,
-            "uiHelperValue": "##CHARTID##_7",
-            "allPlots": [
-                {
-                    "metricDefinition": {},
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-memcached-1.4.14-0",
-                            "propertyValue": "integration-test-memcached-1.4.14-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-memcached-1.4.14-0\"",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin:memcached",
-                            "propertyValue": "memcached",
-                            "NOT": false,
-                            "query": "plugin:memcached",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "memcached_ops.hits",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "memcached_ops.hits"
-                    }
-                },
-                {
-                    "metricDefinition": {},
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin:memcached",
-                            "propertyValue": "memcached",
-                            "NOT": false,
-                            "query": "plugin:memcached",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "memcached_ops.misses",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "memcached_ops.misses"
-                    }
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin:memcached",
-                            "propertyValue": "memcached",
-                            "NOT": false,
-                            "query": "plugin:memcached",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 3,
-                    "name": "Hit Rate %",
-                    "valid": true,
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SCALE",
-                                "options": {
-                                    "scaleAmount": 100
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "metricDefinition": {},
-                    "type": "ratio",
-                    "expressionText": "A/(A+B)",
-                    "seriesData": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 4,
-                    "name": "New Plot",
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "metricDefinition": {},
-                    "type": "plot",
-                    "seriesData": {}
-                }
-            ],
-            "chartType": "line",
-            "revisionNumber": 7
+    "currentUniqueKey" : 3,
+    "revisionNumber" : 6,
+    "uiHelperValue" : "##CHARTID##_6"
+  }
+}, {
+  "marshallId" : 6,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Hosts Reporting",
+  "sf_chartIndex" : 1441223262678,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);A => find(query='(sf_metric:memcached_connections.current AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch -> groupby('host') -> stats:!sum -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_7 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
         },
-        "sf_chartIndex": 1441373050363,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_7_MACROBLOCK=[?A,?B,!OUT]{?A / (?A + ?B)->!OUT};find(query='(sf_metric:memcached_ops.hits AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0) AND (plugin:memcached))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_7;find(query='(sf_metric:memcached_ops.misses AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_7;_SF_PLOT_KEY_##CHARTID##_3_7_MACROBLOCK:!OUT->{ ?in * 100 -> !out }->_SF_PLOT_KEY_##CHARTID##_3_7->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');_SF_PLOT_KEY_##CHARTID##_1_7->?A:_SF_PLOT_KEY_##CHARTID##_3_7_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_7->?B:_SF_PLOT_KEY_##CHARTID##_3_7_MACROBLOCK",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_7_MACROBLOCK=[?A,?B,!OUT]{?A / (?A + ?B)->!OUT};find(query='(sf_metric:memcached_ops.hits AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0) AND (plugin:memcached))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_7 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');find(query='(sf_metric:memcached_ops.misses AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_7 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');_SF_PLOT_KEY_##CHARTID##_3_7_MACROBLOCK:!OUT->{ ?in * 100 -> !out }->_SF_PLOT_KEY_##CHARTID##_3_7->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');_SF_PLOT_KEY_##CHARTID##_1_7->?A:_SF_PLOT_KEY_##CHARTID##_3_7_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_7->?B:_SF_PLOT_KEY_##CHARTID##_3_7_MACROBLOCK",
-        "sf_discoveryQuery": "plugin:memcached",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Hit Rate %",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 10000,
-        "marshallMemberOf": [
-            4
-        ]
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "COUNT"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "memcached_connections.current - Sum by host - Count",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memcached",
+        "query" : "plugin:memcached",
+        "type" : "property",
+        "value" : "memcached"
+      } ],
+      "seriesData" : {
+        "metric" : "memcached_connections.current"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "single",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
     },
-    {
-        "marshallId": 7,
-        "sf_uiModel": {
-            "chartMode": "single",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -3600000,
-                "maxDecimalPlaces": 3,
-                "updateInterval": "",
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": 0,
-                        "max": 100,
-                        "label": "%",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": "",
-                "disableThrottle": false
-            },
-            "currentUniqueKey": 5,
-            "uiHelperValue": "##CHARTID##_9",
-            "relatedDetectors": [],
-            "allPlots": [
-                {
-                    "metricDefinition": {},
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin:memcached",
-                            "propertyValue": "memcached",
-                            "NOT": false,
-                            "query": "plugin:memcached",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "df.cache.free",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "df.cache.free"
-                    }
-                },
-                {
-                    "metricDefinition": {},
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin:memcached",
-                            "propertyValue": "memcached",
-                            "NOT": false,
-                            "query": "plugin:memcached",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "df.cache.used",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "df.cache.used"
-                    }
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin:memcached",
-                            "propertyValue": "memcached",
-                            "NOT": false,
-                            "query": "plugin:memcached",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 3,
-                    "name": "B/(A+B) - Scale:100 - Mean",
-                    "valid": true,
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SCALE",
-                                "options": {
-                                    "scaleAmount": 100
-                                }
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "MEAN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "metricDefinition": {},
-                    "type": "ratio",
-                    "expressionText": "B/(A+B)",
-                    "seriesData": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 4,
-                    "name": "New Plot",
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "metricDefinition": {},
-                    "type": "plot",
-                    "seriesData": {}
-                }
-            ],
-            "chartType": "line",
-            "revisionNumber": 9
-        },
-        "sf_chartIndex": 1441728013972,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK=[?B,?A,!OUT]{?B / (?A + ?B)->!OUT};find(query='(sf_metric:df.cache.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_9;find(query='(sf_metric:df.cache.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_9;_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK:!OUT->{ ?in * 100 -> !out }->groupby()->stats:!mean->_SF_PLOT_KEY_##CHARTID##_3_9->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');_SF_PLOT_KEY_##CHARTID##_2_9->?B:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_9->?A:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK=[?B,?A,!OUT]{?B / (?A + ?B)->!OUT};find(query='(sf_metric:df.cache.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');find(query='(sf_metric:df.cache.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK:!OUT->{ ?in * 100 -> !out }->groupby()->stats:!mean->_SF_PLOT_KEY_##CHARTID##_3_9->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');_SF_PLOT_KEY_##CHARTID##_2_9->?B:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_9->?A:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK",
-        "sf_discoveryQuery": "plugin:memcached",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "% Cache Used",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 10000,
-        "marshallMemberOf": [
-            4
-        ]
+    "currentUniqueKey" : 3,
+    "revisionNumber" : 7,
+    "uiHelperValue" : "##CHARTID##_7"
+  }
+}, {
+  "marshallId" : 7,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Top hosts sets/sec",
+  "sf_chartIndex" : 1481839254910,
+  "sf_description" : "Top hosts by sets/sec",
+  "sf_jobMaxDelay" : 0,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);find(query='(sf_metric:memcached_command.set AND (_missing_:sf_programId AND _missing_:computationId))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_5 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null,
+        "visualization" : null
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "memcached_command.set",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : "memcached_command.set",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "visualization" : null
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "list",
+    "chartType" : "line",
+    "chartconfig" : {
+      "legendColumnConfiguration" : [ {
+        "enabled" : false,
+        "property" : "AWSUniqueId"
+      }, {
+        "enabled" : false,
+        "property" : "dsname"
+      }, {
+        "enabled" : true,
+        "property" : "host"
+      }, {
+        "enabled" : false,
+        "property" : "sf_originatingMetric"
+      }, {
+        "enabled" : false,
+        "property" : "sf_metric"
+      }, {
+        "enabled" : false,
+        "property" : "plugin"
+      } ],
+      "range" : 900000,
+      "sortPreference" : "-value",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
     },
-    {
-        "marshallId": 8,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -3600000,
-                "maxDecimalPlaces": 1,
-                "updateInterval": "",
-                "yAxisConfigurations": [
-                    {
-                        "id": "yAxis0",
-                        "max": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "min": 0
-                    }
-                ],
-                "sortPreference": "-sf_metric",
-                "disableThrottle": false
-            },
-            "currentUniqueKey": 6,
-            "uiHelperValue": "##CHARTID##_15",
-            "relatedDetectors": [],
-            "allPlots": [
-                {
-                    "metricDefinition": {},
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin:memcached",
-                            "propertyValue": "memcached",
-                            "NOT": false,
-                            "query": "plugin:memcached",
-                            "property": "plugin",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-memcached-1.4.14-0",
-                            "propertyValue": "integration-test-memcached-1.4.14-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-memcached-1.4.14-0\"",
-                            "property": "host",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "Current Connections",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "memcached_connections.current"
-                    }
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "metricDefinition": {},
-                    "type": "plot",
-                    "seriesData": {}
-                }
-            ],
-            "chartType": "area",
-            "revisionNumber": 15
+    "currentUniqueKey" : 3,
+    "revisionNumber" : 5,
+    "uiHelperValue" : "##CHARTID##_5"
+  }
+}, {
+  "marshallId" : 8,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Hit Rate",
+  "sf_chartIndex" : 1440940336928,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK=[?A,?B,!OUT]{?A / (?A + ?B)->!OUT};find(query='(sf_metric:memcached_ops.hits AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_19;find(query='(sf_metric:memcached_ops.misses AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_19;_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK:!OUT->{ ?in * 100 -> !out }->_SF_PLOT_KEY_##CHARTID##_3_19->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');_SF_PLOT_KEY_##CHARTID##_1_19->?A:_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_19->?B:_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
         },
-        "sf_description": "",
-        "sf_chartIndex": 1441727951153,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_15=id(report=1);find(query='(sf_metric:memcached_connections.current AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached) AND (host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_15 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_15',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_15')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_15=id(report=1);find(query='(sf_metric:memcached_connections.current AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached) AND (host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_15 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_15',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_15')",
-        "sf_discoveryQuery": "plugin:memcached",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Connections",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            4
-        ]
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "Hits",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memcached",
+        "query" : "plugin:memcached",
+        "type" : "property",
+        "value" : "memcached"
+      } ],
+      "seriesData" : {
+        "metric" : "memcached_ops.hits"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "Misses",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memcached",
+        "query" : "plugin:memcached",
+        "type" : "property",
+        "value" : "memcached"
+      } ],
+      "seriesData" : {
+        "metric" : "memcached_ops.misses"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "scaleAmount" : 100
+          },
+          "type" : "SCALE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A/(A+B)",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "hit rate %",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "forcedResolution" : "0",
+      "maxDecimalPlaces" : 2,
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "%",
+        "max" : 110,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
     },
-    {
-        "marshallId": 9,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "stackedChart": true,
-                "forcedResolution": "0",
-                "colorByMetric": false,
-                "range": -3600000,
-                "updateInterval": "",
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": 0,
-                        "max": null,
-                        "label": "",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    },
-                    {
-                        "max": null,
-                        "title": {
-                            "text": ""
-                        },
-                        "min": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        }
-                    }
-                ],
-                "sortPreference": "",
-                "disableThrottle": false
-            },
-            "currentUniqueKey": 5,
-            "uiHelperValue": "##CHARTID##_14",
-            "allPlots": [
-                {
-                    "metricDefinition": {},
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-memcached-1.4.14-0",
-                            "propertyValue": "integration-test-memcached-1.4.14-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-memcached-1.4.14-0\"",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin:memcached",
-                            "propertyValue": "memcached",
-                            "NOT": false,
-                            "query": "plugin:memcached",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "hits",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#05ce00",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "AUTO"
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "memcached_ops.hits"
-                    }
-                },
-                {
-                    "metricDefinition": {},
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-memcached-1.4.14-0",
-                            "propertyValue": "integration-test-memcached-1.4.14-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-memcached-1.4.14-0\"",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin:memcached",
-                            "propertyValue": "memcached",
-                            "NOT": false,
-                            "query": "plugin:memcached",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "misses",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#e9008a",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "AUTO"
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "memcached_ops.misses"
-                    }
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "New Plot",
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "metricDefinition": {},
-                    "type": "plot",
-                    "seriesData": {}
-                }
-            ],
-            "chartType": "area",
-            "revisionNumber": 14
+    "currentUniqueKey" : 6,
+    "revisionNumber" : 19,
+    "uiHelperValue" : "##CHARTID##_19"
+  }
+}, {
+  "marshallId" : 9,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Lowest Hit Rate",
+  "sf_chartIndex" : 1441336372648,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_10_MACROBLOCK=[?A,?B,!OUT]{?A / (?A + ?B)->!OUT};find(query='(sf_metric:memcached_ops.hits AND (_missing_:sf_programId AND _missing_:computationId))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_10;find(query='(sf_metric:memcached_ops.misses AND (_missing_:sf_programId AND _missing_:computationId))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_10;_SF_PLOT_KEY_##CHARTID##_3_10_MACROBLOCK:!OUT->groupby()->groupby()->select(count=5):!bottom->split->{ ?in * 100 -> !out }->groupby('host')->stats:!mean->_SF_PLOT_KEY_##CHARTID##_3_10->groupby() -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');_SF_PLOT_KEY_##CHARTID##_1_10->?A:_SF_PLOT_KEY_##CHARTID##_3_10_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_10->?B:_SF_PLOT_KEY_##CHARTID##_3_10_MACROBLOCK",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "memcached_ops.hits",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : "memcached_ops.hits"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "memcached_ops.misses",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : "memcached_ops.misses"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
         },
-        "sf_chartIndex": 1441373221856,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_14=id(report=1);find(query='(sf_metric:memcached_ops.hits AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0) AND (plugin:memcached))') -> fetch(maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');find(query='(sf_metric:memcached_ops.misses AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0) AND (plugin:memcached))') -> fetch(maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_14=id(report=1);find(query='(sf_metric:memcached_ops.hits AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0) AND (plugin:memcached))') -> fetch(maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');find(query='(sf_metric:memcached_ops.misses AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0) AND (plugin:memcached))') -> fetch(maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_14 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
-        "sf_discoveryQuery": "plugin:memcached",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Get Requests/sec",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            4
-        ]
+        "fn" : {
+          "options" : {
+            "count" : 5
+          },
+          "type" : "BOTTOMN"
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "scaleAmount" : 100
+          },
+          "type" : "SCALE"
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A/(A+B)",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "list",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "legendColumnConfiguration" : [ {
+        "enabled" : true,
+        "property" : "host"
+      }, {
+        "enabled" : false,
+        "property" : "sf_metric"
+      } ],
+      "maxDecimalPlaces" : 2,
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "+value",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
     },
-    {
-        "marshallId": 10,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "stackedChart": true,
-                "colorByMetric": false,
-                "range": -3600000,
-                "updateInterval": "",
-                "yAxisConfigurations": [
-                    {
-                        "id": "yAxis0",
-                        "max": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "min": null
-                    }
-                ],
-                "sortPreference": "",
-                "disableThrottle": false
-            },
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_10",
-            "relatedDetectors": [],
-            "allPlots": [
-                {
-                    "metricDefinition": {},
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-memcached-1.4.14-0",
-                            "propertyValue": "integration-test-memcached-1.4.14-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-memcached-1.4.14-0\"",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin:memcached",
-                            "propertyValue": "memcached",
-                            "NOT": false,
-                            "query": "plugin:memcached",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "memcached_items.current",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "memcached_items.current"
-                    }
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "metricDefinition": {},
-                    "type": "plot",
-                    "seriesData": {}
-                }
-            ],
-            "chartType": "area",
-            "revisionNumber": 10
+    "currentUniqueKey" : 5,
+    "revisionNumber" : 10,
+    "uiHelperValue" : "##CHARTID##_10"
+  }
+}, {
+  "marshallId" : 10,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Total Items",
+  "sf_chartIndex" : 1440941141413,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_6=id(report=1);find(query='(sf_metric:memcached_items.current AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_6 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
         },
-        "sf_chartIndex": 1442273162711,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_10=id(report=1);find(query='(sf_metric:memcached_items.current AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0) AND (plugin:memcached))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_10=id(report=1);find(query='(sf_metric:memcached_items.current AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0) AND (plugin:memcached))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10')",
-        "sf_discoveryQuery": "plugin:memcached",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "# Items",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            4
-        ]
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "memcached_items.current - Sum",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : "memcached_items.current"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "forcedResolution" : "0",
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "# items",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
     },
-    {
-        "marshallId": 11,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "chartconfig": {
-                "maxDelay": "",
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "forcedResolution": "0",
-                "colorByMetric": false,
-                "range": -3600000,
-                "updateInterval": "",
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": null,
-                        "max": null,
-                        "label": "sets/sec - BLUE",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    },
-                    {
-                        "min": 0,
-                        "max": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "title": {
-                            "text": ""
-                        },
-                        "label": "evictions % - RED"
-                    }
-                ],
-                "sortPreference": "",
-                "disableThrottle": false
-            },
-            "currentUniqueKey": 7,
-            "uiHelperValue": "##CHARTID##_20",
-            "allPlots": [
-                {
-                    "metricDefinition": {},
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-memcached-1.4.14-0",
-                            "propertyValue": "integration-test-memcached-1.4.14-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-memcached-1.4.14-0\"",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin:memcached",
-                            "propertyValue": "memcached",
-                            "NOT": false,
-                            "query": "plugin:memcached",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "sets/sec",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#00b9ff",
-                        "visualization": "area",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "AUTO"
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "memcached_command.set"
-                    }
-                },
-                {
-                    "metricDefinition": {},
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-memcached-1.4.14-0",
-                            "propertyValue": "integration-test-memcached-1.4.14-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-memcached-1.4.14-0\"",
-                            "property": "host",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin:memcached",
-                            "propertyValue": "memcached",
-                            "NOT": false,
-                            "query": "plugin:memcached",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "# evictions / sec",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#b04600",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "memcached_ops.evictions"
-                    }
-                },
-                {
-                    "metricDefinition": {},
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "evictions %",
-                    "valid": true,
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 1,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#b04600",
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "AUTO"
-                    },
-                    "type": "ratio",
-                    "expressionText": "100*B/A",
-                    "seriesData": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 4,
-                    "name": "New Plot",
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "metricDefinition": {},
-                    "type": "plot",
-                    "seriesData": {}
-                }
-            ],
-            "chartType": "line",
-            "revisionNumber": 20
+    "currentUniqueKey" : 3,
+    "revisionNumber" : 6,
+    "uiHelperValue" : "##CHARTID##_6"
+  }
+}, {
+  "marshallId" : 11,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Sets/sec",
+  "sf_chartIndex" : 1443647088193,
+  "sf_description" : "percentile distribution",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_6_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_5_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_6_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_6_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_6_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_7_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_6_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_8_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_6_MACROBLOCK=[?A,!OUT]{?A->!OUT};find(query='(sf_metric:memcached_command.set AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_6;_SF_PLOT_KEY_##CHARTID##_4_6_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_4_6->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');_SF_PLOT_KEY_##CHARTID##_1_6->?A:_SF_PLOT_KEY_##CHARTID##_4_6_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_6_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_5_6->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');_SF_PLOT_KEY_##CHARTID##_1_6->?A:_SF_PLOT_KEY_##CHARTID##_5_6_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_6_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_6_6->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');_SF_PLOT_KEY_##CHARTID##_1_6->?A:_SF_PLOT_KEY_##CHARTID##_6_6_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_6_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_7_6->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');_SF_PLOT_KEY_##CHARTID##_1_6->?A:_SF_PLOT_KEY_##CHARTID##_7_6_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_6_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_8_6->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');_SF_PLOT_KEY_##CHARTID##_1_6->?A:_SF_PLOT_KEY_##CHARTID##_8_6_MACROBLOCK",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "memcached_command.set",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memcached",
+        "query" : "plugin:memcached",
+        "type" : "property",
+        "value" : "memcached"
+      } ],
+      "seriesData" : {
+        "metric" : "memcached_command.set"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#05ce00",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
         },
-        "sf_chartIndex": 1441391009454,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_20=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_20=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_20=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_20_MACROBLOCK=[?B,?A,!OUT]{100 * ?B / ?A->!OUT};find(query='(sf_metric:memcached_command.set AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0) AND (plugin:memcached))') -> fetch(maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_20 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_20',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_20');find(query='(sf_metric:memcached_ops.evictions AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0) AND (plugin:memcached))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_20;_SF_PLOT_KEY_##CHARTID##_5_20_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_5_20->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_20',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_20');_SF_PLOT_KEY_##CHARTID##_2_20->?B:_SF_PLOT_KEY_##CHARTID##_5_20_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_20->?A:_SF_PLOT_KEY_##CHARTID##_5_20_MACROBLOCK",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_20=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_20=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_20=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_20_MACROBLOCK=[?B,?A,!OUT]{100 * ?B / ?A->!OUT};find(query='(sf_metric:memcached_command.set AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0) AND (plugin:memcached))') -> fetch(maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_20 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_20',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_20');find(query='(sf_metric:memcached_ops.evictions AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0) AND (plugin:memcached))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_20 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_20',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_20');_SF_PLOT_KEY_##CHARTID##_5_20_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_5_20->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_20',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_20');_SF_PLOT_KEY_##CHARTID##_2_20->?B:_SF_PLOT_KEY_##CHARTID##_5_20_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_20->?A:_SF_PLOT_KEY_##CHARTID##_5_20_MACROBLOCK",
-        "sf_discoveryQuery": "plugin:memcached",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Sets/sec vs Evictions %",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            4
-        ]
+        "fn" : {
+          "options" : { },
+          "type" : "MIN"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "min",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 2,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#0dba8f",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "percentile" : 10
+          },
+          "type" : "PERCENTILE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "p10",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#00b9ff",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "percentile" : 50
+          },
+          "type" : "PERCENTILE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "median",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 4,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#ff8dd1",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "percentile" : 90
+          },
+          "type" : "PERCENTILE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "p90",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 5,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#bd468d",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MAX"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "max",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 6,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 7,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "forcedResolution" : "0",
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "sets/sec",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
     },
-    {
-        "marshallId": 12,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "stackedChart": true,
-                "colorByMetric": false,
-                "range": -3600000,
-                "maxDecimalPlaces": 3,
-                "updateInterval": "",
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": 0,
-                        "max": null,
-                        "label": "Bytes",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": "",
-                "disableThrottle": false
-            },
-            "currentUniqueKey": 5,
-            "uiHelperValue": "##CHARTID##_11",
-            "relatedDetectors": [],
-            "allPlots": [
-                {
-                    "metricDefinition": {},
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin:memcached",
-                            "propertyValue": "memcached",
-                            "NOT": false,
-                            "query": "plugin:memcached",
-                            "property": "plugin",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-memcached-1.4.14-0",
-                            "propertyValue": "integration-test-memcached-1.4.14-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-memcached-1.4.14-0\"",
-                            "property": "host",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "bytes free",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#05ce00",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": 5,
-                        "extrapolationPolicy": "LAST_VALUE_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "df.cache.free"
-                    }
-                },
-                {
-                    "metricDefinition": {},
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin:memcached",
-                            "propertyValue": "memcached",
-                            "NOT": false,
-                            "query": "plugin:memcached",
-                            "property": "plugin",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "integration-test-memcached-1.4.14-0",
-                            "propertyValue": "integration-test-memcached-1.4.14-0",
-                            "NOT": false,
-                            "query": "host:\"integration-test-memcached-1.4.14-0\"",
-                            "property": "host",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "bytes used",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#e9008a",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": 5,
-                        "extrapolationPolicy": "LAST_VALUE_EXTRAPOLATION"
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "df.cache.used"
-                    }
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "New Plot",
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "metricDefinition": {},
-                    "type": "plot",
-                    "seriesData": {}
-                }
-            ],
-            "chartType": "area",
-            "revisionNumber": 11
-        },
-        "sf_chartIndex": 1442274349331,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_11=id(report=1);find(query='(sf_metric:df.cache.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached) AND (host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');find(query='(sf_metric:df.cache.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached) AND (host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_11=id(report=1);find(query='(sf_metric:df.cache.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached) AND (host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');find(query='(sf_metric:df.cache.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached) AND (host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Cache Size",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            4
-        ]
+    "currentUniqueKey" : 12,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 6,
+    "uiHelperValue" : "##CHARTID##_6"
+  }
+}, {
+  "marshallId" : 12,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Top hosts gets/sec",
+  "sf_chartIndex" : 1481839032004,
+  "sf_description" : "Top hosts gets/sec",
+  "sf_jobMaxDelay" : 0,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);find(query='(sf_metric:memcached_command.get AND (_missing_:sf_programId AND _missing_:computationId))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_7 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null,
+        "visualization" : null
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "memcached_command.get",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : "memcached_command.get",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "visualization" : null
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "list",
+    "chartType" : "line",
+    "chartconfig" : {
+      "legendColumnConfiguration" : [ {
+        "enabled" : false,
+        "property" : "AWSUniqueId"
+      }, {
+        "enabled" : false,
+        "property" : "dsname"
+      }, {
+        "enabled" : true,
+        "property" : "host"
+      }, {
+        "enabled" : false,
+        "property" : "sf_originatingMetric"
+      }, {
+        "enabled" : false,
+        "property" : "sf_metric"
+      }, {
+        "enabled" : false,
+        "property" : "plugin"
+      } ],
+      "range" : 900000,
+      "sortPreference" : "-value",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
     },
-    {
-        "marshallId": 13,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "chartconfig": {
-                "forcedResolution": "0",
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": true,
-                "absoluteEnd": null,
-                "range": -3600000,
-                "updateInterval": "",
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": 0,
-                        "max": null,
-                        "label": "read bps - RED",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    },
-                    {
-                        "min": 0,
-                        "max": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "title": {
-                            "text": ""
-                        },
-                        "label": "write bps - BLUE"
-                    }
-                ],
-                "sortPreference": "",
-                "disableThrottle": false
-            },
-            "currentUniqueKey": 4,
-            "uiHelperValue": "##CHARTID##_12",
-            "relatedDetectors": [],
-            "allPlots": [
-                {
-                    "metricDefinition": {},
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin:memcached",
-                            "propertyValue": "memcached",
-                            "NOT": false,
-                            "query": "plugin:memcached",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "write bps",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SCALE",
-                                "options": {
-                                    "scaleAmount": 8
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 1,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#00b9ff",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "AUTO"
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "memcached_octets.tx"
-                    }
-                },
-                {
-                    "metricDefinition": {},
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "plugin:memcached",
-                            "propertyValue": "memcached",
-                            "NOT": false,
-                            "query": "plugin:memcached",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "read bps",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SCALE",
-                                "options": {
-                                    "scaleAmount": 8
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#b04600",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "AUTO"
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "memcached_octets.rx"
-                    }
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "New Plot",
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "metricDefinition": {},
-                    "type": "plot",
-                    "seriesData": {}
-                }
-            ],
-            "chartType": "column",
-            "revisionNumber": 12
+    "currentUniqueKey" : 3,
+    "revisionNumber" : 7,
+    "uiHelperValue" : "##CHARTID##_7"
+  }
+}, {
+  "marshallId" : 13,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Network bits/sec",
+  "sf_chartIndex" : 1440941057408,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_9=id(report=1);find(query='(sf_metric:memcached_octets.tx AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!sum -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');find(query='(sf_metric:memcached_octets.rx AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
         },
-        "sf_chartIndex": 1441728333222,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_12=id(report=1);find(query='(sf_metric:memcached_octets.tx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!sum -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');find(query='(sf_metric:memcached_octets.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!sum -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_2_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_12=id(report=1);find(query='(sf_metric:memcached_octets.tx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!sum -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');find(query='(sf_metric:memcached_octets.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!sum -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_2_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
-        "sf_discoveryQuery": "plugin:memcached",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Network Bits/sec",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            4
-        ]
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "scaleAmount" : 8
+          },
+          "type" : "SCALE"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "write bits/sec",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : "memcached_octets.tx"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 1
+    }, {
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SCALE"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "read bits/sec",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : "memcached_octets.rx"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "column",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "disableThrottle" : false,
+      "forcedResolution" : "0",
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "useKMG2" : true,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "bits read - RED",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "label" : "bits written - BLUE",
+        "max" : null,
+        "min" : 0,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
+      } ]
     },
-    {
-        "marshallId": 14,
-        "sf_uiModel": {
-            "widgets": [
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 0,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1441223262678,
-                        "id": 1
-                    },
-                    "row": 0
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 8,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1441336372648,
-                        "id": 2
-                    },
-                    "row": 0
-                },
-                {
-                    "type": "chart",
-                    "row": 0,
-                    "sizeX": 4,
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1440940336928,
-                        "id": 3
-                    },
-                    "col": 4
-                },
-                {
-                    "sizeX": 6,
-                    "sizeY": 1,
-                    "col": 0,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1443646401273,
-                        "id": 4
-                    },
-                    "row": 1
-                },
-                {
-                    "sizeX": 6,
-                    "sizeY": 1,
-                    "col": 6,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1443647088193,
-                        "id": 5
-                    },
-                    "row": 1
-                },
-                {
-                    "row": 2,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1440941199061,
-                        "id": 7
-                    },
-                    "col": 6
-                },
-                {
-                    "row": 2,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1440941141413,
-                        "id": 8
-                    },
-                    "col": 0
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 8,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1440941057408,
-                        "id": 9
-                    },
-                    "row": 3
-                },
-                {
-                    "type": "chart",
-                    "row": 3,
-                    "sizeX": 4,
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1440941786425,
-                        "id": 10
-                    },
-                    "col": 4
-                },
-                {
-                    "sizeX": 4,
-                    "sizeY": 1,
-                    "col": 0,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1441289901282,
-                        "id": 11
-                    },
-                    "row": 3
-                },
-                {
-                    "sizeX": 6,
-                    "sizeY": 1,
-                    "col": 0,
-                    "type": "chart",
-                    "options": {
-                        "type": "chart",
-                        "name": "",
-                        "chartIndex": 1443898759402
-                    },
-                    "row": 4
-                }
-            ],
-            "version": 1
+    "currentUniqueKey" : 4,
+    "revisionNumber" : 9,
+    "uiHelperValue" : "##CHARTID##_9"
+  }
+}, {
+  "marshallId" : 14,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Total Evictions/sec",
+  "sf_chartIndex" : 1440941199061,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);find(query='(sf_metric:memcached_ops.evictions AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_7 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
         },
-        "sf_description": "",
-        "sf_discoveryQuery": "plugin:memcached",
-        "sf_discoverySelectors": [
-            "sf_hostHasService:memcached",
-            "_exist_:aws_availability_zone",
-            "plugin:memcached",
-            "_exists_:aws_region",
-            "_exists_:aws_instance_type"
-        ],
-        "sf_type": "Dashboard",
-        "marshallMemberOf": [
-            3
-        ],
-        "sf_dashboard": "Memcached (a)"
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "# evictions/sec",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : "memcached_ops.evictions"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "forcedResolution" : "0",
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "# evictions",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
     },
-    {
-        "marshallId": 15,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "stackedChart": false,
-                "colorByMetric": false,
-                "range": -3600000,
-                "disableThrottle": false,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": 0,
-                        "max": null,
-                        "label": "# items",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": "",
-                "forcedResolution": "0"
-            },
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_6",
-            "allPlots": [
-                {
-                    "metricDefinition": {},
-                    "queryItems": [],
-                    "uniqueKey": 1,
-                    "name": "memcached_items.current - Sum",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "memcached_items.current"
-                    }
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "metricDefinition": {},
-                    "type": "plot",
-                    "seriesData": {}
-                }
-            ],
-            "chartType": "area",
-            "revisionNumber": 6
+    "currentUniqueKey" : 3,
+    "revisionNumber" : 7,
+    "uiHelperValue" : "##CHARTID##_7"
+  }
+}, {
+  "marshallId" : 15,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Gets/sec",
+  "sf_chartIndex" : 1443646401273,
+  "sf_description" : "percentile distribution",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_7_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_5_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_7_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_6_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_7_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_7_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_7_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_8_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_7_MACROBLOCK=[?A,!OUT]{?A->!OUT};find(query='(sf_metric:memcached_command.get AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_7;_SF_PLOT_KEY_##CHARTID##_4_7_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_4_7->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');_SF_PLOT_KEY_##CHARTID##_1_7->?A:_SF_PLOT_KEY_##CHARTID##_4_7_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_7_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_5_7->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');_SF_PLOT_KEY_##CHARTID##_1_7->?A:_SF_PLOT_KEY_##CHARTID##_5_7_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_7_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_6_7->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');_SF_PLOT_KEY_##CHARTID##_1_7->?A:_SF_PLOT_KEY_##CHARTID##_6_7_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_7_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_7_7->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');_SF_PLOT_KEY_##CHARTID##_1_7->?A:_SF_PLOT_KEY_##CHARTID##_7_7_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_7_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_8_7->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');_SF_PLOT_KEY_##CHARTID##_1_7->?A:_SF_PLOT_KEY_##CHARTID##_8_7_MACROBLOCK",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "memcached_command.get",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memcached",
+        "query" : "plugin:memcached",
+        "type" : "property",
+        "value" : "memcached"
+      } ],
+      "seriesData" : {
+        "metric" : "memcached_command.get"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#05ce00",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
         },
-        "sf_chartIndex": 1440941141413,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_6=id(report=1);find(query='(sf_metric:memcached_items.current AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_6 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_6=id(report=1);find(query='(sf_metric:memcached_items.current AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_6 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Total Items",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            14
-        ]
+        "fn" : {
+          "options" : { },
+          "type" : "MIN"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "min",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 2,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#0dba8f",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "percentile" : 10
+          },
+          "type" : "PERCENTILE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "p10",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#00b9ff",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "percentile" : 50
+          },
+          "type" : "PERCENTILE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "median",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 4,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#ff8dd1",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "percentile" : 90
+          },
+          "type" : "PERCENTILE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "p90",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 5,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#bd468d",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MAX"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "max",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 6,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 7,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "forcedResolution" : "0",
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "gets/sec",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
     },
-    {
-        "marshallId": 16,
-        "sf_uiModel": {
-            "chartMode": "single",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -3600000,
-                "disableThrottle": false,
-                "yAxisConfigurations": [
-                    {
-                        "id": "yAxis0",
-                        "max": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "min": null
-                    }
-                ],
-                "sortPreference": "",
-                "forcedResolution": "0"
-            },
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_6",
-            "allPlots": [
-                {
-                    "metricDefinition": {},
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "memcached",
-                            "propertyValue": "memcached",
-                            "NOT": false,
-                            "query": "plugin:memcached",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "memcached_connections.current - Sum",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "memcached_connections.current"
-                    }
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "metricDefinition": {},
-                    "type": "plot",
-                    "seriesData": {}
-                }
-            ],
-            "chartType": "line",
-            "revisionNumber": 6
+    "currentUniqueKey" : 12,
+    "revisionNumber" : 7,
+    "uiHelperValue" : "##CHARTID##_7"
+  }
+}, {
+  "marshallId" : 16,
+  "marshallMemberOf" : [ 2 ],
+  "sf_dashboard" : "Memcached",
+  "sf_discoveryQuery" : "plugin:memcached AND _exists_:host",
+  "sf_discoverySelectors" : [ "_exists_:host" ],
+  "sf_filterAlias" : {
+    "variables" : [ {
+      "alias" : "host",
+      "description" : "Memcached server",
+      "dimension" : "host",
+      "globalScope" : true,
+      "preferredSuggestions" : [ ],
+      "required" : true,
+      "restricted" : false
+    } ]
+  },
+  "sf_type" : "Dashboard",
+  "sf_uiModel" : {
+    "version" : 1,
+    "widgets" : [ {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 1441373050363,
+        "id" : 1,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 0,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 4,
+      "options" : {
+        "chartIndex" : 1441373221856,
+        "id" : 2,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 0,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 8,
+      "options" : {
+        "chartIndex" : 1441391009454,
+        "id" : 3,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 0,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 8,
+      "options" : {
+        "chartIndex" : 1441727951153,
+        "id" : 4,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 1,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 1441396908169,
+        "id" : 5,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 1,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 4,
+      "options" : {
+        "chartIndex" : 1442273162711,
+        "id" : 6,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 1,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 4,
+      "options" : {
+        "chartIndex" : 1442274349331,
+        "id" : 7,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 2,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 8,
+      "options" : {
+        "chartIndex" : 1441728333222,
+        "id" : 8,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 2,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 1441728013972,
+        "id" : 9,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 2,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    } ]
+  }
+}, {
+  "marshallId" : 17,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "Sets/sec vs Evictions %",
+  "sf_chartIndex" : 1441391009454,
+  "sf_discoveryQuery" : "plugin:memcached",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_20=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_20=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_20=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_20_MACROBLOCK=[?B,?A,!OUT]{100 * ?B / ?A->!OUT};find(query='(sf_metric:memcached_command.set AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0) AND (plugin:memcached))') -> fetch(maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_20 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_20',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_20');find(query='(sf_metric:memcached_ops.evictions AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0) AND (plugin:memcached))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_20;_SF_PLOT_KEY_##CHARTID##_5_20_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_5_20->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_20',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_20');_SF_PLOT_KEY_##CHARTID##_2_20->?B:_SF_PLOT_KEY_##CHARTID##_5_20_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_20->?A:_SF_PLOT_KEY_##CHARTID##_5_20_MACROBLOCK",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "colorOverride" : "#00b9ff",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null,
+        "visualization" : "area"
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "sets/sec",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-memcached-1.4.14-0",
+        "query" : "host:\"integration-test-memcached-1.4.14-0\"",
+        "type" : "property",
+        "value" : "integration-test-memcached-1.4.14-0"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memcached",
+        "query" : "plugin:memcached",
+        "type" : "property",
+        "value" : "plugin:memcached"
+      } ],
+      "seriesData" : {
+        "metric" : "memcached_command.set"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "# evictions / sec",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-memcached-1.4.14-0",
+        "query" : "host:\"integration-test-memcached-1.4.14-0\"",
+        "type" : "property",
+        "value" : "integration-test-memcached-1.4.14-0"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memcached",
+        "query" : "plugin:memcached",
+        "type" : "property",
+        "value" : "plugin:memcached"
+      } ],
+      "seriesData" : {
+        "metric" : "memcached_ops.evictions"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "expressionText" : "100*B/A",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "evictions %",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 1
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "forcedResolution" : "0",
+      "maxDelay" : "",
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "sets/sec - BLUE",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "label" : "evictions % - RED",
+        "max" : null,
+        "min" : 0,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
         },
-        "sf_chartIndex": 1440941786425,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_6=id(report=1);find(query='(sf_metric:memcached_connections.current AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_6 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_6=id(report=1);find(query='(sf_metric:memcached_connections.current AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_6 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Total Connections",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 10000,
-        "marshallMemberOf": [
-            14
-        ]
+        "title" : {
+          "text" : ""
+        }
+      } ]
     },
-    {
-        "marshallId": 17,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": true,
-                "range": -3600000,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": 0,
-                        "max": null,
-                        "label": "sets/sec",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": "",
-                "forcedResolution": "0"
-            },
-            "currentUniqueKey": 12,
-            "uiHelperValue": "##CHARTID##_6",
-            "relatedDetectors": [],
-            "allPlots": [
-                {
-                    "metricDefinition": {},
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "memcached",
-                            "propertyValue": "memcached",
-                            "NOT": false,
-                            "query": "plugin:memcached",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "memcached_command.set",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "memcached_command.set"
-                    }
-                },
-                {
-                    "metricDefinition": {},
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "min",
-                    "valid": true,
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "MIN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#05ce00",
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "ratio",
-                    "expressionText": "A",
-                    "seriesData": {}
-                },
-                {
-                    "metricDefinition": {},
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "p10",
-                    "valid": true,
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "PERCENTILE",
-                                "options": {
-                                    "percentile": 10
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#0dba8f",
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "ratio",
-                    "expressionText": "A",
-                    "seriesData": {}
-                },
-                {
-                    "metricDefinition": {},
-                    "queryItems": [],
-                    "uniqueKey": 4,
-                    "name": "median",
-                    "valid": true,
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "PERCENTILE",
-                                "options": {
-                                    "percentile": 50
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#00b9ff",
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "ratio",
-                    "expressionText": "A",
-                    "seriesData": {}
-                },
-                {
-                    "metricDefinition": {},
-                    "queryItems": [],
-                    "uniqueKey": 5,
-                    "name": "p90",
-                    "valid": true,
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "PERCENTILE",
-                                "options": {
-                                    "percentile": 90
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#ff8dd1",
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "ratio",
-                    "expressionText": "A",
-                    "seriesData": {}
-                },
-                {
-                    "metricDefinition": {},
-                    "queryItems": [],
-                    "uniqueKey": 6,
-                    "name": "max",
-                    "valid": true,
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "MAX",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#bd468d",
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "ratio",
-                    "expressionText": "A",
-                    "seriesData": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 7,
-                    "name": "New Plot",
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "metricDefinition": {},
-                    "type": "plot",
-                    "seriesData": {}
-                }
-            ],
-            "chartType": "area",
-            "revisionNumber": 6
-        },
-        "sf_description": "percentile distribution",
-        "sf_chartIndex": 1443647088193,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_6_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_5_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_6_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_6_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_6_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_7_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_6_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_8_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_6_MACROBLOCK=[?A,!OUT]{?A->!OUT};find(query='(sf_metric:memcached_command.set AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_6;_SF_PLOT_KEY_##CHARTID##_4_6_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_4_6->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');_SF_PLOT_KEY_##CHARTID##_1_6->?A:_SF_PLOT_KEY_##CHARTID##_4_6_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_6_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_5_6->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');_SF_PLOT_KEY_##CHARTID##_1_6->?A:_SF_PLOT_KEY_##CHARTID##_5_6_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_6_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_6_6->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');_SF_PLOT_KEY_##CHARTID##_1_6->?A:_SF_PLOT_KEY_##CHARTID##_6_6_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_6_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_7_6->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');_SF_PLOT_KEY_##CHARTID##_1_6->?A:_SF_PLOT_KEY_##CHARTID##_7_6_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_6_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_8_6->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');_SF_PLOT_KEY_##CHARTID##_1_6->?A:_SF_PLOT_KEY_##CHARTID##_8_6_MACROBLOCK",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_6_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_5_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_6_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_6_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_6_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_7_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_6_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_8_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_6_MACROBLOCK=[?A,!OUT]{?A->!OUT};find(query='(sf_metric:memcached_command.set AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_6 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');_SF_PLOT_KEY_##CHARTID##_4_6_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_4_6->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');_SF_PLOT_KEY_##CHARTID##_1_6->?A:_SF_PLOT_KEY_##CHARTID##_4_6_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_6_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_5_6->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');_SF_PLOT_KEY_##CHARTID##_1_6->?A:_SF_PLOT_KEY_##CHARTID##_5_6_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_6_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_6_6->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');_SF_PLOT_KEY_##CHARTID##_1_6->?A:_SF_PLOT_KEY_##CHARTID##_6_6_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_6_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_7_6->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');_SF_PLOT_KEY_##CHARTID##_1_6->?A:_SF_PLOT_KEY_##CHARTID##_7_6_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_6_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_8_6->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');_SF_PLOT_KEY_##CHARTID##_1_6->?A:_SF_PLOT_KEY_##CHARTID##_8_6_MACROBLOCK",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Sets/sec",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            14
-        ]
+    "currentUniqueKey" : 7,
+    "revisionNumber" : 20,
+    "uiHelperValue" : "##CHARTID##_20"
+  }
+}, {
+  "marshallId" : 18,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "Cache Size",
+  "sf_chartIndex" : 1442274349331,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_11=id(report=1);find(query='(sf_metric:df.cache.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached) AND (host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');find(query='(sf_metric:df.cache.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached) AND (host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "colorOverride" : "#05ce00",
+        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION",
+        "maxExtrapolations" : 5,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "bytes free",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memcached",
+        "query" : "plugin:memcached",
+        "type" : "property",
+        "value" : "plugin:memcached"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-memcached-1.4.14-0",
+        "query" : "host:\"integration-test-memcached-1.4.14-0\"",
+        "type" : "property",
+        "value" : "integration-test-memcached-1.4.14-0"
+      } ],
+      "seriesData" : {
+        "metric" : "df.cache.free"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#e9008a",
+        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION",
+        "maxExtrapolations" : 5,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "bytes used",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memcached",
+        "query" : "plugin:memcached",
+        "type" : "property",
+        "value" : "plugin:memcached"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-memcached-1.4.14-0",
+        "query" : "host:\"integration-test-memcached-1.4.14-0\"",
+        "type" : "property",
+        "value" : "integration-test-memcached-1.4.14-0"
+      } ],
+      "seriesData" : {
+        "metric" : "df.cache.used"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "maxDecimalPlaces" : 3,
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "Bytes",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
     },
-    {
-        "marshallId": 18,
-        "sf_uiModel": {
-            "chartMode": "single",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -3600000,
-                "maxDecimalPlaces": 3,
-                "disableThrottle": false,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": 0,
-                        "max": 100,
-                        "label": "",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": "",
-                "forcedResolution": "0"
-            },
-            "currentUniqueKey": 5,
-            "uiHelperValue": "##CHARTID##_9",
-            "allPlots": [
-                {
-                    "metricDefinition": {},
-                    "queryItems": [],
-                    "uniqueKey": 1,
-                    "name": "df.cache.free",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "df.cache.free"
-                    }
-                },
-                {
-                    "metricDefinition": {},
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "df.cache.used",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "df.cache.used"
-                    }
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "B/(A+B) - Scale:100 - Mean",
-                    "valid": true,
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SCALE",
-                                "options": {
-                                    "scaleAmount": 100
-                                }
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "MEAN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "metricDefinition": {},
-                    "type": "ratio",
-                    "expressionText": "B/(A+B)",
-                    "seriesData": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 4,
-                    "name": "New Plot",
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "metricDefinition": {},
-                    "type": "plot",
-                    "seriesData": {}
-                }
-            ],
-            "chartType": "line",
-            "revisionNumber": 9
+    "currentUniqueKey" : 5,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 11,
+    "uiHelperValue" : "##CHARTID##_11"
+  }
+}, {
+  "marshallId" : 19,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "Network Bits/sec",
+  "sf_chartIndex" : 1441728333222,
+  "sf_discoveryQuery" : "plugin:memcached",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_12=id(report=1);find(query='(sf_metric:memcached_octets.tx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!sum -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');find(query='(sf_metric:memcached_octets.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!sum -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_2_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "colorOverride" : "#00b9ff",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
         },
-        "sf_chartIndex": 1441289901282,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK=[?B,?A,!OUT]{?B / (?A + ?B)->!OUT};find(query='(sf_metric:df.cache.free AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_9;find(query='(sf_metric:df.cache.used AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_9;_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK:!OUT->{ ?in * 100 -> !out }->groupby()->stats:!mean->_SF_PLOT_KEY_##CHARTID##_3_9->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');_SF_PLOT_KEY_##CHARTID##_2_9->?B:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_9->?A:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK=[?B,?A,!OUT]{?B / (?A + ?B)->!OUT};find(query='(sf_metric:df.cache.free AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');find(query='(sf_metric:df.cache.used AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK:!OUT->{ ?in * 100 -> !out }->groupby()->stats:!mean->_SF_PLOT_KEY_##CHARTID##_3_9->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');_SF_PLOT_KEY_##CHARTID##_2_9->?B:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_9->?A:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "% Cache Used",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 10000,
-        "marshallMemberOf": [
-            14
-        ]
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "scaleAmount" : 8
+          },
+          "type" : "SCALE"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "write bps",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memcached",
+        "query" : "plugin:memcached",
+        "type" : "property",
+        "value" : "plugin:memcached"
+      } ],
+      "seriesData" : {
+        "metric" : "memcached_octets.tx"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 1
+    }, {
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "scaleAmount" : 8
+          },
+          "type" : "SCALE"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "read bps",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memcached",
+        "query" : "plugin:memcached",
+        "type" : "property",
+        "value" : "plugin:memcached"
+      } ],
+      "seriesData" : {
+        "metric" : "memcached_octets.rx"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "column",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "disableThrottle" : false,
+      "forcedResolution" : "0",
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "read bps - RED",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "label" : "write bps - BLUE",
+        "max" : null,
+        "min" : 0,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
+      } ]
     },
-    {
-        "marshallId": 19,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "chartconfig": {
-                "forcedResolution": "0",
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": true,
-                "absoluteEnd": null,
-                "range": -3600000,
-                "sortPreference": "",
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": 0,
-                        "max": null,
-                        "label": "bits read - RED",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    },
-                    {
-                        "min": 0,
-                        "max": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "title": {
-                            "text": ""
-                        },
-                        "label": "bits written - BLUE"
-                    }
-                ],
-                "useKMG2": true,
-                "disableThrottle": false
-            },
-            "currentUniqueKey": 4,
-            "uiHelperValue": "##CHARTID##_9",
-            "allPlots": [
-                {
-                    "metricDefinition": {},
-                    "queryItems": [],
-                    "uniqueKey": 1,
-                    "name": "write bits/sec",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SCALE",
-                                "options": {
-                                    "scaleAmount": 8
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 1,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#0077c2",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "AUTO"
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "memcached_octets.tx"
-                    }
-                },
-                {
-                    "metricDefinition": {},
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "read bits/sec",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SCALE",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#b04600",
-                        "rollupPolicy": null,
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "AUTO"
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "memcached_octets.rx"
-                    }
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "New Plot",
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "metricDefinition": {},
-                    "type": "plot",
-                    "seriesData": {}
-                }
-            ],
-            "chartType": "column",
-            "revisionNumber": 9
+    "currentUniqueKey" : 4,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 12,
+    "uiHelperValue" : "##CHARTID##_12"
+  }
+}, {
+  "marshallId" : 20,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "% Cache Used",
+  "sf_chartIndex" : 1441728013972,
+  "sf_discoveryQuery" : "plugin:memcached",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK=[?B,?A,!OUT]{?B / (?A + ?B)->!OUT};find(query='(sf_metric:df.cache.free AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_9;find(query='(sf_metric:df.cache.used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_9;_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK:!OUT->{ ?in * 100 -> !out }->groupby()->stats:!mean->_SF_PLOT_KEY_##CHARTID##_3_9->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');_SF_PLOT_KEY_##CHARTID##_2_9->?B:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_9->?A:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "df.cache.free",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memcached",
+        "query" : "plugin:memcached",
+        "type" : "property",
+        "value" : "plugin:memcached"
+      } ],
+      "seriesData" : {
+        "metric" : "df.cache.free"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "df.cache.used",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memcached",
+        "query" : "plugin:memcached",
+        "type" : "property",
+        "value" : "plugin:memcached"
+      } ],
+      "seriesData" : {
+        "metric" : "df.cache.used"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
         },
-        "sf_chartIndex": 1440941057408,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_9=id(report=1);find(query='(sf_metric:memcached_octets.tx AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!sum -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');find(query='(sf_metric:memcached_octets.rx AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_9=id(report=1);find(query='(sf_metric:memcached_octets.tx AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!sum -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');find(query='(sf_metric:memcached_octets.rx AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Network bits/sec",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            14
-        ]
+        "fn" : {
+          "options" : {
+            "scaleAmount" : 100
+          },
+          "type" : "SCALE"
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "B/(A+B)",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "B/(A+B) - Scale:100 - Mean",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memcached",
+        "query" : "plugin:memcached",
+        "type" : "property",
+        "value" : "plugin:memcached"
+      } ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "single",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "maxDecimalPlaces" : 3,
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "%",
+        "max" : 100,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
     },
-    {
-        "marshallId": 20,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "stackedChart": false,
-                "colorByMetric": false,
-                "range": -3600000,
-                "disableThrottle": false,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": 0,
-                        "max": null,
-                        "label": "# evictions",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": "",
-                "forcedResolution": "0"
-            },
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_7",
-            "allPlots": [
-                {
-                    "metricDefinition": {},
-                    "queryItems": [],
-                    "uniqueKey": 1,
-                    "name": "# evictions/sec",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "memcached_ops.evictions"
-                    }
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "metricDefinition": {},
-                    "type": "plot",
-                    "seriesData": {}
-                }
-            ],
-            "chartType": "area",
-            "revisionNumber": 7
-        },
-        "sf_chartIndex": 1440941199061,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);find(query='(sf_metric:memcached_ops.evictions AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_7 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);find(query='(sf_metric:memcached_ops.evictions AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_7 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Total Evictions/sec",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            14
-        ]
+    "currentUniqueKey" : 5,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 9,
+    "uiHelperValue" : "##CHARTID##_9"
+  }
+}, {
+  "marshallId" : 21,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "# Items",
+  "sf_chartIndex" : 1442273162711,
+  "sf_discoveryQuery" : "plugin:memcached",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_10=id(report=1);find(query='(sf_metric:memcached_items.current AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0) AND (plugin:memcached))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "memcached_items.current",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-memcached-1.4.14-0",
+        "query" : "host:\"integration-test-memcached-1.4.14-0\"",
+        "type" : "property",
+        "value" : "integration-test-memcached-1.4.14-0"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memcached",
+        "query" : "plugin:memcached",
+        "type" : "property",
+        "value" : "plugin:memcached"
+      } ],
+      "seriesData" : {
+        "metric" : "memcached_items.current"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
     },
-    {
-        "marshallId": 21,
-        "sf_uiModel": {
-            "chartMode": "single",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -3600000,
-                "updateInterval": "",
-                "yAxisConfigurations": [
-                    {
-                        "id": "yAxis0",
-                        "max": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "min": null
-                    }
-                ],
-                "sortPreference": "",
-                "disableThrottle": false
-            },
-            "currentUniqueKey": 3,
-            "uiHelperValue": "##CHARTID##_7",
-            "allPlots": [
-                {
-                    "metricDefinition": {},
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "memcached",
-                            "propertyValue": "memcached",
-                            "NOT": false,
-                            "query": "plugin:memcached",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "memcached_connections.current - Sum by host - Count",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [
-                                        {
-                                            "value": "host"
-                                        }
-                                    ],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "COUNT",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "memcached_connections.current"
-                    }
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "New Plot",
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "metricDefinition": {},
-                    "type": "plot",
-                    "seriesData": {}
-                }
-            ],
-            "chartType": "line",
-            "revisionNumber": 7
+    "currentUniqueKey" : 3,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 10,
+    "uiHelperValue" : "##CHARTID##_10"
+  }
+}, {
+  "marshallId" : 22,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "Items 1h Change %",
+  "sf_chartIndex" : 1441396908169,
+  "sf_description" : "",
+  "sf_discoveryQuery" : "plugin:memcached",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_10_MACROBLOCK=[?A,?B,!OUT]{?A / ?B - 1->!OUT};find(query='(sf_metric:memcached_items.current AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0) AND (plugin:memcached))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_10;find(query='(sf_metric:memcached_items.current AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0) AND (plugin:memcached))') -> fetch(offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_10;_SF_PLOT_KEY_##CHARTID##_3_10_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_10->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');_SF_PLOT_KEY_##CHARTID##_1_10->?A:_SF_PLOT_KEY_##CHARTID##_3_10_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_10->?B:_SF_PLOT_KEY_##CHARTID##_3_10_MACROBLOCK",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "memcached_items.current",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-memcached-1.4.14-0",
+        "query" : "host:\"integration-test-memcached-1.4.14-0\"",
+        "type" : "property",
+        "value" : "integration-test-memcached-1.4.14-0"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memcached",
+        "query" : "plugin:memcached",
+        "type" : "property",
+        "value" : "plugin:memcached"
+      } ],
+      "seriesData" : {
+        "metric" : "memcached_items.current"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
         },
-        "sf_chartIndex": 1441223262678,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);A => find(query='(sf_metric:memcached_connections.current AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch -> groupby('host') -> stats:!sum -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_7 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);A => find(query='(sf_metric:memcached_connections.current AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch -> groupby('host') -> stats:!sum -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_7 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Hosts Reporting",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 10000,
-        "marshallMemberOf": [
-            14
-        ]
+        "fn" : {
+          "options" : {
+            "milliseconds" : 3600000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "memcached_items.current - Timeshift 1h",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-memcached-1.4.14-0",
+        "query" : "host:\"integration-test-memcached-1.4.14-0\"",
+        "type" : "property",
+        "value" : "integration-test-memcached-1.4.14-0"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memcached",
+        "query" : "plugin:memcached",
+        "type" : "property",
+        "value" : "plugin:memcached"
+      } ],
+      "seriesData" : {
+        "metric" : "memcached_items.current"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "expressionText" : "A/B-1",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "A/B-1",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "single",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "forcedResolution" : "0",
+      "maxDecimalPlaces" : 2,
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
     },
-    {
-        "marshallId": 22,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "forcedResolution": "0",
-                "colorByMetric": false,
-                "range": -3600000,
-                "maxDecimalPlaces": 2,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": 0,
-                        "max": 110,
-                        "label": "%",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": "",
-                "disableThrottle": false
-            },
-            "currentUniqueKey": 6,
-            "uiHelperValue": "##CHARTID##_19",
-            "allPlots": [
-                {
-                    "metricDefinition": {},
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "memcached",
-                            "propertyValue": "memcached",
-                            "NOT": false,
-                            "query": "plugin:memcached",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "Hits",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "memcached_ops.hits"
-                    }
-                },
-                {
-                    "metricDefinition": {},
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "memcached",
-                            "propertyValue": "memcached",
-                            "NOT": false,
-                            "query": "plugin:memcached",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "Misses",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "memcached_ops.misses"
-                    }
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "hit rate %",
-                    "valid": true,
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SCALE",
-                                "options": {
-                                    "scaleAmount": 100
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "metricDefinition": {},
-                    "type": "ratio",
-                    "expressionText": "A/(A+B)",
-                    "seriesData": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 4,
-                    "name": "New Plot",
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "metricDefinition": {},
-                    "type": "plot",
-                    "seriesData": {}
-                }
-            ],
-            "chartType": "area",
-            "revisionNumber": 19
-        },
-        "sf_chartIndex": 1440940336928,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK=[?A,?B,!OUT]{?A / (?A + ?B)->!OUT};find(query='(sf_metric:memcached_ops.hits AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_19;find(query='(sf_metric:memcached_ops.misses AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_19;_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK:!OUT->{ ?in * 100 -> !out }->_SF_PLOT_KEY_##CHARTID##_3_19->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');_SF_PLOT_KEY_##CHARTID##_1_19->?A:_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_19->?B:_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK=[?A,?B,!OUT]{?A / (?A + ?B)->!OUT};find(query='(sf_metric:memcached_ops.hits AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_19 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');find(query='(sf_metric:memcached_ops.misses AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_19 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK:!OUT->{ ?in * 100 -> !out }->_SF_PLOT_KEY_##CHARTID##_3_19->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');_SF_PLOT_KEY_##CHARTID##_1_19->?A:_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_19->?B:_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Hit Rate",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            14
-        ]
+    "currentUniqueKey" : 5,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 10,
+    "uiHelperValue" : "##CHARTID##_10"
+  }
+}, {
+  "marshallId" : 23,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "Connections",
+  "sf_chartIndex" : 1441727951153,
+  "sf_description" : "",
+  "sf_discoveryQuery" : "plugin:memcached",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_15=id(report=1);find(query='(sf_metric:memcached_connections.current AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached) AND (host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_15 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_15',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_15')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Current Connections",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memcached",
+        "query" : "plugin:memcached",
+        "type" : "property",
+        "value" : "plugin:memcached"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-memcached-1.4.14-0",
+        "query" : "host:\"integration-test-memcached-1.4.14-0\"",
+        "type" : "property",
+        "value" : "integration-test-memcached-1.4.14-0"
+      } ],
+      "seriesData" : {
+        "metric" : "memcached_connections.current"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "maxDecimalPlaces" : 1,
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "-sf_metric",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
     },
-    {
-        "marshallId": 23,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -3600000,
-                "maxDecimalPlaces": 2,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": 0,
-                        "max": 100,
-                        "label": "%",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": "",
-                "disableThrottle": false
-            },
-            "currentUniqueKey": 6,
-            "uiHelperValue": "##CHARTID##_16",
-            "relatedDetectors": [],
-            "allPlots": [
-                {
-                    "metricDefinition": {},
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "memcached",
-                            "propertyValue": "memcached",
-                            "NOT": false,
-                            "query": "plugin:memcached",
-                            "property": "plugin",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "sf-icon-property",
-                            "value": "memcached",
-                            "propertyValue": "memcached",
-                            "NOT": false,
-                            "query": "sf_hostHasService:memcached",
-                            "property": "sf_hostHasService",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "Hits",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "memcached_ops.hits"
-                    }
-                },
-                {
-                    "metricDefinition": {},
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "memcached",
-                            "propertyValue": "memcached",
-                            "NOT": false,
-                            "query": "plugin:memcached",
-                            "property": "plugin",
-                            "type": "property"
-                        },
-                        {
-                            "iconClass": "sf-icon-property",
-                            "value": "memcached",
-                            "propertyValue": "memcached",
-                            "NOT": false,
-                            "query": "sf_hostHasService:memcached",
-                            "property": "sf_hostHasService",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 2,
-                    "name": "Misses",
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SUM",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "memcached_ops.misses"
-                    }
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "100*Hits/(Hits+Misses)",
-                    "valid": true,
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SCALE",
-                                "options": {
-                                    "scaleAmount": 100
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "metricDefinition": {},
-                    "type": "ratio",
-                    "expressionText": "A/(A+B)",
-                    "seriesData": {}
-                },
-                {
-                    "queryItems": [
-                        {
-                            "iconClass": "sf-icon-property",
-                            "value": "memcached",
-                            "propertyValue": "memcached",
-                            "NOT": false,
-                            "query": "sf_hostHasService:memcached",
-                            "property": "sf_hostHasService",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 4,
-                    "name": "New Plot",
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "metricDefinition": {},
-                    "type": "plot",
-                    "seriesData": {}
-                }
-            ],
-            "chartType": "line",
-            "revisionNumber": 16
+    "currentUniqueKey" : 6,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 15,
+    "uiHelperValue" : "##CHARTID##_15"
+  }
+}, {
+  "marshallId" : 24,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "Hit Rate %",
+  "sf_chartIndex" : 1441373050363,
+  "sf_discoveryQuery" : "plugin:memcached",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_7_MACROBLOCK=[?A,?B,!OUT]{?A / (?A + ?B)->!OUT};find(query='(sf_metric:memcached_ops.hits AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0) AND (plugin:memcached))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_7;find(query='(sf_metric:memcached_ops.misses AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_7;_SF_PLOT_KEY_##CHARTID##_3_7_MACROBLOCK:!OUT->{ ?in * 100 -> !out }->_SF_PLOT_KEY_##CHARTID##_3_7->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');_SF_PLOT_KEY_##CHARTID##_1_7->?A:_SF_PLOT_KEY_##CHARTID##_3_7_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_7->?B:_SF_PLOT_KEY_##CHARTID##_3_7_MACROBLOCK",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "memcached_ops.hits",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-memcached-1.4.14-0",
+        "query" : "host:\"integration-test-memcached-1.4.14-0\"",
+        "type" : "property",
+        "value" : "integration-test-memcached-1.4.14-0"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memcached",
+        "query" : "plugin:memcached",
+        "type" : "property",
+        "value" : "plugin:memcached"
+      } ],
+      "seriesData" : {
+        "metric" : "memcached_ops.hits"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "memcached_ops.misses",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memcached",
+        "query" : "plugin:memcached",
+        "type" : "property",
+        "value" : "plugin:memcached"
+      } ],
+      "seriesData" : {
+        "metric" : "memcached_ops.misses"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
         },
-        "sf_description": "",
-        "sf_chartIndex": 1443898759402,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK=[?A,?B,!OUT]{?A / (?A + ?B)->!OUT};find(query='(sf_metric:memcached_ops.hits AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached) AND (sf_hostHasService:memcached))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_16;find(query='(sf_metric:memcached_ops.misses AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached) AND (sf_hostHasService:memcached))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_16;_SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK:!OUT->{ ?in * 100 -> !out }->_SF_PLOT_KEY_##CHARTID##_3_16->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');_SF_PLOT_KEY_##CHARTID##_1_16->?A:_SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_16->?B:_SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK=[?A,?B,!OUT]{?A / (?A + ?B)->!OUT};find(query='(sf_metric:memcached_ops.hits AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached) AND (sf_hostHasService:memcached))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_16 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');find(query='(sf_metric:memcached_ops.misses AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached) AND (sf_hostHasService:memcached))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_16 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');_SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK:!OUT->{ ?in * 100 -> !out }->_SF_PLOT_KEY_##CHARTID##_3_16->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');_SF_PLOT_KEY_##CHARTID##_1_16->?A:_SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_16->?B:_SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Hit Rate",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            14
-        ]
+        "fn" : {
+          "options" : {
+            "scaleAmount" : 100
+          },
+          "type" : "SCALE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A/(A+B)",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Hit Rate %",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memcached",
+        "query" : "plugin:memcached",
+        "type" : "property",
+        "value" : "plugin:memcached"
+      } ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "single",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "maxDecimalPlaces" : 3,
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : 100,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
     },
-    {
-        "marshallId": 24,
-        "sf_uiModel": {
-            "chartMode": "list",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": false,
-                "range": -3600000,
-                "maxDecimalPlaces": 2,
-                "yAxisConfigurations": [
-                    {
-                        "id": "yAxis0",
-                        "max": null,
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "name": "yAxis0",
-                        "min": null
-                    }
-                ],
-                "sortPreference": "+value",
-                "disableThrottle": false
-            },
-            "currentUniqueKey": 5,
-            "uiHelperValue": "##CHARTID##_9",
-            "allPlots": [
-                {
-                    "metricDefinition": {},
-                    "queryItems": [],
-                    "uniqueKey": 1,
-                    "name": "memcached_ops.hits",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "memcached_ops.hits"
-                    }
-                },
-                {
-                    "metricDefinition": {},
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "memcached_ops.misses",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "memcached_ops.misses"
-                    }
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "",
-                    "valid": true,
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "BOTTOMN",
-                                "options": {
-                                    "count": 5
-                                }
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "SCALE",
-                                "options": {
-                                    "scaleAmount": 100
-                                }
-                            },
-                            "showMe": false
-                        },
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [
-                                        {
-                                            "value": "host"
-                                        }
-                                    ],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "MEAN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "metricDefinition": {},
-                    "type": "ratio",
-                    "expressionText": "A/(A+B)",
-                    "seriesData": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 4,
-                    "name": "New Plot",
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "metricDefinition": {},
-                    "type": "plot",
-                    "seriesData": {}
-                }
-            ],
-            "chartType": "line",
-            "revisionNumber": 9
+    "currentUniqueKey" : 5,
+    "revisionNumber" : 7,
+    "uiHelperValue" : "##CHARTID##_7"
+  }
+}, {
+  "marshallId" : 25,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "Get Requests/sec",
+  "sf_chartIndex" : 1441373221856,
+  "sf_discoveryQuery" : "plugin:memcached",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_14=id(report=1);find(query='(sf_metric:memcached_ops.hits AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0) AND (plugin:memcached))') -> fetch(maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');find(query='(sf_metric:memcached_ops.misses AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:integration\\\\-test\\\\-memcached\\\\-1.4.14\\\\-0) AND (plugin:memcached))') -> fetch(maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_14 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "colorOverride" : "#05ce00",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "hits",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-memcached-1.4.14-0",
+        "query" : "host:\"integration-test-memcached-1.4.14-0\"",
+        "type" : "property",
+        "value" : "integration-test-memcached-1.4.14-0"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memcached",
+        "query" : "plugin:memcached",
+        "type" : "property",
+        "value" : "plugin:memcached"
+      } ],
+      "seriesData" : {
+        "metric" : "memcached_ops.hits"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#e9008a",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "misses",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-memcached-1.4.14-0",
+        "query" : "host:\"integration-test-memcached-1.4.14-0\"",
+        "type" : "property",
+        "value" : "integration-test-memcached-1.4.14-0"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memcached",
+        "query" : "plugin:memcached",
+        "type" : "property",
+        "value" : "plugin:memcached"
+      } ],
+      "seriesData" : {
+        "metric" : "memcached_ops.misses"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "forcedResolution" : "0",
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
         },
-        "sf_chartIndex": 1441336372648,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK=[?A,?B,!OUT]{?A / (?A + ?B)->!OUT};A => find(query='(sf_metric:memcached_ops.hits AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_9;B => find(query='(sf_metric:memcached_ops.misses AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_9;_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK:!OUT->groupby()->groupby()->select(count=5):!bottom->split() -> stats:!mean->{ ?in * 100 -> !out }->groupby('host')->stats:!mean->_SF_PLOT_KEY_##CHARTID##_3_9->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');_SF_PLOT_KEY_##CHARTID##_1_9->?A:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_9->?B:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK=[?A,?B,!OUT]{?A / (?A + ?B)->!OUT};A => find(query='(sf_metric:memcached_ops.hits AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');B => find(query='(sf_metric:memcached_ops.misses AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK:!OUT->groupby()->groupby()->select(count=5):!bottom->split() -> stats:!mean->{ ?in * 100 -> !out }->groupby('host')->stats:!mean->_SF_PLOT_KEY_##CHARTID##_3_9->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');_SF_PLOT_KEY_##CHARTID##_1_9->?A:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_9->?B:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Lowest Hit Rate",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 10000,
-        "marshallMemberOf": [
-            14
-        ]
+        "title" : {
+          "text" : ""
+        }
+      } ]
     },
-    {
-        "marshallId": 25,
-        "sf_uiModel": {
-            "chartMode": "graph",
-            "chartconfig": {
-                "absoluteEnd": null,
-                "rangeEnd": 0,
-                "absoluteStart": null,
-                "colorByMetric": true,
-                "range": -3600000,
-                "yAxisConfigurations": [
-                    {
-                        "name": "yAxis0",
-                        "min": 0,
-                        "max": null,
-                        "label": "gets/sec",
-                        "plotlines": {
-                            "high": null,
-                            "low": null
-                        },
-                        "id": "yAxis0"
-                    }
-                ],
-                "sortPreference": "",
-                "forcedResolution": "0"
-            },
-            "currentUniqueKey": 12,
-            "uiHelperValue": "##CHARTID##_7",
-            "allPlots": [
-                {
-                    "metricDefinition": {},
-                    "queryItems": [
-                        {
-                            "iconClass": "icon-properties",
-                            "value": "memcached",
-                            "propertyValue": "memcached",
-                            "NOT": false,
-                            "query": "plugin:memcached",
-                            "property": "plugin",
-                            "type": "property"
-                        }
-                    ],
-                    "uniqueKey": 1,
-                    "name": "memcached_command.get",
-                    "dataManipulations": [],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": true,
-                    "focusNext": false,
-                    "configuration": {
-                        "rollupPolicy": null
-                    },
-                    "type": "plot",
-                    "seriesData": {
-                        "metric": "memcached_command.get"
-                    }
-                },
-                {
-                    "metricDefinition": {},
-                    "queryItems": [],
-                    "uniqueKey": 2,
-                    "name": "min",
-                    "valid": true,
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "MIN",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#05ce00",
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "ratio",
-                    "expressionText": "A",
-                    "seriesData": {}
-                },
-                {
-                    "metricDefinition": {},
-                    "queryItems": [],
-                    "uniqueKey": 3,
-                    "name": "p10",
-                    "valid": true,
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "PERCENTILE",
-                                "options": {
-                                    "percentile": 10
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#0dba8f",
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "ratio",
-                    "expressionText": "A",
-                    "seriesData": {}
-                },
-                {
-                    "metricDefinition": {},
-                    "queryItems": [],
-                    "uniqueKey": 4,
-                    "name": "median",
-                    "valid": true,
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "PERCENTILE",
-                                "options": {
-                                    "percentile": 50
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#00b9ff",
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "ratio",
-                    "expressionText": "A",
-                    "seriesData": {}
-                },
-                {
-                    "metricDefinition": {},
-                    "queryItems": [],
-                    "uniqueKey": 5,
-                    "name": "p90",
-                    "valid": true,
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "PERCENTILE",
-                                "options": {
-                                    "percentile": 90
-                                }
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#ff8dd1",
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "ratio",
-                    "expressionText": "A",
-                    "seriesData": {}
-                },
-                {
-                    "metricDefinition": {},
-                    "queryItems": [],
-                    "uniqueKey": 6,
-                    "name": "max",
-                    "valid": true,
-                    "dataManipulations": [
-                        {
-                            "direction": {
-                                "type": "aggregation",
-                                "options": {
-                                    "aggregateGroupBy": [],
-                                    "collapseGroups": false,
-                                    "transformTimeRange": null
-                                }
-                            },
-                            "fn": {
-                                "type": "MAX",
-                                "options": {}
-                            },
-                            "showMe": false
-                        }
-                    ],
-                    "transient": false,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "configuration": {
-                        "colorOverride": "#bd468d",
-                        "maxExtrapolations": -1,
-                        "extrapolationPolicy": "NULL_EXTRAPOLATION"
-                    },
-                    "type": "ratio",
-                    "expressionText": "A",
-                    "seriesData": {}
-                },
-                {
-                    "queryItems": [],
-                    "uniqueKey": 7,
-                    "name": "New Plot",
-                    "dataManipulations": [],
-                    "transient": true,
-                    "yAxisIndex": 0,
-                    "invisible": false,
-                    "focusNext": false,
-                    "metricDefinition": {},
-                    "type": "plot",
-                    "seriesData": {}
-                }
-            ],
-            "chartType": "area",
-            "revisionNumber": 7
-        },
-        "sf_description": "percentile distribution",
-        "sf_chartIndex": 1443646401273,
-        "sf_programTextRegex": "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_7_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_5_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_7_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_6_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_7_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_7_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_7_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_8_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_7_MACROBLOCK=[?A,!OUT]{?A->!OUT};find(query='(sf_metric:memcached_command.get AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_7;_SF_PLOT_KEY_##CHARTID##_4_7_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_4_7->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');_SF_PLOT_KEY_##CHARTID##_1_7->?A:_SF_PLOT_KEY_##CHARTID##_4_7_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_7_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_5_7->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');_SF_PLOT_KEY_##CHARTID##_1_7->?A:_SF_PLOT_KEY_##CHARTID##_5_7_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_7_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_6_7->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');_SF_PLOT_KEY_##CHARTID##_1_7->?A:_SF_PLOT_KEY_##CHARTID##_6_7_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_7_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_7_7->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');_SF_PLOT_KEY_##CHARTID##_1_7->?A:_SF_PLOT_KEY_##CHARTID##_7_7_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_7_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_8_7->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');_SF_PLOT_KEY_##CHARTID##_1_7->?A:_SF_PLOT_KEY_##CHARTID##_8_7_MACROBLOCK",
-        "sf_viewProgramText": "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_7_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_5_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_7_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_6_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_7_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_7_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_7_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_8_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_7_MACROBLOCK=[?A,!OUT]{?A->!OUT};find(query='(sf_metric:memcached_command.get AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:memcached))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_7 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');_SF_PLOT_KEY_##CHARTID##_4_7_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_4_7->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');_SF_PLOT_KEY_##CHARTID##_1_7->?A:_SF_PLOT_KEY_##CHARTID##_4_7_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_7_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_5_7->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');_SF_PLOT_KEY_##CHARTID##_1_7->?A:_SF_PLOT_KEY_##CHARTID##_5_7_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_7_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_6_7->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');_SF_PLOT_KEY_##CHARTID##_1_7->?A:_SF_PLOT_KEY_##CHARTID##_6_7_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_7_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_7_7->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');_SF_PLOT_KEY_##CHARTID##_1_7->?A:_SF_PLOT_KEY_##CHARTID##_7_7_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_7_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_8_7->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');_SF_PLOT_KEY_##CHARTID##_1_7->?A:_SF_PLOT_KEY_##CHARTID##_8_7_MACROBLOCK",
-        "sf_jobMaxDelay": 0,
-        "sf_cacheProgram": false,
-        "sf_type": "Chart",
-        "sf_chart": "Gets/sec",
-        "sf_disallowCachedProgram": true,
-        "sf_jobResolution": 1000,
-        "marshallMemberOf": [
-            14
-        ]
-    }
-]
+    "currentUniqueKey" : 5,
+    "revisionNumber" : 14,
+    "uiHelperValue" : "##CHARTID##_14"
+  }
+} ]

--- a/CollectD/Page_Varnish.json
+++ b/CollectD/Page_Varnish.json
@@ -1,4360 +1,4320 @@
 [ {
   "marshallScope" : 2
 }, {
+  "marshallId" : 1,
   "sf_description" : "Metrics about Varnish.",
-  "sf_type" : "Service",
   "sf_service" : "Varnish",
-  "marshallId" : 1
+  "sf_type" : "Service"
 }, {
-  "sf_page" : "Varnish",
-  "sf_description" : "Dashboards about Varnish.",
-  "sf_type" : "Page",
   "marshallId" : 2,
-  "marshallMemberOf" : [ 1 ]
+  "marshallMemberOf" : [ 1 ],
+  "sf_description" : "Dashboards about Varnish.",
+  "sf_page" : "Varnish",
+  "sf_type" : "Page"
 }, {
-  "sf_dashboard" : "Varnish (a)",
+  "marshallId" : 3,
+  "marshallMemberOf" : [ 2 ],
+  "sf_dashboard" : "Varnish",
+  "sf_description" : "Single host",
+  "sf_discoveryQuery" : "plugin:varnish",
+  "sf_discoverySelectors" : [ "_exists_:host" ],
+  "sf_filterAlias" : {
+    "variables" : [ {
+      "alias" : "host",
+      "description" : "Varnish node",
+      "dimension" : "host",
+      "globalScope" : true,
+      "preferredSuggestions" : [ ],
+      "required" : true,
+      "restricted" : false
+    } ]
+  },
+  "sf_type" : "Dashboard",
   "sf_uiModel" : {
+    "version" : 1,
     "widgets" : [ {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 4,
-      "type" : "chart",
+      "col" : 0,
       "options" : {
-        "type" : "chart",
-        "name" : "",
         "chartIndex" : 1440618403043,
-        "id" : 1
-      },
-      "row" : 0
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 0,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
+        "id" : 1,
         "name" : "",
-        "chartIndex" : 1441044802676,
-        "id" : 3
+        "type" : "chart"
       },
-      "row" : 0
-    }, {
+      "row" : 0,
       "sizeX" : 4,
       "sizeY" : 1,
+      "type" : "chart"
+    }, {
       "col" : 8,
-      "type" : "chart",
       "options" : {
-        "type" : "chart",
+        "chartIndex" : 1440781311595,
+        "id" : 2,
         "name" : "",
-        "chartIndex" : 1441301459735,
-        "id" : 2
+        "type" : "chart"
       },
-      "row" : 0
-    }, {
+      "row" : 0,
       "sizeX" : 4,
       "sizeY" : 1,
+      "type" : "chart"
+    }, {
       "col" : 4,
-      "type" : "chart",
       "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1441232963548,
-        "id" : 4
-      },
-      "row" : 1
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 0,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1441233341000,
-        "id" : 5
-      },
-      "row" : 1
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 8,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1441302803911,
-        "id" : 6
-      },
-      "row" : 1
-    }, {
-      "sizeX" : 4,
-      "options" : {
-        "type" : "chart",
-        "name" : "",
         "chartIndex" : 1440618213590,
-        "id" : 7
+        "id" : 3,
+        "name" : "",
+        "type" : "chart"
       },
-      "type" : "chart",
-      "col" : 4,
-      "row" : 2
+      "row" : 0,
+      "sizeX" : 4,
+      "type" : "chart"
     }, {
+      "col" : 8,
+      "options" : {
+        "chartIndex" : 1440618052144,
+        "id" : 4,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 1,
+      "sizeX" : 4,
+      "type" : "chart"
+    }, {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 1440781752695,
+        "id" : 6,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 1,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 4,
+      "options" : {
+        "chartIndex" : 1440782296628,
+        "id" : 5,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 1,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 1441040394089,
+        "id" : 7,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 2,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 8,
+      "options" : {
+        "chartIndex" : 1440780940034,
+        "id" : 9,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 2,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 4,
+      "options" : {
+        "chartIndex" : 1440780872072,
+        "id" : 8,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 2,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 8,
+      "options" : {
+        "chartIndex" : 1441231423837,
+        "id" : 11,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 3,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 1441232232693,
+        "id" : 12,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 3,
       "sizeX" : 4,
       "sizeY" : 2,
-      "col" : 0,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1441302597692,
-        "id" : 8
-      },
-      "row" : 2
+      "type" : "chart"
     }, {
-      "sizeX" : 4,
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1440618052144,
-        "id" : 9
-      },
-      "type" : "chart",
-      "col" : 8,
-      "row" : 2
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 8,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1440781506039,
-        "id" : 10
-      },
-      "row" : 3
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
       "col" : 4,
-      "type" : "chart",
       "options" : {
-        "type" : "chart",
+        "chartIndex" : 1441231853402,
+        "id" : 10,
         "name" : "",
-        "chartIndex" : 1440781311595,
-        "id" : 11
+        "type" : "chart"
       },
-      "row" : 3
-    } ],
-    "version" : 1
-  },
-  "sf_discoverySelectors" : [ "_exists_:aws_region", "sf_hostHasService:varnish", "_exists_:aws_availability_zone", "_exists_:aws_instance_type", "plugin:varnish" ],
-  "sf_description" : "Multiple varnish servers",
-  "sf_type" : "Dashboard",
-  "sf_discoveryQuery" : "plugin:varnish",
-  "marshallId" : 3,
-  "marshallMemberOf" : [ 2 ]
+      "row" : 3,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 8,
+      "options" : {
+        "chartIndex" : 1441041836777,
+        "id" : 13,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 4,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 4,
+      "options" : {
+        "chartIndex" : 1440781506039,
+        "id" : 14,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 4,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    } ]
+  }
 }, {
-  "sf_chart" : "Total Bytes/sec",
+  "marshallId" : 4,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Shared Memory Operations",
+  "sf_chartIndex" : 1440781506039,
+  "sf_description" : "",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);A => find(query='(sf_metric:total_operations.* AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0) AND (plugin_instance:*\\\\-shm))') -> fetch(maxExtrapolations=-1) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
+  "sf_type" : "Chart",
   "sf_uiModel" : {
-    "revisionNumber" : 9,
-    "chartType" : "column",
     "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
+      "configuration" : {
+        "colorOverride" : null,
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "sf_metric"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
       } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "*-shm",
+        "query" : "plugin_instance:*\\-shm",
+        "type" : "property",
+        "value" : "plugin_instance:*-shm"
+      } ],
+      "seriesData" : {
+        "metric" : "total_operations.*"
+      },
+      "transient" : false,
+      "type" : "plot",
       "uniqueKey" : 1,
-      "name" : "total_bytes.resp_body - Sum",
-      "seriesData" : {
-        "metric" : "total_bytes.resp_body"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
+      "yAxisIndex" : 0
     }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
-      "name" : "total_bytes.resp_header - Sum",
-      "seriesData" : {
-        "metric" : "total_bytes.resp_header"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 3,
-      "name" : "Response bytes",
-      "seriesData" : { },
       "dataManipulations" : [ ],
-      "expressionText" : "A+B",
-      "transient" : false,
-      "yAxisIndex" : 1,
+      "focusNext" : false,
       "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#0077c2",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 4,
-      "name" : "total_bytes.req_body - Sum",
-      "seriesData" : {
-        "metric" : "total_bytes.req_body"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 5,
-      "name" : "total_bytes.req_header - Sum",
-      "seriesData" : {
-        "metric" : "total_bytes.req_header"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 6,
-      "name" : "Request bytes",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "expressionText" : "D+E",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#b04600",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 7,
+      "metricDefinition" : { },
       "name" : "New Plot",
+      "queryItems" : [ ],
       "seriesData" : { },
-      "dataManipulations" : [ ],
       "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
       "type" : "plot",
-      "metricDefinition" : { }
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
     } ],
-    "uiHelperValue" : "##CHARTID##_9",
     "chartMode" : "graph",
+    "chartType" : "area",
     "chartconfig" : {
       "absoluteEnd" : null,
-      "rangeEnd" : 0,
       "absoluteStart" : null,
-      "useKMG2" : true,
-      "colorByMetric" : false,
+      "colorByMetric" : true,
       "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : true,
       "updateInterval" : "",
-      "disableThrottle" : false,
       "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
+        "id" : "yAxis0",
+        "label" : "ops / sec",
         "max" : null,
-        "label" : "request - RED",
+        "min" : 0,
+        "name" : "yAxis0",
         "plotlines" : {
           "high" : null,
           "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 3,
+    "revisionNumber" : 5,
+    "uiHelperValue" : "##CHARTID##_5"
+  }
+}, {
+  "marshallId" : 5,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Connection States",
+  "sf_chartIndex" : 1440781311595,
+  "sf_description" : "",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_6=id(report=1);A => find(query='(sf_metric:connections.* AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0) AND (plugin_instance:*\\\\-backend))') -> fetch -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_6 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "sf_metric"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
         },
-        "id" : "yAxis0"
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
       }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "*-backend",
+        "query" : "plugin_instance:*\\-backend",
+        "type" : "property",
+        "value" : "plugin_instance:*-backend"
+      } ],
+      "seriesData" : {
+        "metric" : "connections.*"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "connections / sec",
         "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 3,
+    "revisionNumber" : 6,
+    "uiHelperValue" : "##CHARTID##_6"
+  }
+}, {
+  "marshallId" : 6,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Total Request Bytes",
+  "sf_chartIndex" : 1440780872072,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_7=id(report=1);A => find(query='(sf_metric:total_bytes.req_body AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_7 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');B => find(query='(sf_metric:total_bytes.req_header AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_7 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "total_bytes.req_body",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      } ],
+      "seriesData" : {
+        "metric" : "total_bytes.req_body"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "total_bytes.req_header",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      } ],
+      "seriesData" : {
+        "metric" : "total_bytes.req_header"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "bytes / sec",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 4,
+    "revisionNumber" : 7,
+    "uiHelperValue" : "##CHARTID##_7"
+  }
+}, {
+  "marshallId" : 7,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "VCL on Host",
+  "sf_chartIndex" : 1441041836777,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_5=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_5=id(report=1);A => find(query='(sf_metric:vcl.total_vcl AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5');B => find(query='(sf_metric:vcl.avail_vcl AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5');C => find(query='(sf_metric:vcl.discarded_vcl AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Total VCL",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      } ],
+      "seriesData" : {
+        "metric" : "vcl.total_vcl"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Available VCL",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      } ],
+      "seriesData" : {
+        "metric" : "vcl.avail_vcl"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Discarded VCL",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      } ],
+      "seriesData" : {
+        "metric" : "vcl.discarded_vcl"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "VCL count",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 5,
+    "revisionNumber" : 5,
+    "uiHelperValue" : "##CHARTID##_5"
+  }
+}, {
+  "marshallId" : 8,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Total Response Bytes",
+  "sf_chartIndex" : 1440780940034,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_5=id(report=1);A => find(query='(sf_metric:total_bytes.resp_body AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5');B => find(query='(sf_metric:total_bytes.resp_header AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "total_bytes.resp_body",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      } ],
+      "seriesData" : {
+        "metric" : "total_bytes.resp_body"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "total_bytes.resp_header",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      } ],
+      "seriesData" : {
+        "metric" : "total_bytes.resp_header"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "bytes / sec",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 4,
+    "revisionNumber" : 5,
+    "uiHelperValue" : "##CHARTID##_5"
+  }
+}, {
+  "marshallId" : 9,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Uptime",
+  "sf_chartIndex" : 1441040394089,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_7=id(report=1);B => _SF_PLOT_KEY_##CHARTID##_2_7_MACROBLOCK=[?A,!OUT]{?A / (60 * 60 * 24)->!OUT};A => find(query='(sf_metric:uptime.client_uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_7 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');_SF_PLOT_KEY_##CHARTID##_2_7_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_2_7->publish(metric='_SF_PLOT_KEY_##CHARTID##_2_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');_SF_PLOT_KEY_##CHARTID##_1_7->?A:_SF_PLOT_KEY_##CHARTID##_2_7_MACROBLOCK",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Seconds",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      } ],
+      "seriesData" : {
+        "metric" : "uptime.client_uptime"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "expressionText" : "A/(60*60*24)",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Days",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      } ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 2,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "list",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "maxDecimalPlaces" : 2,
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "+value",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 4,
+    "revisionNumber" : 7,
+    "uiHelperValue" : "##CHARTID##_7"
+  }
+}, {
+  "marshallId" : 10,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Cache Results/sec",
+  "sf_chartIndex" : 1440618213590,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_10=id(report=1);A => find(query='(sf_metric:cache_result.hit AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch(maxExtrapolations=-1) -> groupby('host') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');B => find(query='(sf_metric:cache_result.miss AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch(maxExtrapolations=-1) -> groupby('host') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');C => find(query='(sf_metric:cache_result.hitpass AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch(maxExtrapolations=-1) -> groupby('host') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "colorOverride" : "#05ce00",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "cache_hit",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      } ],
+      "seriesData" : {
+        "metric" : "cache_result.hit"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "cache_miss",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      } ],
+      "seriesData" : {
+        "metric" : "cache_result.miss"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#00b9ff",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "cache_hitpass",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      } ],
+      "seriesData" : {
+        "metric" : "cache_result.hitpass"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "results / sec",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 5,
+    "revisionNumber" : 10,
+    "uiHelperValue" : "##CHARTID##_10"
+  }
+}, {
+  "marshallId" : 11,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Bytes/sec",
+  "sf_chartIndex" : 1441231423837,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_6_MACROBLOCK=[?A,?B,!OUT]{?A + ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_4_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_6_MACROBLOCK=[?D,?E,!OUT]{?D + ?E->!OUT};find(query='(sf_metric:total_bytes.resp_body AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_6;find(query='(sf_metric:total_bytes.resp_header AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_6;_SF_PLOT_KEY_##CHARTID##_3_6_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_6->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');_SF_PLOT_KEY_##CHARTID##_1_6->?A:_SF_PLOT_KEY_##CHARTID##_3_6_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_6->?B:_SF_PLOT_KEY_##CHARTID##_3_6_MACROBLOCK;find(query='(sf_metric:total_bytes.req_body AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_4_6;find(query='(sf_metric:total_bytes.req_header AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_5_6;_SF_PLOT_KEY_##CHARTID##_6_6_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_6_6->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');_SF_PLOT_KEY_##CHARTID##_4_6->?D:_SF_PLOT_KEY_##CHARTID##_6_6_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_6->?E:_SF_PLOT_KEY_##CHARTID##_6_6_MACROBLOCK",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "total_bytes.resp_body",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      } ],
+      "seriesData" : {
+        "metric" : "total_bytes.resp_body"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "total_bytes.resp_header",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      } ],
+      "seriesData" : {
+        "metric" : "total_bytes.resp_header"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "expressionText" : "A+B",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "response bytes/sec",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      } ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 1
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "total_bytes.req_body",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      } ],
+      "seriesData" : {
+        "metric" : "total_bytes.req_body"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "total_bytes.req_header",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      } ],
+      "seriesData" : {
+        "metric" : "total_bytes.req_header"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 5,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "expressionText" : "D+E",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "request bytes/sec",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      } ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 6,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 7,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "column",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "forcedResolution" : "0",
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "request - RED",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
         "label" : "response - BLUE",
+        "max" : null,
+        "min" : 0,
         "plotlines" : {
           "high" : null,
           "low" : null
         },
         "title" : {
           "text" : ""
-        },
-        "min" : 0
-      } ],
-      "sortPreference" : "",
-      "forcedResolution" : "0"
+        }
+      } ]
     },
-    "relatedDetectors" : [ ],
-    "currentUniqueKey" : 8
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK=[?A,?B,!OUT]{?A + ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_4_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_9_MACROBLOCK=[?D,?E,!OUT]{?D + ?E->!OUT};find(query='(sf_metric:total_bytes.resp_body AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_9;find(query='(sf_metric:total_bytes.resp_header AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_9;_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_9->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');_SF_PLOT_KEY_##CHARTID##_1_9->?A:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_9->?B:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK;find(query='(sf_metric:total_bytes.req_body AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_9;find(query='(sf_metric:total_bytes.req_header AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_5_9;_SF_PLOT_KEY_##CHARTID##_6_9_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_6_9->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');_SF_PLOT_KEY_##CHARTID##_4_9->?D:_SF_PLOT_KEY_##CHARTID##_6_9_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_9->?E:_SF_PLOT_KEY_##CHARTID##_6_9_MACROBLOCK",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1441301459735,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 1000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK=[?A,?B,!OUT]{?A + ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_4_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_9_MACROBLOCK=[?D,?E,!OUT]{?D + ?E->!OUT};find(query='(sf_metric:total_bytes.resp_body AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');find(query='(sf_metric:total_bytes.resp_header AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_9->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');_SF_PLOT_KEY_##CHARTID##_1_9->?A:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_9->?B:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK;find(query='(sf_metric:total_bytes.req_body AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');find(query='(sf_metric:total_bytes.req_header AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_5_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_5_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');_SF_PLOT_KEY_##CHARTID##_6_9_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_6_9->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');_SF_PLOT_KEY_##CHARTID##_4_9->?D:_SF_PLOT_KEY_##CHARTID##_6_9_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_9->?E:_SF_PLOT_KEY_##CHARTID##_6_9_MACROBLOCK",
-  "marshallId" : 4,
-  "marshallMemberOf" : [ 3 ]
+    "currentUniqueKey" : 8,
+    "revisionNumber" : 6,
+    "uiHelperValue" : "##CHARTID##_6"
+  }
 }, {
-  "sf_chart" : "Connection States",
-  "sf_uiModel" : {
-    "revisionNumber" : 4,
-    "chartType" : "area",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "",
-      "seriesData" : {
-        "metric" : "connections.*"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "sf_metric"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 2,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_4",
-    "chartMode" : "graph",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "stackedChart" : true,
-      "colorByMetric" : true,
-      "range" : -3600000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
-        "max" : null,
-        "label" : "connections / sec",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "",
-      "disableThrottle" : false
-    },
-    "relatedDetectors" : [ ],
-    "currentUniqueKey" : 3
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_4=id(report=1);A => find(query='(sf_metric:connections.* AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_4 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_4')",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1440781311595,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 1000,
-  "sf_throttledProgramText" : "",
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_4=id(report=1);A => find(query='(sf_metric:connections.* AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_4 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_4')",
-  "marshallId" : 5,
-  "marshallMemberOf" : [ 3 ]
-}, {
-  "sf_chart" : "Worker Thread Distribution",
-  "sf_uiModel" : {
-    "revisionNumber" : 11,
-    "chartType" : "area",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "min",
-      "seriesData" : { },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MIN",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "D",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#007c1d",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
-      "name" : "median",
-      "seriesData" : { },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "PERCENTILE",
-          "options" : {
-            "percentile" : 50
-          }
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "D",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#0077c2",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 3,
-      "name" : "max",
-      "seriesData" : { },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MAX",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "D",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#bd468d",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 4,
-      "name" : "threads.worker",
-      "seriesData" : {
-        "metric" : "threads.worker"
-      },
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 5,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_11",
-    "chartMode" : "graph",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "stackedChart" : false,
-      "colorByMetric" : false,
-      "range" : -3600000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
-        "max" : null,
-        "label" : "# threads",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "",
-      "disableThrottle" : false
-    },
-    "relatedDetectors" : [ ],
-    "currentUniqueKey" : 12
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_7_11=id(report=1);G => _SF_PLOT_KEY_##CHARTID##_7_11_MACROBLOCK=[?J,!OUT]{?J->!OUT};_SF_PLOT_KEY_##CHARTID##_8_11=id(report=1);H => _SF_PLOT_KEY_##CHARTID##_8_11_MACROBLOCK=[?J,!OUT]{?J->!OUT};_SF_PLOT_KEY_##CHARTID##_9_11=id(report=1);I => _SF_PLOT_KEY_##CHARTID##_9_11_MACROBLOCK=[?J,!OUT]{?J->!OUT};_SF_PLOT_KEY_##CHARTID##_10_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_11_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_7_11->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_10_11->?J:_SF_PLOT_KEY_##CHARTID##_7_11_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_11_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_8_11->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_10_11->?J:_SF_PLOT_KEY_##CHARTID##_8_11_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_9_11_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_9_11->publish(metric='_SF_PLOT_KEY_##CHARTID##_9_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_10_11->?J:_SF_PLOT_KEY_##CHARTID##_9_11_MACROBLOCK;J => find(query='(sf_metric:threads.worker AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_10_11",
-  "sf_cacheProgram" : false,
-  "sf_description" : "percentiles",
-  "sf_chartIndex" : 1441233341000,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 1000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_7_11=id(report=1);G => _SF_PLOT_KEY_##CHARTID##_7_11_MACROBLOCK=[?J,!OUT]{?J->!OUT};_SF_PLOT_KEY_##CHARTID##_8_11=id(report=1);H => _SF_PLOT_KEY_##CHARTID##_8_11_MACROBLOCK=[?J,!OUT]{?J->!OUT};_SF_PLOT_KEY_##CHARTID##_9_11=id(report=1);I => _SF_PLOT_KEY_##CHARTID##_9_11_MACROBLOCK=[?J,!OUT]{?J->!OUT};_SF_PLOT_KEY_##CHARTID##_10_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_11_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_7_11->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_10_11->?J:_SF_PLOT_KEY_##CHARTID##_7_11_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_11_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_8_11->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_10_11->?J:_SF_PLOT_KEY_##CHARTID##_8_11_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_9_11_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_9_11->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_9_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_10_11->?J:_SF_PLOT_KEY_##CHARTID##_9_11_MACROBLOCK;J => find(query='(sf_metric:threads.worker AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_10_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_10_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11')",
-  "marshallId" : 6,
-  "marshallMemberOf" : [ 3 ]
-}, {
-  "sf_chart" : "Cache Results",
-  "sf_uiModel" : {
-    "revisionNumber" : 5,
-    "chartType" : "area",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "cache_hit",
-      "seriesData" : {
-        "metric" : "cache_result.hit"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#007c1d",
-        "rollupPolicy" : null,
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
-      "name" : "cache_miss",
-      "seriesData" : {
-        "metric" : "cache_result.miss"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#b04600",
-        "rollupPolicy" : null,
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 3,
-      "name" : "cache_hitpass",
-      "seriesData" : {
-        "metric" : "cache_result.hitpass"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#876ff3",
-        "rollupPolicy" : null,
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 4,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_5",
-    "chartMode" : "graph",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "stackedChart" : true,
-      "colorByMetric" : true,
-      "range" : -3600000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
-        "max" : null,
-        "label" : "count / sec",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "",
-      "disableThrottle" : false
-    },
-    "relatedDetectors" : [ ],
-    "currentUniqueKey" : 5
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_5=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_5=id(report=1);A => find(query='(sf_metric:cache_result.hit AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5');B => find(query='(sf_metric:cache_result.miss AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5');C => find(query='(sf_metric:cache_result.hitpass AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1440618213590,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 1000,
-  "sf_throttledProgramText" : "",
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_5=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_5=id(report=1);A => find(query='(sf_metric:cache_result.hit AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_5 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5');B => find(query='(sf_metric:cache_result.miss AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_5 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5');C => find(query='(sf_metric:cache_result.hitpass AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_5 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
-  "marshallId" : 7,
-  "marshallMemberOf" : [ 3 ]
-}, {
-  "sf_chart" : "Session Operations / sec",
-  "sf_uiModel" : {
-    "revisionNumber" : 4,
-    "chartType" : "line",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "",
-      "seriesData" : {
-        "metric" : "total_operations.*"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "sf_metric"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 2,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_4",
-    "chartMode" : "list",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "colorByMetric" : true,
-      "range" : -3600000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "max" : null,
-        "min" : null,
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "name" : "yAxis0",
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "+sf_originatingMetric",
-      "disableThrottle" : false
-    },
-    "currentUniqueKey" : 3
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_4=id(report=1);A => find(query='(sf_metric:total_operations.* AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_4 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_4')",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1441302597692,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 10000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_4=id(report=1);A => find(query='(sf_metric:total_operations.* AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_4 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_4')",
-  "marshallId" : 8,
-  "marshallMemberOf" : [ 3 ]
-}, {
-  "sf_chart" : "Shared Memory Operations",
-  "sf_uiModel" : {
-    "revisionNumber" : 3,
-    "chartType" : "area",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "",
-      "seriesData" : {
-        "metric" : "total_operations.*"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "sf_metric"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : null,
-        "rollupPolicy" : null,
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "AUTO"
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 2,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_3",
-    "chartMode" : "graph",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "stackedChart" : true,
-      "colorByMetric" : true,
-      "range" : -3600000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
-        "max" : null,
-        "label" : "ops / sec",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "",
-      "disableThrottle" : false
-    },
-    "relatedDetectors" : [ ],
-    "currentUniqueKey" : 3
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_3=id(report=1);A => find(query='(sf_metric:total_operations.* AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch(maxExtrapolations=-1) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_3 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1440781506039,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 1000,
-  "sf_throttledProgramText" : "",
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_3=id(report=1);A => find(query='(sf_metric:total_operations.* AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch(maxExtrapolations=-1) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_3 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')",
-  "marshallId" : 9,
-  "marshallMemberOf" : [ 3 ]
-}, {
-  "sf_chart" : "# Servers",
-  "sf_uiModel" : {
-    "revisionNumber" : 7,
-    "chartType" : "line",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "Server count",
-      "seriesData" : {
-        "metric" : "uptime.client_uptime"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "host"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      }, {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "COUNT",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#05ce00",
-        "rollupPolicy" : null,
-        "maxExtrapolations" : 5,
-        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION"
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 2,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_7",
-    "chartMode" : "single",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "range" : -3600000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "max" : null,
-        "min" : null,
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "name" : "yAxis0",
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "",
-      "disableThrottle" : false
-    },
-    "currentUniqueKey" : 4
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_2_7=id(report=1);B => find(query='(sf_metric:uptime.client_uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby('host') -> stats:!sum -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_2_7 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1441044802676,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 10000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_2_7=id(report=1);B => find(query='(sf_metric:uptime.client_uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby('host') -> stats:!sum -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_2_7 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
-  "marshallId" : 10,
-  "marshallMemberOf" : [ 3 ]
-}, {
-  "sf_chart" : "Overall Hit Rate %",
-  "sf_uiModel" : {
-    "revisionNumber" : 10,
-    "chartType" : "line",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "cache_result.hit - Sum",
-      "seriesData" : {
-        "metric" : "cache_result.hit"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null,
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
-      "name" : "cache_result.miss - Sum",
-      "seriesData" : {
-        "metric" : "cache_result.miss",
-        "regExStyle" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 3,
-      "name" : "hit rate percentage",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "expressionText" : "A/(A+B) * 100",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#05ce00",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "AUTO"
-      },
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 5,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_10",
-    "chartMode" : "single",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "stackedChart" : false,
-      "colorByMetric" : false,
-      "range" : -3600000,
-      "maxDecimalPlaces" : 3,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
-        "max" : 110,
-        "label" : "hit %",
-        "plotlines" : {
-          "high" : 100,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "",
-      "disableThrottle" : false
-    },
-    "relatedDetectors" : [ ],
-    "currentUniqueKey" : 7
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_10_MACROBLOCK=[?A,?B,!OUT]{?A / (?A + ?B)  *  100->!OUT};find(query='(sf_metric:cache_result.hit AND _missing_:sf_programId) AND ((plugin:varnish))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_10;find(query='(sf_metric:cache_result.miss AND _missing_:sf_programId) AND ((plugin:varnish))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_10;_SF_PLOT_KEY_##CHARTID##_3_10_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_10->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');_SF_PLOT_KEY_##CHARTID##_1_10->?A:_SF_PLOT_KEY_##CHARTID##_3_10_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_10->?B:_SF_PLOT_KEY_##CHARTID##_3_10_MACROBLOCK",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1440618403043,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 10000,
-  "sf_throttledProgramText" : "",
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_10_MACROBLOCK=[?A,?B,!OUT]{?A / (?A + ?B)  *  100->!OUT};find(query='(sf_metric:cache_result.hit AND _missing_:sf_programId) AND ((plugin:varnish))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');find(query='(sf_metric:cache_result.miss AND _missing_:sf_programId) AND ((plugin:varnish))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');_SF_PLOT_KEY_##CHARTID##_3_10_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_10->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');_SF_PLOT_KEY_##CHARTID##_1_10->?A:_SF_PLOT_KEY_##CHARTID##_3_10_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_10->?B:_SF_PLOT_KEY_##CHARTID##_3_10_MACROBLOCK",
-  "marshallId" : 11,
-  "marshallMemberOf" : [ 3 ]
-}, {
-  "sf_chart" : "Hit Rate %",
-  "sf_uiModel" : {
-    "revisionNumber" : 13,
-    "chartType" : "area",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "cache_result.hit - Sum by host",
-      "seriesData" : {
-        "metric" : "cache_result.hit"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "host"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
-      "name" : "cache_result.miss - Sum by host",
-      "seriesData" : {
-        "metric" : "cache_result.miss",
-        "regExStyle" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "host"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 3,
-      "name" : "hit rate percentage",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "expressionText" : "A/(A+B) * 100",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#05ce00",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "AUTO"
-      },
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 4,
-      "name" : "cache_result.hitpass - Sum by host",
-      "seriesData" : {
-        "metric" : "cache_result.hitpass"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "host"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 5,
-      "name" : "min",
-      "seriesData" : { },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MIN",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "C",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#05ce00",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 6,
-      "name" : "median",
-      "seriesData" : { },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "PERCENTILE",
-          "options" : {
-            "percentile" : 50
-          }
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "C",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#00b9ff",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 7,
-      "name" : "max",
-      "seriesData" : { },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MAX",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "C",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#bd468d",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 8,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_13",
-    "chartMode" : "graph",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "stackedChart" : false,
-      "forcedResolution" : "0",
-      "colorByMetric" : false,
-      "range" : -3600000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
-        "max" : 110,
-        "label" : "hit rate %",
-        "plotlines" : {
-          "high" : 100,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "",
-      "disableThrottle" : false
-    },
-    "relatedDetectors" : [ ],
-    "currentUniqueKey" : 11
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_13_MACROBLOCK=[?A,?B,!OUT]{?A / (?A + ?B)  *  100->!OUT};_SF_PLOT_KEY_##CHARTID##_4_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_13_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_6_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_13_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_7_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_13_MACROBLOCK=[?C,!OUT]{?C->!OUT};find(query='(sf_metric:cache_result.hit AND _missing_:sf_programId) AND ((plugin:varnish))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_13;find(query='(sf_metric:cache_result.miss AND _missing_:sf_programId) AND ((plugin:varnish))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_13;_SF_PLOT_KEY_##CHARTID##_3_13_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_13->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');_SF_PLOT_KEY_##CHARTID##_1_13->?A:_SF_PLOT_KEY_##CHARTID##_3_13_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_13->?B:_SF_PLOT_KEY_##CHARTID##_3_13_MACROBLOCK;find(query='(sf_metric:cache_result.hitpass AND _missing_:sf_programId) AND ((plugin:varnish))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_13;_SF_PLOT_KEY_##CHARTID##_5_13_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_5_13->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');_SF_PLOT_KEY_##CHARTID##_3_13->?C:_SF_PLOT_KEY_##CHARTID##_5_13_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_13_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_6_13->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');_SF_PLOT_KEY_##CHARTID##_3_13->?C:_SF_PLOT_KEY_##CHARTID##_6_13_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_13_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_7_13->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');_SF_PLOT_KEY_##CHARTID##_3_13->?C:_SF_PLOT_KEY_##CHARTID##_7_13_MACROBLOCK",
-  "sf_cacheProgram" : false,
-  "sf_description" : "percentile distribution",
-  "sf_chartIndex" : 1441232963548,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 1000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_13_MACROBLOCK=[?A,?B,!OUT]{?A / (?A + ?B)  *  100->!OUT};_SF_PLOT_KEY_##CHARTID##_4_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_13_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_6_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_13_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_7_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_13_MACROBLOCK=[?C,!OUT]{?C->!OUT};find(query='(sf_metric:cache_result.hit AND _missing_:sf_programId) AND ((plugin:varnish))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:cache_result.miss AND _missing_:sf_programId) AND ((plugin:varnish))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');_SF_PLOT_KEY_##CHARTID##_3_13_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_13->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');_SF_PLOT_KEY_##CHARTID##_1_13->?A:_SF_PLOT_KEY_##CHARTID##_3_13_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_13->?B:_SF_PLOT_KEY_##CHARTID##_3_13_MACROBLOCK;find(query='(sf_metric:cache_result.hitpass AND _missing_:sf_programId) AND ((plugin:varnish))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');_SF_PLOT_KEY_##CHARTID##_5_13_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_5_13->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');_SF_PLOT_KEY_##CHARTID##_3_13->?C:_SF_PLOT_KEY_##CHARTID##_5_13_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_13_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_6_13->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');_SF_PLOT_KEY_##CHARTID##_3_13->?C:_SF_PLOT_KEY_##CHARTID##_6_13_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_13_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_7_13->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');_SF_PLOT_KEY_##CHARTID##_3_13->?C:_SF_PLOT_KEY_##CHARTID##_7_13_MACROBLOCK",
   "marshallId" : 12,
-  "marshallMemberOf" : [ 3 ]
-}, {
-  "sf_chart" : "Connection Rate/sec",
-  "sf_uiModel" : {
-    "revisionNumber" : 11,
-    "chartType" : "area",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "connections.received - Sum by host",
-      "seriesData" : {
-        "metric" : "connections.received"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "host"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
-      "name" : "min",
-      "seriesData" : { },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MIN",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "A",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#05ce00",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 3,
-      "name" : "median",
-      "seriesData" : { },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "PERCENTILE",
-          "options" : {
-            "percentile" : 50
-          }
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "A",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#00b9ff",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 4,
-      "name" : "max",
-      "seriesData" : { },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MAX",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "A",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#bd468d",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 5,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_11",
-    "chartMode" : "graph",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "stackedChart" : false,
-      "forcedResolution" : "0",
-      "colorByMetric" : false,
-      "range" : -3600000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
-        "max" : null,
-        "label" : "conns/sec",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "",
-      "disableThrottle" : false
-    },
-    "relatedDetectors" : [ ],
-    "currentUniqueKey" : 11
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_2_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_11_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_8_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_11_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_9_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_9_11_MACROBLOCK=[?B,!OUT]{?B->!OUT};find(query='(sf_metric:connections.received AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch -> groupby('host') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_11;_SF_PLOT_KEY_##CHARTID##_7_11_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_7_11->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_2_11->?B:_SF_PLOT_KEY_##CHARTID##_7_11_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_11_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_8_11->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_2_11->?B:_SF_PLOT_KEY_##CHARTID##_8_11_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_9_11_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_9_11->publish(metric='_SF_PLOT_KEY_##CHARTID##_9_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_2_11->?B:_SF_PLOT_KEY_##CHARTID##_9_11_MACROBLOCK",
-  "sf_cacheProgram" : false,
-  "sf_description" : "percentile distribution",
-  "sf_chartIndex" : 1441302803911,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 1000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_2_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_11_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_8_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_11_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_9_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_9_11_MACROBLOCK=[?B,!OUT]{?B->!OUT};find(query='(sf_metric:connections.received AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch -> groupby('host') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_7_11_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_7_11->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_2_11->?B:_SF_PLOT_KEY_##CHARTID##_7_11_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_11_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_8_11->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_2_11->?B:_SF_PLOT_KEY_##CHARTID##_8_11_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_9_11_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_9_11->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_9_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_2_11->?B:_SF_PLOT_KEY_##CHARTID##_9_11_MACROBLOCK",
-  "marshallId" : 13,
-  "marshallMemberOf" : [ 3 ]
-}, {
-  "sf_chart" : "Total Connection Rate/sec",
-  "sf_uiModel" : {
-    "revisionNumber" : 5,
-    "chartType" : "area",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "connections.received - Sum",
-      "seriesData" : {
-        "metric" : "connections.received"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 2,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_5",
-    "chartMode" : "graph",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "forcedResolution" : "0",
-      "colorByMetric" : false,
-      "range" : -3600000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
-        "max" : null,
-        "label" : "conns / sec",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "",
-      "disableThrottle" : false
-    },
-    "relatedDetectors" : [ ],
-    "currentUniqueKey" : 3
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);find(query='(sf_metric:connections.received AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1440618052144,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 1000,
-  "sf_throttledProgramText" : "",
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);find(query='(sf_metric:connections.received AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_5 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
-  "marshallId" : 14,
-  "marshallMemberOf" : [ 3 ]
-}, {
-  "sf_filterAlias" : {
-    "variables" : [ {
-      "dimension" : "host",
-      "alias" : "host",
-      "globalScope" : true,
-      "required" : true,
-      "description" : "Varnish node",
-      "restricted" : false,
-      "preferredSuggestions" : [ ]
-    } ]
-  },
-  "sf_dashboard" : "Varnish",
-  "sf_uiModel" : {
-    "widgets" : [ {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 0,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1440618403043,
-        "id" : 1
-      },
-      "row" : 0
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 8,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1440781311595,
-        "id" : 2
-      },
-      "row" : 0
-    }, {
-      "sizeX" : 4,
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1440618213590,
-        "id" : 3
-      },
-      "type" : "chart",
-      "col" : 4,
-      "row" : 0
-    }, {
-      "sizeX" : 4,
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1440618052144,
-        "id" : 4
-      },
-      "type" : "chart",
-      "col" : 8,
-      "row" : 1
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 0,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1440781752695,
-        "id" : 6
-      },
-      "row" : 1
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 4,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1440782296628,
-        "id" : 5
-      },
-      "row" : 1
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 0,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1441040394089,
-        "id" : 7
-      },
-      "row" : 2
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 8,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1440780940034,
-        "id" : 9
-      },
-      "row" : 2
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 4,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1440780872072,
-        "id" : 8
-      },
-      "row" : 2
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 8,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1441231423837,
-        "id" : 11
-      },
-      "row" : 3
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 2,
-      "col" : 0,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1441232232693,
-        "id" : 12
-      },
-      "row" : 3
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 4,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1441231853402,
-        "id" : 10
-      },
-      "row" : 3
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 8,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1441041836777,
-        "id" : 13
-      },
-      "row" : 4
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 4,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1440781506039,
-        "id" : 14
-      },
-      "row" : 4
-    } ],
-    "version" : 1
-  },
-  "sf_discoverySelectors" : [ "_exists_:host" ],
-  "sf_description" : "Single host",
-  "sf_type" : "Dashboard",
-  "sf_discoveryQuery" : "plugin:varnish",
-  "marshallId" : 15,
-  "marshallMemberOf" : [ 2 ]
-}, {
-  "sf_chart" : "Total Response Bytes",
-  "sf_uiModel" : {
-    "revisionNumber" : 5,
-    "chartType" : "line",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "total_bytes.resp_body",
-      "seriesData" : {
-        "metric" : "total_bytes.resp_body"
-      },
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
-      "name" : "total_bytes.resp_header",
-      "seriesData" : {
-        "metric" : "total_bytes.resp_header"
-      },
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 3,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_5",
-    "chartMode" : "graph",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "stackedChart" : true,
-      "colorByMetric" : false,
-      "range" : -3600000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : null,
-        "max" : null,
-        "label" : "bytes / sec",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : ""
-    },
-    "currentUniqueKey" : 4
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_5=id(report=1);A => find(query='(sf_metric:total_bytes.resp_body AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5');B => find(query='(sf_metric:total_bytes.resp_header AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1440780940034,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 1000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_5=id(report=1);A => find(query='(sf_metric:total_bytes.resp_body AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_5 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5');B => find(query='(sf_metric:total_bytes.resp_header AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_5 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
-  "marshallId" : 16,
-  "marshallMemberOf" : [ 15 ]
-}, {
-  "sf_chart" : "Cache Results/sec",
-  "sf_uiModel" : {
-    "revisionNumber" : 10,
-    "chartType" : "area",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "cache_hit",
-      "seriesData" : {
-        "metric" : "cache_result.hit"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "host"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#05ce00",
-        "rollupPolicy" : null,
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "AUTO"
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
-      "name" : "cache_miss",
-      "seriesData" : {
-        "metric" : "cache_result.miss"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "host"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#b04600",
-        "rollupPolicy" : null,
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "AUTO"
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 3,
-      "name" : "cache_hitpass",
-      "seriesData" : {
-        "metric" : "cache_result.hitpass"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "host"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#00b9ff",
-        "rollupPolicy" : null,
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "AUTO"
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 4,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_10",
-    "chartMode" : "graph",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "stackedChart" : true,
-      "colorByMetric" : true,
-      "range" : -3600000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
-        "max" : null,
-        "label" : "results / sec",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : ""
-    },
-    "currentUniqueKey" : 5
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_10=id(report=1);A => find(query='(sf_metric:cache_result.hit AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch(maxExtrapolations=-1) -> groupby('host') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');B => find(query='(sf_metric:cache_result.miss AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch(maxExtrapolations=-1) -> groupby('host') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');C => find(query='(sf_metric:cache_result.hitpass AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch(maxExtrapolations=-1) -> groupby('host') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10')",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1440618213590,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 1000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_10=id(report=1);A => find(query='(sf_metric:cache_result.hit AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch(maxExtrapolations=-1) -> groupby('host') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');B => find(query='(sf_metric:cache_result.miss AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch(maxExtrapolations=-1) -> groupby('host') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');C => find(query='(sf_metric:cache_result.hitpass AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch(maxExtrapolations=-1) -> groupby('host') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10')",
-  "marshallId" : 17,
-  "marshallMemberOf" : [ 15 ]
-}, {
-  "sf_chart" : "Connection States",
-  "sf_uiModel" : {
-    "revisionNumber" : 6,
-    "chartType" : "area",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "plugin_instance:*-backend",
-        "propertyValue" : "*-backend",
-        "NOT" : false,
-        "query" : "plugin_instance:*\\-backend",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "",
-      "seriesData" : {
-        "metric" : "connections.*"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "sf_metric"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 2,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_6",
-    "chartMode" : "graph",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "colorByMetric" : true,
-      "range" : -3600000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : null,
-        "max" : null,
-        "label" : "connections / sec",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : ""
-    },
-    "currentUniqueKey" : 3
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_6=id(report=1);A => find(query='(sf_metric:connections.* AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0) AND (plugin_instance:*\\\\-backend))') -> fetch -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_6 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6')",
-  "sf_cacheProgram" : false,
-  "sf_description" : "",
-  "sf_chartIndex" : 1440781311595,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 1000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_6=id(report=1);A => find(query='(sf_metric:connections.* AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0) AND (plugin_instance:*\\\\-backend))') -> fetch -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_6 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6')",
-  "marshallId" : 18,
-  "marshallMemberOf" : [ 15 ]
-}, {
+  "marshallMemberOf" : [ 3 ],
   "sf_chart" : "Session Operations/sec",
-  "sf_uiModel" : {
-    "revisionNumber" : 6,
-    "chartType" : "line",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "plugin_instance:*-session",
-        "propertyValue" : "*-session",
-        "NOT" : false,
-        "query" : "plugin_instance:*\\-session",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "",
-      "seriesData" : {
-        "metric" : "total_operations.*"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "sf_metric"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 2,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_6",
-    "chartMode" : "list",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "stackedChart" : true,
-      "colorByMetric" : true,
-      "range" : -3600000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "max" : null,
-        "min" : null,
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "name" : "yAxis0",
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "+sf_originatingMetric"
-    },
-    "currentUniqueKey" : 3
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_6=id(report=1);A => find(query='(sf_metric:total_operations.* AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0) AND (plugin_instance:*\\\\-session))') -> fetch -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_6 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6')",
-  "sf_cacheProgram" : false,
   "sf_chartIndex" : 1441232232693,
   "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
   "sf_jobResolution" : 10000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_6=id(report=1);A => find(query='(sf_metric:total_operations.* AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0) AND (plugin_instance:*\\\\-session))') -> fetch -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_6 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6')",
-  "marshallId" : 19,
-  "marshallMemberOf" : [ 15 ]
-}, {
-  "sf_chart" : "VCL on Host",
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);find(query='(sf_metric:total_operations.* AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0) AND (plugin_instance:*\\\\-session))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_7 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
+  "sf_type" : "Chart",
   "sf_uiModel" : {
-    "revisionNumber" : 5,
-    "chartType" : "area",
     "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "sf_metric"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
       } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "*-session",
+        "query" : "plugin_instance:*\\-session",
+        "type" : "property",
+        "value" : "plugin_instance:*-session"
+      } ],
+      "seriesData" : {
+        "metric" : "total_operations.*"
+      },
+      "transient" : false,
+      "type" : "plot",
       "uniqueKey" : 1,
-      "name" : "Total VCL",
-      "seriesData" : {
-        "metric" : "vcl.total_vcl"
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
       },
       "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
       "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
-      "name" : "Available VCL",
-      "seriesData" : {
-        "metric" : "vcl.avail_vcl"
-      },
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
       "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 3,
-      "name" : "Discarded VCL",
-      "seriesData" : {
-        "metric" : "vcl.discarded_vcl"
-      },
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 4,
+      "metricDefinition" : { },
       "name" : "New Plot",
+      "queryItems" : [ ],
       "seriesData" : { },
-      "dataManipulations" : [ ],
       "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
       "type" : "plot",
-      "metricDefinition" : { }
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
     } ],
-    "uiHelperValue" : "##CHARTID##_5",
-    "chartMode" : "graph",
+    "chartMode" : "list",
+    "chartType" : "line",
     "chartconfig" : {
       "absoluteEnd" : null,
-      "rangeEnd" : 0,
       "absoluteStart" : null,
-      "stackedChart" : true,
       "colorByMetric" : true,
+      "legendColumnConfiguration" : [ {
+        "enabled" : true,
+        "property" : "sf_originatingMetric"
+      }, {
+        "enabled" : false,
+        "property" : "sf_metric"
+      } ],
       "range" : -3600000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
-        "max" : null,
-        "label" : "VCL count",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : ""
-    },
-    "currentUniqueKey" : 5
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_5=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_5=id(report=1);A => find(query='(sf_metric:vcl.total_vcl AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5');B => find(query='(sf_metric:vcl.avail_vcl AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5');C => find(query='(sf_metric:vcl.discarded_vcl AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1441041836777,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 1000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_5=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_5=id(report=1);A => find(query='(sf_metric:vcl.total_vcl AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_5 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5');B => find(query='(sf_metric:vcl.avail_vcl AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_5 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5');C => find(query='(sf_metric:vcl.discarded_vcl AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_5 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
-  "marshallId" : 20,
-  "marshallMemberOf" : [ 15 ]
-}, {
-  "sf_chart" : "Total Request Bytes",
-  "sf_uiModel" : {
-    "revisionNumber" : 7,
-    "chartType" : "line",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "total_bytes.req_body",
-      "seriesData" : {
-        "metric" : "total_bytes.req_body"
-      },
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
-      "name" : "total_bytes.req_header",
-      "seriesData" : {
-        "metric" : "total_bytes.req_header"
-      },
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 3,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_7",
-    "chartMode" : "graph",
-    "chartconfig" : {
-      "absoluteEnd" : null,
       "rangeEnd" : 0,
-      "absoluteStart" : null,
+      "sortPreference" : "+sf_originatingMetric",
       "stackedChart" : true,
-      "colorByMetric" : false,
-      "range" : -3600000,
       "updateInterval" : "",
       "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : null,
+        "id" : "yAxis0",
         "max" : null,
-        "label" : "bytes / sec",
+        "min" : null,
+        "name" : "yAxis0",
         "plotlines" : {
           "high" : null,
           "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : ""
+        }
+      } ]
     },
-    "currentUniqueKey" : 4
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_7=id(report=1);A => find(query='(sf_metric:total_bytes.req_body AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_7 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');B => find(query='(sf_metric:total_bytes.req_header AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_7 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1440780872072,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 1000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_7=id(report=1);A => find(query='(sf_metric:total_bytes.req_body AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_7 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');B => find(query='(sf_metric:total_bytes.req_header AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_7 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
-  "marshallId" : 21,
-  "marshallMemberOf" : [ 15 ]
+    "currentUniqueKey" : 3,
+    "revisionNumber" : 7,
+    "uiHelperValue" : "##CHARTID##_7"
+  }
 }, {
+  "marshallId" : 13,
+  "marshallMemberOf" : [ 3 ],
   "sf_chart" : "Backend count",
+  "sf_chartIndex" : 1440782296628,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_3=id(report=1);A => find(query='(sf_metric:backends.n_backends AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_3 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')",
+  "sf_type" : "Chart",
   "sf_uiModel" : {
-    "revisionNumber" : 3,
-    "chartType" : "line",
     "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
       "name" : "Backend count",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      } ],
       "seriesData" : {
         "metric" : "backends.n_backends"
       },
-      "dataManipulations" : [ ],
       "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
       "type" : "plot",
-      "metricDefinition" : { }
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
     }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 2,
-      "name" : "New Plot",
-      "seriesData" : { },
       "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
       "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
       "type" : "plot",
-      "metricDefinition" : { }
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
     } ],
-    "uiHelperValue" : "##CHARTID##_3",
     "chartMode" : "single",
+    "chartType" : "line",
     "chartconfig" : {
       "absoluteEnd" : null,
-      "rangeEnd" : 0,
       "absoluteStart" : null,
       "colorByMetric" : false,
       "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
       "updateInterval" : "",
       "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
         "max" : null,
         "min" : null,
+        "name" : "yAxis0",
         "plotlines" : {
           "high" : null,
           "low" : null
-        },
-        "name" : "yAxis0",
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : ""
+        }
+      } ]
     },
-    "currentUniqueKey" : 3
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_3=id(report=1);A => find(query='(sf_metric:backends.n_backends AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_3 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1440782296628,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 10000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_3=id(report=1);A => find(query='(sf_metric:backends.n_backends AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_3 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')",
-  "marshallId" : 22,
-  "marshallMemberOf" : [ 15 ]
+    "currentUniqueKey" : 3,
+    "revisionNumber" : 3,
+    "uiHelperValue" : "##CHARTID##_3"
+  }
 }, {
+  "marshallId" : 14,
+  "marshallMemberOf" : [ 3 ],
   "sf_chart" : "Bytes/request",
+  "sf_chartIndex" : 1441231853402,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_8_MACROBLOCK=[?A,?B,?G,!OUT]{(?A + ?B) / ?G->!OUT};_SF_PLOT_KEY_##CHARTID##_4_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_8_MACROBLOCK=[?D,?E,?G,!OUT]{(?D + ?E) / ?G->!OUT};_SF_PLOT_KEY_##CHARTID##_7_8=id(report=1);find(query='(sf_metric:total_bytes.resp_body AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_8;find(query='(sf_metric:total_bytes.resp_header AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_8;_SF_PLOT_KEY_##CHARTID##_3_8_MACROBLOCK:!OUT->groupby()->stats:!mean->_SF_PLOT_KEY_##CHARTID##_3_8->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8');_SF_PLOT_KEY_##CHARTID##_1_8->?A:_SF_PLOT_KEY_##CHARTID##_3_8_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_8->?B:_SF_PLOT_KEY_##CHARTID##_3_8_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_8->?G:_SF_PLOT_KEY_##CHARTID##_3_8_MACROBLOCK;find(query='(sf_metric:total_bytes.req_body AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_4_8;find(query='(sf_metric:total_bytes.req_header AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_5_8;_SF_PLOT_KEY_##CHARTID##_6_8_MACROBLOCK:!OUT->groupby()->stats:!mean->_SF_PLOT_KEY_##CHARTID##_6_8->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8');_SF_PLOT_KEY_##CHARTID##_4_8->?D:_SF_PLOT_KEY_##CHARTID##_6_8_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_8->?E:_SF_PLOT_KEY_##CHARTID##_6_8_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_8->?G:_SF_PLOT_KEY_##CHARTID##_6_8_MACROBLOCK;find(query='(sf_metric:connections.received AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_7_8",
+  "sf_type" : "Chart",
   "sf_uiModel" : {
-    "revisionNumber" : 8,
-    "chartType" : "column",
     "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
       "name" : "total_bytes.resp_body",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      } ],
       "seriesData" : {
         "metric" : "total_bytes.resp_body"
       },
-      "dataManipulations" : [ ],
       "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
       "configuration" : {
         "rollupPolicy" : null
       },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
       "name" : "total_bytes.resp_header",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      } ],
       "seriesData" : {
         "metric" : "total_bytes.resp_header"
       },
-      "dataManipulations" : [ ],
       "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
       "type" : "plot",
-      "metricDefinition" : { }
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
     }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 3,
-      "name" : "response bytes/request",
-      "seriesData" : { },
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1
+      },
       "dataManipulations" : [ {
         "direction" : {
-          "type" : "aggregation",
           "options" : {
             "aggregateGroupBy" : [ ],
             "collapseGroups" : false,
             "transformTimeRange" : null
-          }
+          },
+          "type" : "aggregation"
         },
         "fn" : {
-          "type" : "MEAN",
-          "options" : { }
+          "options" : { },
+          "type" : "MEAN"
         },
         "showMe" : false
       } ],
       "expressionText" : "(A+B)/G",
-      "transient" : false,
-      "yAxisIndex" : 1,
-      "invisible" : false,
       "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#0077c2",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "AUTO"
-      },
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "response bytes/request",
       "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "varnish",
-        "propertyValue" : "varnish",
         "NOT" : false,
-        "query" : "plugin:varnish",
+        "iconClass" : "icon-properties",
         "property" : "plugin",
-        "type" : "property"
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
       }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
         "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "iconClass" : "icon-properties",
         "property" : "host",
-        "type" : "property"
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
       } ],
-      "uniqueKey" : 4,
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 1
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
       "name" : "total_bytes.req_body",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      } ],
       "seriesData" : {
         "metric" : "total_bytes.req_body"
       },
-      "dataManipulations" : [ ],
       "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
+    }, {
       "configuration" : {
         "rollupPolicy" : null
       },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 5,
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
       "name" : "total_bytes.req_header",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      } ],
       "seriesData" : {
         "metric" : "total_bytes.req_header"
       },
-      "dataManipulations" : [ ],
       "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
       "type" : "plot",
-      "metricDefinition" : { }
+      "uniqueKey" : 5,
+      "yAxisIndex" : 0
     }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 6,
-      "name" : "request bytes/request",
-      "seriesData" : { },
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1
+      },
       "dataManipulations" : [ {
         "direction" : {
-          "type" : "aggregation",
           "options" : {
             "aggregateGroupBy" : [ ],
             "collapseGroups" : false,
             "transformTimeRange" : null
-          }
+          },
+          "type" : "aggregation"
         },
         "fn" : {
-          "type" : "MEAN",
-          "options" : { }
+          "options" : { },
+          "type" : "MEAN"
         },
         "showMe" : false
       } ],
       "expressionText" : "(D+E)/G",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
       "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#b04600",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "AUTO"
-      },
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "request bytes/request",
       "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "varnish",
-        "propertyValue" : "varnish",
         "NOT" : false,
-        "query" : "plugin:varnish",
+        "iconClass" : "icon-properties",
         "property" : "plugin",
-        "type" : "property"
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
       }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
         "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "iconClass" : "icon-properties",
         "property" : "host",
-        "type" : "property"
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
       } ],
-      "uniqueKey" : 7,
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 6,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
       "name" : "connections.received - Mean",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      } ],
       "seriesData" : {
         "metric" : "connections.received"
       },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MEAN",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
       "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
       "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 8,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_8",
-    "chartMode" : "graph",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "range" : -3600000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
-        "max" : null,
-        "label" : "request - RED",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      }, {
-        "max" : null,
-        "label" : "response - BLUE",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "title" : {
-          "text" : ""
-        },
-        "min" : 0
-      } ],
-      "sortPreference" : "",
-      "forcedResolution" : "0"
-    },
-    "relatedDetectors" : [ ],
-    "currentUniqueKey" : 11
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_8_MACROBLOCK=[?A,?B,?G,!OUT]{(?A + ?B) / ?G->!OUT};_SF_PLOT_KEY_##CHARTID##_4_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_8_MACROBLOCK=[?D,?E,?G,!OUT]{(?D + ?E) / ?G->!OUT};_SF_PLOT_KEY_##CHARTID##_7_8=id(report=1);find(query='(sf_metric:total_bytes.resp_body AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_8;find(query='(sf_metric:total_bytes.resp_header AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_8;_SF_PLOT_KEY_##CHARTID##_3_8_MACROBLOCK:!OUT->groupby()->stats:!mean->_SF_PLOT_KEY_##CHARTID##_3_8->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8');_SF_PLOT_KEY_##CHARTID##_1_8->?A:_SF_PLOT_KEY_##CHARTID##_3_8_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_8->?B:_SF_PLOT_KEY_##CHARTID##_3_8_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_8->?G:_SF_PLOT_KEY_##CHARTID##_3_8_MACROBLOCK;find(query='(sf_metric:total_bytes.req_body AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_4_8;find(query='(sf_metric:total_bytes.req_header AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_5_8;_SF_PLOT_KEY_##CHARTID##_6_8_MACROBLOCK:!OUT->groupby()->stats:!mean->_SF_PLOT_KEY_##CHARTID##_6_8->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8');_SF_PLOT_KEY_##CHARTID##_4_8->?D:_SF_PLOT_KEY_##CHARTID##_6_8_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_8->?E:_SF_PLOT_KEY_##CHARTID##_6_8_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_8->?G:_SF_PLOT_KEY_##CHARTID##_6_8_MACROBLOCK;find(query='(sf_metric:connections.received AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_7_8",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1441231853402,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 1000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_8_MACROBLOCK=[?A,?B,?G,!OUT]{(?A + ?B) / ?G->!OUT};_SF_PLOT_KEY_##CHARTID##_4_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_8=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_8_MACROBLOCK=[?D,?E,?G,!OUT]{(?D + ?E) / ?G->!OUT};_SF_PLOT_KEY_##CHARTID##_7_8=id(report=1);find(query='(sf_metric:total_bytes.resp_body AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_8 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8');find(query='(sf_metric:total_bytes.resp_header AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_8 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8');_SF_PLOT_KEY_##CHARTID##_3_8_MACROBLOCK:!OUT->groupby()->stats:!mean->_SF_PLOT_KEY_##CHARTID##_3_8->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8');_SF_PLOT_KEY_##CHARTID##_1_8->?A:_SF_PLOT_KEY_##CHARTID##_3_8_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_8->?B:_SF_PLOT_KEY_##CHARTID##_3_8_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_8->?G:_SF_PLOT_KEY_##CHARTID##_3_8_MACROBLOCK;find(query='(sf_metric:total_bytes.req_body AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_4_8 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8');find(query='(sf_metric:total_bytes.req_header AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_5_8 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_5_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8');_SF_PLOT_KEY_##CHARTID##_6_8_MACROBLOCK:!OUT->groupby()->stats:!mean->_SF_PLOT_KEY_##CHARTID##_6_8->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8');_SF_PLOT_KEY_##CHARTID##_4_8->?D:_SF_PLOT_KEY_##CHARTID##_6_8_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_8->?E:_SF_PLOT_KEY_##CHARTID##_6_8_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_8->?G:_SF_PLOT_KEY_##CHARTID##_6_8_MACROBLOCK;find(query='(sf_metric:connections.received AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_7_8 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_7_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_8')",
-  "marshallId" : 23,
-  "marshallMemberOf" : [ 15 ]
-}, {
-  "sf_chart" : "Bytes/sec",
-  "sf_uiModel" : {
-    "revisionNumber" : 6,
-    "chartType" : "column",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "total_bytes.resp_body",
-      "seriesData" : {
-        "metric" : "total_bytes.resp_body"
-      },
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
-      "name" : "total_bytes.resp_header",
-      "seriesData" : {
-        "metric" : "total_bytes.resp_header"
-      },
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 3,
-      "name" : "response bytes/sec",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "expressionText" : "A+B",
-      "transient" : false,
-      "yAxisIndex" : 1,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#0077c2",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "AUTO"
-      },
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 4,
-      "name" : "total_bytes.req_body",
-      "seriesData" : {
-        "metric" : "total_bytes.req_body"
-      },
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 5,
-      "name" : "total_bytes.req_header",
-      "seriesData" : {
-        "metric" : "total_bytes.req_header"
-      },
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 6,
-      "name" : "request bytes/sec",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "expressionText" : "D+E",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#b04600",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "AUTO"
-      },
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
       "uniqueKey" : 7,
-      "name" : "New Plot",
-      "seriesData" : { },
+      "yAxisIndex" : 0
+    }, {
       "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
       "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
       "type" : "plot",
-      "metricDefinition" : { }
+      "uniqueKey" : 8,
+      "yAxisIndex" : 0
     } ],
-    "uiHelperValue" : "##CHARTID##_6",
     "chartMode" : "graph",
+    "chartType" : "column",
     "chartconfig" : {
       "absoluteEnd" : null,
-      "rangeEnd" : 0,
       "absoluteStart" : null,
       "colorByMetric" : false,
+      "forcedResolution" : "0",
       "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
       "updateInterval" : "",
       "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
-        "max" : null,
+        "id" : "yAxis0",
         "label" : "request - RED",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
         "plotlines" : {
           "high" : null,
           "low" : null
-        },
-        "id" : "yAxis0"
+        }
       }, {
-        "max" : null,
         "label" : "response - BLUE",
+        "max" : null,
+        "min" : 0,
         "plotlines" : {
           "high" : null,
           "low" : null
         },
         "title" : {
           "text" : ""
-        },
-        "min" : 0
-      } ],
-      "sortPreference" : "",
-      "forcedResolution" : "0"
+        }
+      } ]
     },
-    "currentUniqueKey" : 8
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_6_MACROBLOCK=[?A,?B,!OUT]{?A + ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_4_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_6_MACROBLOCK=[?D,?E,!OUT]{?D + ?E->!OUT};find(query='(sf_metric:total_bytes.resp_body AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_6;find(query='(sf_metric:total_bytes.resp_header AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_6;_SF_PLOT_KEY_##CHARTID##_3_6_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_6->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');_SF_PLOT_KEY_##CHARTID##_1_6->?A:_SF_PLOT_KEY_##CHARTID##_3_6_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_6->?B:_SF_PLOT_KEY_##CHARTID##_3_6_MACROBLOCK;find(query='(sf_metric:total_bytes.req_body AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_4_6;find(query='(sf_metric:total_bytes.req_header AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_5_6;_SF_PLOT_KEY_##CHARTID##_6_6_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_6_6->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');_SF_PLOT_KEY_##CHARTID##_4_6->?D:_SF_PLOT_KEY_##CHARTID##_6_6_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_6->?E:_SF_PLOT_KEY_##CHARTID##_6_6_MACROBLOCK",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1441231423837,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 1000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_6_MACROBLOCK=[?A,?B,!OUT]{?A + ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_4_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_6=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_6_MACROBLOCK=[?D,?E,!OUT]{?D + ?E->!OUT};find(query='(sf_metric:total_bytes.resp_body AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_6 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');find(query='(sf_metric:total_bytes.resp_header AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_6 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');_SF_PLOT_KEY_##CHARTID##_3_6_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_6->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');_SF_PLOT_KEY_##CHARTID##_1_6->?A:_SF_PLOT_KEY_##CHARTID##_3_6_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_6->?B:_SF_PLOT_KEY_##CHARTID##_3_6_MACROBLOCK;find(query='(sf_metric:total_bytes.req_body AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_4_6 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');find(query='(sf_metric:total_bytes.req_header AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_5_6 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_5_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');_SF_PLOT_KEY_##CHARTID##_6_6_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_6_6->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_6');_SF_PLOT_KEY_##CHARTID##_4_6->?D:_SF_PLOT_KEY_##CHARTID##_6_6_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_6->?E:_SF_PLOT_KEY_##CHARTID##_6_6_MACROBLOCK",
-  "marshallId" : 24,
-  "marshallMemberOf" : [ 15 ]
+    "currentUniqueKey" : 11,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 8,
+    "uiHelperValue" : "##CHARTID##_8"
+  }
 }, {
-  "sf_chart" : "Uptime",
+  "marshallId" : 15,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "# Worker Threads",
+  "sf_chartIndex" : 1440781752695,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);A => find(query='(sf_metric:threads.worker AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
+  "sf_type" : "Chart",
   "sf_uiModel" : {
-    "revisionNumber" : 7,
-    "chartType" : "line",
     "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "Seconds",
-      "seriesData" : {
-        "metric" : "uptime.client_uptime"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MEAN",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
       "configuration" : {
         "rollupPolicy" : null
       },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Worker thread count",
       "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
         "NOT" : false,
-        "query" : "plugin:varnish",
+        "iconClass" : "icon-properties",
         "property" : "plugin",
-        "type" : "property"
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
       }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
         "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "iconClass" : "icon-properties",
         "property" : "host",
-        "type" : "property"
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
       } ],
-      "uniqueKey" : 2,
-      "name" : "Days",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "expressionText" : "A/(60*60*24)",
+      "seriesData" : {
+        "metric" : "threads.worker"
+      },
       "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 3,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
       "type" : "plot",
-      "metricDefinition" : { }
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
     } ],
-    "uiHelperValue" : "##CHARTID##_7",
-    "chartMode" : "list",
+    "chartMode" : "single",
+    "chartType" : "line",
     "chartconfig" : {
       "absoluteEnd" : null,
-      "rangeEnd" : 0,
       "absoluteStart" : null,
       "colorByMetric" : false,
       "range" : -3600000,
-      "maxDecimalPlaces" : 2,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
       "updateInterval" : "",
       "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
         "max" : null,
         "min" : null,
+        "name" : "yAxis0",
         "plotlines" : {
           "high" : null,
           "low" : null
-        },
-        "name" : "yAxis0",
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "+value"
+        }
+      } ]
     },
-    "currentUniqueKey" : 4
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_7=id(report=1);B => _SF_PLOT_KEY_##CHARTID##_2_7_MACROBLOCK=[?A,!OUT]{?A / (60 * 60 * 24)->!OUT};A => find(query='(sf_metric:uptime.client_uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_7 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');_SF_PLOT_KEY_##CHARTID##_2_7_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_2_7->publish(metric='_SF_PLOT_KEY_##CHARTID##_2_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');_SF_PLOT_KEY_##CHARTID##_1_7->?A:_SF_PLOT_KEY_##CHARTID##_2_7_MACROBLOCK",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1441040394089,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 10000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_7=id(report=1);B => _SF_PLOT_KEY_##CHARTID##_2_7_MACROBLOCK=[?A,!OUT]{?A / (60 * 60 * 24)->!OUT};A => find(query='(sf_metric:uptime.client_uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_7 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');_SF_PLOT_KEY_##CHARTID##_2_7_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_2_7->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_2_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7');_SF_PLOT_KEY_##CHARTID##_1_7->?A:_SF_PLOT_KEY_##CHARTID##_2_7_MACROBLOCK",
-  "marshallId" : 25,
-  "marshallMemberOf" : [ 15 ]
+    "currentUniqueKey" : 3,
+    "revisionNumber" : 5,
+    "uiHelperValue" : "##CHARTID##_5"
+  }
 }, {
-  "sf_chart" : "Cache Hit Rate %",
+  "marshallId" : 16,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Connections Received",
+  "sf_chartIndex" : 1440618052144,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);find(query='(sf_metric:connections.received AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_7 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
+  "sf_type" : "Chart",
   "sf_uiModel" : {
-    "revisionNumber" : 9,
-    "chartType" : "line",
     "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "connections.received",
       "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
         "NOT" : false,
-        "query" : "plugin:varnish",
+        "iconClass" : "icon-properties",
         "property" : "plugin",
-        "type" : "property"
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
       }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
         "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "iconClass" : "icon-properties",
         "property" : "host",
-        "type" : "property"
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
       } ],
-      "uniqueKey" : 1,
-      "name" : "cache_result.hit - Sum by host",
       "seriesData" : {
-        "metric" : "cache_result.hit"
+        "metric" : "connections.received"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "forcedResolution" : "0",
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "conns/sec",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 3,
+    "revisionNumber" : 7,
+    "uiHelperValue" : "##CHARTID##_7"
+  }
+}, {
+  "marshallId" : 17,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Cache Hit Rate %",
+  "sf_chartIndex" : 1440618403043,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK=[?A,?B,!OUT]{?A / (?A + ?B)  *  100->!OUT};find(query='(sf_metric:cache_result.hit AND _missing_:sf_programId) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_9;find(query='(sf_metric:cache_result.miss AND _missing_:sf_programId) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_9;_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK:!OUT->window(1m)->stats:!mean->_SF_PLOT_KEY_##CHARTID##_3_9->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');_SF_PLOT_KEY_##CHARTID##_1_9->?A:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_9->?B:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
       },
       "dataManipulations" : [ {
         "direction" : {
-          "type" : "aggregation",
           "options" : {
             "aggregateGroupBy" : [ {
               "value" : "host"
             } ],
             "collapseGroups" : false,
             "transformTimeRange" : null
-          }
+          },
+          "type" : "aggregation"
         },
         "fn" : {
-          "type" : "SUM",
-          "options" : { }
+          "options" : { },
+          "type" : "SUM"
         },
         "showMe" : false
       } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
       "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "cache_result.hit - Sum by host",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      } ],
+      "seriesData" : {
+        "metric" : "cache_result.hit"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
       "configuration" : {
         "rollupPolicy" : null
       },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
       } ],
-      "uniqueKey" : 2,
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
       "name" : "cache_result.miss - Sum by host",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      } ],
       "seriesData" : {
         "metric" : "cache_result.miss",
         "regExStyle" : null
       },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
       "dataManipulations" : [ {
         "direction" : {
-          "type" : "aggregation",
+          "options" : {
+            "amount" : 1,
+            "transformTimeRange" : "1m",
+            "unit" : "m"
+          },
+          "type" : "transformation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A/(A+B) * 100",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "hit / received",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      } ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 5,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "single",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "maxDecimalPlaces" : 3,
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "hit %",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 6,
+    "revisionNumber" : 9,
+    "uiHelperValue" : "##CHARTID##_9"
+  }
+}, {
+  "marshallId" : 18,
+  "marshallMemberOf" : [ 2 ],
+  "sf_dashboard" : "Varnish (a)",
+  "sf_description" : "Multiple varnish servers",
+  "sf_discoveryQuery" : "plugin:varnish",
+  "sf_discoverySelectors" : [ "_exists_:aws_region", "sf_hostHasService:varnish", "_exists_:aws_availability_zone", "_exists_:aws_instance_type", "plugin:varnish" ],
+  "sf_type" : "Dashboard",
+  "sf_uiModel" : {
+    "version" : 1,
+    "widgets" : [ {
+      "col" : 4,
+      "options" : {
+        "chartIndex" : 1440618403043,
+        "id" : 1,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 0,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 1441044802676,
+        "id" : 3,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 0,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 8,
+      "options" : {
+        "chartIndex" : 1441301459735,
+        "id" : 2,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 0,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 4,
+      "options" : {
+        "chartIndex" : 1441232963548,
+        "id" : 4,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 1,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 1441233341000,
+        "id" : 5,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 1,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 8,
+      "options" : {
+        "chartIndex" : 1441302803911,
+        "id" : 6,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 1,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 4,
+      "options" : {
+        "chartIndex" : 1440618213590,
+        "id" : 7,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 2,
+      "sizeX" : 4,
+      "type" : "chart"
+    }, {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 1441302597692,
+        "id" : 8,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 2,
+      "sizeX" : 4,
+      "sizeY" : 2,
+      "type" : "chart"
+    }, {
+      "col" : 8,
+      "options" : {
+        "chartIndex" : 1440618052144,
+        "id" : 9,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 2,
+      "sizeX" : 4,
+      "type" : "chart"
+    }, {
+      "col" : 8,
+      "options" : {
+        "chartIndex" : 1440781506039,
+        "id" : 10,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 3,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 4,
+      "options" : {
+        "chartIndex" : 1440781311595,
+        "id" : 11,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 3,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    } ]
+  }
+}, {
+  "marshallId" : 19,
+  "marshallMemberOf" : [ 18 ],
+  "sf_chart" : "Total Connection Rate/sec",
+  "sf_chartIndex" : 1440618052144,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);find(query='(sf_metric:connections.received AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "connections.received - Sum",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "varnish"
+      } ],
+      "seriesData" : {
+        "metric" : "connections.received"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "forcedResolution" : "0",
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "conns / sec",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 3,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 5,
+    "uiHelperValue" : "##CHARTID##_5"
+  }
+}, {
+  "marshallId" : 20,
+  "marshallMemberOf" : [ 18 ],
+  "sf_chart" : "# Servers",
+  "sf_chartIndex" : 1441044802676,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_2_7=id(report=1);B => find(query='(sf_metric:uptime.client_uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby('host') -> stats:!sum -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_2_7 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "colorOverride" : "#05ce00",
+        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION",
+        "maxExtrapolations" : 5,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
           "options" : {
             "aggregateGroupBy" : [ {
               "value" : "host"
             } ],
             "collapseGroups" : false,
             "transformTimeRange" : null
-          }
+          },
+          "type" : "aggregation"
         },
         "fn" : {
-          "type" : "SUM",
-          "options" : { }
+          "options" : { },
+          "type" : "SUM"
         },
         "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
       }, {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 3,
-      "name" : "hit / received",
-      "seriesData" : { },
-      "dataManipulations" : [ {
         "direction" : {
-          "type" : "transformation",
           "options" : {
-            "amount" : 1,
-            "transformTimeRange" : "1m",
-            "unit" : "m"
-          }
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
         },
         "fn" : {
-          "type" : "MEAN",
-          "options" : { }
+          "options" : { },
+          "type" : "COUNT"
         },
         "showMe" : false
       } ],
-      "expressionText" : "A/(A+B) * 100",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Server count",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "varnish"
+      } ],
+      "seriesData" : {
+        "metric" : "uptime.client_uptime"
+      },
       "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 5,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
       "type" : "plot",
-      "metricDefinition" : { }
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
     } ],
-    "uiHelperValue" : "##CHARTID##_9",
     "chartMode" : "single",
+    "chartType" : "line",
     "chartconfig" : {
       "absoluteEnd" : null,
-      "rangeEnd" : 0,
       "absoluteStart" : null,
       "colorByMetric" : false,
+      "disableThrottle" : false,
       "range" : -3600000,
-      "maxDecimalPlaces" : 3,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
       "updateInterval" : "",
       "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : null,
+        "id" : "yAxis0",
         "max" : null,
-        "label" : "hit %",
+        "min" : null,
+        "name" : "yAxis0",
         "plotlines" : {
           "high" : null,
           "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : ""
+        }
+      } ]
     },
-    "currentUniqueKey" : 6
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK=[?A,?B,!OUT]{?A / (?A + ?B)  *  100->!OUT};find(query='(sf_metric:cache_result.hit AND _missing_:sf_programId) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_9;find(query='(sf_metric:cache_result.miss AND _missing_:sf_programId) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_9;_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK:!OUT->window(1m)->stats:!mean->_SF_PLOT_KEY_##CHARTID##_3_9->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');_SF_PLOT_KEY_##CHARTID##_1_9->?A:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_9->?B:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1440618403043,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 10000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK=[?A,?B,!OUT]{?A / (?A + ?B)  *  100->!OUT};find(query='(sf_metric:cache_result.hit AND _missing_:sf_programId) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');find(query='(sf_metric:cache_result.miss AND _missing_:sf_programId) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK:!OUT->window(1m)->stats:!mean->_SF_PLOT_KEY_##CHARTID##_3_9->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');_SF_PLOT_KEY_##CHARTID##_1_9->?A:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_9->?B:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK",
-  "marshallId" : 26,
-  "marshallMemberOf" : [ 15 ]
+    "currentUniqueKey" : 4,
+    "revisionNumber" : 7,
+    "uiHelperValue" : "##CHARTID##_7"
+  }
 }, {
-  "sf_chart" : "# Worker Threads",
+  "marshallId" : 21,
+  "marshallMemberOf" : [ 18 ],
+  "sf_chart" : "Hit Rate %",
+  "sf_chartIndex" : 1441232963548,
+  "sf_description" : "percentile distribution",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_13_MACROBLOCK=[?A,?B,!OUT]{?A / (?A + ?B)  *  100->!OUT};_SF_PLOT_KEY_##CHARTID##_4_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_13_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_6_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_13_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_7_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_13_MACROBLOCK=[?C,!OUT]{?C->!OUT};find(query='(sf_metric:cache_result.hit AND _missing_:sf_programId) AND ((plugin:varnish))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_13;find(query='(sf_metric:cache_result.miss AND _missing_:sf_programId) AND ((plugin:varnish))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_13;_SF_PLOT_KEY_##CHARTID##_3_13_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_13->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');_SF_PLOT_KEY_##CHARTID##_1_13->?A:_SF_PLOT_KEY_##CHARTID##_3_13_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_13->?B:_SF_PLOT_KEY_##CHARTID##_3_13_MACROBLOCK;find(query='(sf_metric:cache_result.hitpass AND _missing_:sf_programId) AND ((plugin:varnish))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_13;_SF_PLOT_KEY_##CHARTID##_5_13_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_5_13->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');_SF_PLOT_KEY_##CHARTID##_3_13->?C:_SF_PLOT_KEY_##CHARTID##_5_13_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_13_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_6_13->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');_SF_PLOT_KEY_##CHARTID##_3_13->?C:_SF_PLOT_KEY_##CHARTID##_6_13_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_13_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_7_13->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');_SF_PLOT_KEY_##CHARTID##_3_13->?C:_SF_PLOT_KEY_##CHARTID##_7_13_MACROBLOCK",
+  "sf_type" : "Chart",
   "sf_uiModel" : {
-    "revisionNumber" : 5,
-    "chartType" : "line",
     "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
       } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "cache_result.hit - Sum by host",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      } ],
+      "seriesData" : {
+        "metric" : "cache_result.hit"
+      },
+      "transient" : false,
+      "type" : "plot",
       "uniqueKey" : 1,
-      "name" : "Worker thread count",
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "cache_result.miss - Sum by host",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      } ],
+      "seriesData" : {
+        "metric" : "cache_result.miss",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#05ce00",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "expressionText" : "A/(A+B) * 100",
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "hit rate percentage",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      } ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "cache_result.hitpass - Sum by host",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      } ],
+      "seriesData" : {
+        "metric" : "cache_result.hitpass"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#05ce00",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MIN"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "C",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "min",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      } ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 5,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#00b9ff",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "percentile" : 50
+          },
+          "type" : "PERCENTILE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "C",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "median",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      } ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 6,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#bd468d",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MAX"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "C",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "max",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      } ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 7,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 8,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "forcedResolution" : "0",
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : false,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "hit rate %",
+        "max" : 110,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : 100,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 11,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 13,
+    "uiHelperValue" : "##CHARTID##_13"
+  }
+}, {
+  "marshallId" : 22,
+  "marshallMemberOf" : [ 18 ],
+  "sf_chart" : "Worker Thread Distribution",
+  "sf_chartIndex" : 1441233341000,
+  "sf_description" : "percentiles",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_7_11=id(report=1);G => _SF_PLOT_KEY_##CHARTID##_7_11_MACROBLOCK=[?J,!OUT]{?J->!OUT};_SF_PLOT_KEY_##CHARTID##_8_11=id(report=1);H => _SF_PLOT_KEY_##CHARTID##_8_11_MACROBLOCK=[?J,!OUT]{?J->!OUT};_SF_PLOT_KEY_##CHARTID##_9_11=id(report=1);I => _SF_PLOT_KEY_##CHARTID##_9_11_MACROBLOCK=[?J,!OUT]{?J->!OUT};_SF_PLOT_KEY_##CHARTID##_10_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_11_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_7_11->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_10_11->?J:_SF_PLOT_KEY_##CHARTID##_7_11_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_11_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_8_11->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_10_11->?J:_SF_PLOT_KEY_##CHARTID##_8_11_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_9_11_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_9_11->publish(metric='_SF_PLOT_KEY_##CHARTID##_9_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_10_11->?J:_SF_PLOT_KEY_##CHARTID##_9_11_MACROBLOCK;J => find(query='(sf_metric:threads.worker AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_10_11",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "colorOverride" : "#007c1d",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MIN"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "D",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "min",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      } ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 1,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "percentile" : 50
+          },
+          "type" : "PERCENTILE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "D",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "median",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      } ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 2,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#bd468d",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MAX"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "D",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "max",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      } ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "threads.worker",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "varnish"
+      } ],
       "seriesData" : {
         "metric" : "threads.worker"
       },
-      "dataManipulations" : [ ],
       "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
       "type" : "plot",
-      "metricDefinition" : { }
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
     }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 2,
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
       "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_5",
-    "chartMode" : "single",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "range" : -3600000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "max" : null,
-        "min" : null,
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "name" : "yAxis0",
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : ""
-    },
-    "currentUniqueKey" : 3
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);A => find(query='(sf_metric:threads.worker AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1440781752695,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 10000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);A => find(query='(sf_metric:threads.worker AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_5 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
-  "marshallId" : 27,
-  "marshallMemberOf" : [ 15 ]
-}, {
-  "sf_chart" : "Connections Received",
-  "sf_uiModel" : {
-    "revisionNumber" : 7,
-    "chartType" : "area",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "connections.received",
-      "seriesData" : {
-        "metric" : "connections.received"
-      },
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
       "queryItems" : [ ],
-      "uniqueKey" : 2,
-      "name" : "New Plot",
       "seriesData" : { },
-      "dataManipulations" : [ ],
       "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
       "type" : "plot",
-      "metricDefinition" : { }
+      "uniqueKey" : 5,
+      "yAxisIndex" : 0
     } ],
-    "uiHelperValue" : "##CHARTID##_7",
     "chartMode" : "graph",
+    "chartType" : "area",
     "chartconfig" : {
       "absoluteEnd" : null,
-      "rangeEnd" : 0,
       "absoluteStart" : null,
       "colorByMetric" : false,
+      "disableThrottle" : false,
       "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : false,
       "updateInterval" : "",
       "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
+        "id" : "yAxis0",
+        "label" : "# threads",
         "max" : null,
-        "label" : "conns/sec",
+        "min" : 0,
+        "name" : "yAxis0",
         "plotlines" : {
           "high" : null,
           "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "",
-      "forcedResolution" : "0"
+        }
+      } ]
     },
-    "currentUniqueKey" : 3
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);find(query='(sf_metric:connections.received AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_7 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1440618052144,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 1000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_7=id(report=1);find(query='(sf_metric:connections.received AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_7 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')",
-  "marshallId" : 28,
-  "marshallMemberOf" : [ 15 ]
+    "currentUniqueKey" : 12,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 11,
+    "uiHelperValue" : "##CHARTID##_11"
+  }
 }, {
-  "sf_chart" : "Shared Memory Operations",
+  "marshallId" : 23,
+  "marshallMemberOf" : [ 18 ],
+  "sf_chart" : "Session Operations / sec",
+  "sf_chartIndex" : 1441302597692,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_4=id(report=1);A => find(query='(sf_metric:total_operations.* AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_4 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_4')",
+  "sf_type" : "Chart",
   "sf_uiModel" : {
-    "revisionNumber" : 5,
-    "chartType" : "area",
     "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin:varnish",
-        "propertyValue" : "varnish",
-        "NOT" : false,
-        "query" : "plugin:varnish",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "propertyValue" : "integration-test-varnish-4.0.3-0",
-        "NOT" : false,
-        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
-        "property" : "host",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "plugin_instance:*-shm",
-        "propertyValue" : "*-shm",
-        "NOT" : false,
-        "query" : "plugin_instance:*\\-shm",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "",
-      "seriesData" : {
-        "metric" : "total_operations.*"
+      "configuration" : {
+        "rollupPolicy" : null
       },
       "dataManipulations" : [ {
         "direction" : {
-          "type" : "aggregation",
           "options" : {
             "aggregateGroupBy" : [ {
               "value" : "sf_metric"
             } ],
             "collapseGroups" : false,
             "transformTimeRange" : null
-          }
+          },
+          "type" : "aggregation"
         },
         "fn" : {
-          "type" : "SUM",
-          "options" : { }
+          "options" : { },
+          "type" : "SUM"
         },
         "showMe" : false
       } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
       "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : null,
-        "rollupPolicy" : null,
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "AUTO"
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "varnish"
+      } ],
+      "seriesData" : {
+        "metric" : "total_operations.*"
       },
+      "transient" : false,
       "type" : "plot",
-      "metricDefinition" : { }
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
     }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 2,
-      "name" : "New Plot",
-      "seriesData" : { },
       "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
       "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
       "type" : "plot",
-      "metricDefinition" : { }
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
     } ],
-    "uiHelperValue" : "##CHARTID##_5",
-    "chartMode" : "graph",
+    "chartMode" : "list",
+    "chartType" : "line",
     "chartconfig" : {
       "absoluteEnd" : null,
-      "rangeEnd" : 0,
       "absoluteStart" : null,
-      "stackedChart" : true,
       "colorByMetric" : true,
+      "disableThrottle" : false,
       "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "+sf_originatingMetric",
       "updateInterval" : "",
       "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
+        "id" : "yAxis0",
         "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 3,
+    "revisionNumber" : 4,
+    "uiHelperValue" : "##CHARTID##_4"
+  }
+}, {
+  "marshallId" : 24,
+  "marshallMemberOf" : [ 18 ],
+  "sf_chart" : "Shared Memory Operations",
+  "sf_chartIndex" : 1440781506039,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_3=id(report=1);A => find(query='(sf_metric:total_operations.* AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch(maxExtrapolations=-1) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_3 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "colorOverride" : null,
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "sf_metric"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "varnish"
+      } ],
+      "seriesData" : {
+        "metric" : "total_operations.*"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "disableThrottle" : false,
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
         "label" : "ops / sec",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 3,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 3,
+    "uiHelperValue" : "##CHARTID##_3"
+  }
+}, {
+  "marshallId" : 25,
+  "marshallMemberOf" : [ 18 ],
+  "sf_chart" : "Total Bytes/sec",
+  "sf_chartIndex" : 1441301459735,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK=[?A,?B,!OUT]{?A + ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_4_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_9_MACROBLOCK=[?D,?E,!OUT]{?D + ?E->!OUT};find(query='(sf_metric:total_bytes.resp_body AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_9;find(query='(sf_metric:total_bytes.resp_header AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_9;_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_9->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');_SF_PLOT_KEY_##CHARTID##_1_9->?A:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_9->?B:_SF_PLOT_KEY_##CHARTID##_3_9_MACROBLOCK;find(query='(sf_metric:total_bytes.req_body AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_9;find(query='(sf_metric:total_bytes.req_header AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_5_9;_SF_PLOT_KEY_##CHARTID##_6_9_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_6_9->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');_SF_PLOT_KEY_##CHARTID##_4_9->?D:_SF_PLOT_KEY_##CHARTID##_6_9_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_9->?E:_SF_PLOT_KEY_##CHARTID##_6_9_MACROBLOCK",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "total_bytes.resp_body - Sum",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      } ],
+      "seriesData" : {
+        "metric" : "total_bytes.resp_body"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "total_bytes.resp_header - Sum",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      } ],
+      "seriesData" : {
+        "metric" : "total_bytes.resp_header"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "expressionText" : "A+B",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Response bytes",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      } ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 1
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "total_bytes.req_body - Sum",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      } ],
+      "seriesData" : {
+        "metric" : "total_bytes.req_body"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "total_bytes.req_header - Sum",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      } ],
+      "seriesData" : {
+        "metric" : "total_bytes.req_header"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 5,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "expressionText" : "D+E",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Request bytes",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      } ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 6,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 7,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "column",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "forcedResolution" : "0",
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "updateInterval" : "",
+      "useKMG2" : true,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "request - RED",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "label" : "response - BLUE",
+        "max" : null,
+        "min" : 0,
         "plotlines" : {
           "high" : null,
           "low" : null
         },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : ""
+        "title" : {
+          "text" : ""
+        }
+      } ]
     },
-    "currentUniqueKey" : 3
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);A => find(query='(sf_metric:total_operations.* AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0) AND (plugin_instance:*\\\\-shm))') -> fetch(maxExtrapolations=-1) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
-  "sf_cacheProgram" : false,
-  "sf_description" : "",
-  "sf_chartIndex" : 1440781506039,
+    "currentUniqueKey" : 8,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 9,
+    "uiHelperValue" : "##CHARTID##_9"
+  }
+}, {
+  "marshallId" : 26,
+  "marshallMemberOf" : [ 18 ],
+  "sf_chart" : "Connection States",
+  "sf_chartIndex" : 1440781311595,
   "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
   "sf_jobResolution" : 1000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);A => find(query='(sf_metric:total_operations.* AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish) AND (host:integration\\\\-test\\\\-varnish\\\\-4.0.3\\\\-0) AND (plugin_instance:*\\\\-shm))') -> fetch(maxExtrapolations=-1) -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_5 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_4=id(report=1);A => find(query='(sf_metric:connections.* AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch -> groupby('sf_metric') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_4 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_4')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "sf_metric"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "varnish"
+      } ],
+      "seriesData" : {
+        "metric" : "connections.*"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "disableThrottle" : false,
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "connections / sec",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 3,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 4,
+    "uiHelperValue" : "##CHARTID##_4"
+  }
+}, {
+  "marshallId" : 27,
+  "marshallMemberOf" : [ 18 ],
+  "sf_chart" : "Cache Results",
+  "sf_chartIndex" : 1440618213590,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_5=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_5=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_5=id(report=1);A => find(query='(sf_metric:cache_result.hit AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5');B => find(query='(sf_metric:cache_result.miss AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5');C => find(query='(sf_metric:cache_result.hitpass AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_5 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_5')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "colorOverride" : "#007c1d",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "cache_hit",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "varnish"
+      } ],
+      "seriesData" : {
+        "metric" : "cache_result.hit"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "cache_miss",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "varnish"
+      } ],
+      "seriesData" : {
+        "metric" : "cache_result.miss"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#876ff3",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "cache_hitpass",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "varnish"
+      } ],
+      "seriesData" : {
+        "metric" : "cache_result.hitpass"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "disableThrottle" : false,
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "count / sec",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 5,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 5,
+    "uiHelperValue" : "##CHARTID##_5"
+  }
+}, {
+  "marshallId" : 28,
+  "marshallMemberOf" : [ 18 ],
+  "sf_chart" : "Connection Rate/sec",
+  "sf_chartIndex" : 1441302803911,
+  "sf_description" : "percentile distribution",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_2_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_11_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_8_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_11_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_9_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_9_11_MACROBLOCK=[?B,!OUT]{?B->!OUT};find(query='(sf_metric:connections.received AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:varnish))') -> fetch -> groupby('host') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_11;_SF_PLOT_KEY_##CHARTID##_7_11_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_7_11->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_2_11->?B:_SF_PLOT_KEY_##CHARTID##_7_11_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_11_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_8_11->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_2_11->?B:_SF_PLOT_KEY_##CHARTID##_8_11_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_9_11_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_9_11->publish(metric='_SF_PLOT_KEY_##CHARTID##_9_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_2_11->?B:_SF_PLOT_KEY_##CHARTID##_9_11_MACROBLOCK",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "connections.received - Sum by host",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "varnish"
+      } ],
+      "seriesData" : {
+        "metric" : "connections.received"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#05ce00",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MIN"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "min",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      } ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 2,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#00b9ff",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "percentile" : 50
+          },
+          "type" : "PERCENTILE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "median",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      } ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#bd468d",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MAX"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "max",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      } ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 4,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 5,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "forcedResolution" : "0",
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : false,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "conns/sec",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 11,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 11,
+    "uiHelperValue" : "##CHARTID##_11"
+  }
+}, {
   "marshallId" : 29,
-  "marshallMemberOf" : [ 15 ]
+  "marshallMemberOf" : [ 18 ],
+  "sf_chart" : "Overall Hit Rate %",
+  "sf_chartIndex" : 1440618403043,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_10_MACROBLOCK=[?A,?B,!OUT]{?A / (?A + ?B)  *  100->!OUT};find(query='(sf_metric:cache_result.hit AND _missing_:sf_programId) AND ((plugin:varnish))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_10;find(query='(sf_metric:cache_result.miss AND _missing_:sf_programId) AND ((plugin:varnish))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_10;_SF_PLOT_KEY_##CHARTID##_3_10_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_10->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');_SF_PLOT_KEY_##CHARTID##_1_10->?A:_SF_PLOT_KEY_##CHARTID##_3_10_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_10->?B:_SF_PLOT_KEY_##CHARTID##_3_10_MACROBLOCK",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "cache_result.hit - Sum",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "varnish"
+      } ],
+      "seriesData" : {
+        "metric" : "cache_result.hit"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "cache_result.miss - Sum",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "varnish"
+      } ],
+      "seriesData" : {
+        "metric" : "cache_result.miss",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#05ce00",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "expressionText" : "A/(A+B) * 100",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "hit rate percentage",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-varnish-4.0.3-0",
+        "query" : "host:\"integration-test-varnish-4.0.3-0\"",
+        "type" : "property",
+        "value" : "host:\"integration-test-varnish-4.0.3-0\""
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "varnish",
+        "query" : "plugin:varnish",
+        "type" : "property",
+        "value" : "plugin:varnish"
+      } ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 5,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "single",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "maxDecimalPlaces" : 3,
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : false,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "hit %",
+        "max" : 110,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : 100,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 7,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 10,
+    "uiHelperValue" : "##CHARTID##_10"
+  }
 } ]


### PR DESCRIPTION
Addresses:
[FUSE-10756: memcached(a) dashboard has two identical 'Hit Rate' charts](https://signalfuse.atlassian.net/browse/FUSE-10756)
[FUSE-10708: Varnish: session operations/sec list chart has no labels](https://signalfuse.atlassian.net/browse/FUSE-10708)
[FUSE-10707: Network traffic should probably use IEC units - Giga instead of Billion](https://signalfuse.atlassian.net/browse/FUSE-10707)
[FUSE-10706: CPU percentile distribution chart has incorrect plot label](https://signalfuse.atlassian.net/browse/FUSE-10706)