### PR TITLE
exclude other agents  from collectd charts

### DIFF
--- a/CollectD/Page_CollectD_SFX.json
+++ b/CollectD/Page_CollectD_SFX.json
@@ -51,18 +51,6 @@
       "sizeY" : 1,
       "type" : "chart"
     }, {
-      "col" : 6,
-      "options" : {
-        "chartIndex" : 1459445812323,
-        "id" : 3,
-        "name" : "",
-        "type" : "chart"
-      },
-      "row" : 0,
-      "sizeX" : 3,
-      "sizeY" : 1,
-      "type" : "chart"
-    }, {
       "col" : 9,
       "options" : {
         "chartIndex" : 1459445557108,
@@ -79,6 +67,18 @@
       "options" : {
         "chartIndex" : 1459444857291,
         "id" : 2,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 0,
+      "sizeX" : 3,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 6,
+      "options" : {
+        "chartIndex" : 1459445812323,
+        "id" : 3,
         "name" : "",
         "type" : "chart"
       },
@@ -187,283 +187,9 @@
 }, {
   "marshallId" : 4,
   "marshallMemberOf" : [ 3 ],
-  "sf_chart" : "Disk Used %",
-  "sf_chartIndex" : 1459445557108,
-  "sf_description" : "",
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 10000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_14=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_14_MACROBLOCK=[?A,!OUT]{?A->!OUT};find(query='(sf_metric:disk.utilization AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:signalfx\\\\-metadata))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_14;_SF_PLOT_KEY_##CHARTID##_2_14_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_2_14->groupby() -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_2_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14');_SF_PLOT_KEY_##CHARTID##_1_14->?A:_SF_PLOT_KEY_##CHARTID##_2_14_MACROBLOCK",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlotConstructs" : [ ],
-    "allPlots" : [ {
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#b04600",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "MEAN"
-        },
-        "showMe" : false
-      } ],
-      "focusNext" : false,
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "",
-      "queryItems" : [ {
-        "NOT" : false,
-        "displayName" : "signalfx-metadata",
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "signalfx-metadata",
-        "query" : "plugin:\"signalfx-metadata\"",
-        "type" : "property",
-        "value" : "signalfx-metadata"
-      } ],
-      "seriesData" : {
-        "metric" : "disk.utilization",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "expressionText" : "A",
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 2,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 3,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "list",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "legendColumnConfiguration" : null,
-      "maxDecimalPlaces" : 3,
-      "range" : -7200000,
-      "rangeEnd" : 0,
-      "sortPreference" : "-value",
-      "stackedChart" : true,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "%",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 7,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 14,
-    "uiHelperValue" : "##CHARTID##_14"
-  }
-}, {
-  "marshallId" : 5,
-  "marshallMemberOf" : [ 3 ],
-  "sf_chart" : "Memory Paging",
-  "sf_chartIndex" : 3,
-  "sf_description" : "page swaps/sec",
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 1000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_15=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_15=id(report=1);find(query='(sf_metric:vmpage_io.swap.in AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:vmem))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> split -> _SF_PLOT_KEY_##CHARTID##_1_15 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_15',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_15');find(query='(sf_metric:vmpage_io.swap.out AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:vmem))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> split -> _SF_PLOT_KEY_##CHARTID##_2_15 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_15',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_15')",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allDetectorDecorators" : [ ],
-    "allPlotConstructs" : [ ],
-    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.vmem.vmpage_io.swap.in AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_3_4')", "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.vmem.vmpage_io.swap.out AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_3_4')" ],
-    "allPlots" : [ {
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#b04600",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "DELTA_ROLLUP"
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "swapped in",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "vmem",
-        "query" : "plugin:vmem",
-        "type" : "property",
-        "value" : "vmem"
-      } ],
-      "seriesData" : {
-        "metric" : "vmpage_io.swap.in"
-      },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#0077c2",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "DELTA_ROLLUP"
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "swapped out",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "vmem",
-        "query" : "plugin:vmem",
-        "type" : "property",
-        "value" : "vmem"
-      } ],
-      "seriesData" : {
-        "metric" : "vmpage_io.swap.out"
-      },
-      "sf_programText" : "find(refresh=300000,query='sf_metric:collectd.vmem.vmpage_io.swap.in AND sf_organizationID:BqDQY5OAAAA AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_BwzVGs0AEAA_2_2=id -> publish(defaultSource='_SF_PLOT_KEY_BwzVGs0AEAA_2_2',metric='_SF_PLOT_KEY_BwzVGs0AEAA_2_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='BwzVGs0AEAA_2')",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "valid" : false,
-      "yAxisIndex" : 1
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ {
-        "iconClass" : "sf-icon-property",
-        "query" : "aws_service:quantizer",
-        "type" : "property",
-        "value" : "Aws_service:quantizer"
-      } ],
-      "seriesData" : { },
-      "sf_programText" : "",
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 3,
-      "valid" : false,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "disableThrottle" : false,
-      "legendColumnConfiguration" : null,
-      "maxDecimalPlaces" : 3,
-      "range" : -7200000,
-      "rangeEnd" : 0,
-      "sortPreference" : "",
-      "stackedChart" : false,
-      "updateInterval" : "",
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "swapped in - RED",
-        "max" : null,
-        "min" : 0,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      }, {
-        "label" : "swapped out - BLUE",
-        "max" : null,
-        "min" : 0,
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "title" : {
-          "text" : ""
-        }
-      } ]
-    },
-    "currentUniqueKey" : 4,
-    "revisionNumber" : 15,
-    "sf_detectorDecorators" : [ ],
-    "uiHelperValue" : "##CHARTID##_15"
-  }
-}, {
-  "marshallId" : 6,
-  "marshallMemberOf" : [ 3 ],
   "sf_chart" : "CPU Used %",
   "sf_chartIndex" : 1459444857291,
   "sf_description" : "",
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 10000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_20=id(report=1);find(query='(sf_metric:cpu.utilization AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:signalfx\\\\-metadata))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_20 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_20',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_20')",
   "sf_type" : "Chart",
   "sf_uiModel" : {
     "allDetectorDecorators" : [ ],
@@ -490,6 +216,14 @@
         "query" : "plugin:\"signalfx-metadata\"",
         "type" : "property",
         "value" : "signalfx-metadata"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
       } ],
       "seriesData" : {
         "metric" : "cpu.utilization",
@@ -545,279 +279,16 @@
     },
     "currentUniqueKey" : 7,
     "relatedDetectors" : [ ],
-    "revisionNumber" : 20,
+    "revisionNumber" : 21,
     "sf_detectorDecorators" : [ ],
-    "uiHelperValue" : "##CHARTID##_20"
+    "uiHelperValue" : "##CHARTID##_21"
   }
 }, {
-  "marshallId" : 7,
-  "marshallMemberOf" : [ 3 ],
-  "sf_chart" : "Memory Used %",
-  "sf_chartIndex" : 1459445051615,
-  "sf_description" : "",
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 10000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);find(query='(sf_metric:memory.utilization AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:signalfx\\\\-metadata))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_18 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18')",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allDetectorDecorators" : [ ],
-    "allPlotConstructs" : [ ],
-    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.free AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3=id", "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.used AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK=[?B,?A,!OUT]{?B  /  (?A  +  ?B)  *  100->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('sf_source')->groupby('aws_Name')->stats:!mean->_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_2_3');_SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3->?B:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK;_SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK" ],
-    "allPlots" : [ {
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#05ce00",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "free",
-      "queryItems" : [ {
-        "NOT" : false,
-        "displayName" : "signalfx-metadata",
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "signalfx-metadata",
-        "query" : "plugin:\"signalfx-metadata\"",
-        "type" : "property",
-        "value" : "signalfx-metadata"
-      } ],
-      "seriesData" : {
-        "metric" : "memory.utilization",
-        "regExStyle" : null
-      },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "single",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : true,
-      "disableThrottle" : false,
-      "hideTimestamp" : false,
-      "maxDecimalPlaces" : 3,
-      "range" : -7200000,
-      "rangeEnd" : 0,
-      "sortPreference" : "-value",
-      "stackedChart" : true,
-      "updateInterval" : "",
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "%",
-        "max" : null,
-        "min" : 0,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 9,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 18,
-    "sf_detectorDecorators" : [ ],
-    "uiHelperValue" : "##CHARTID##_18"
-  }
-}, {
-  "marshallId" : 8,
-  "marshallMemberOf" : [ 3 ],
-  "sf_chart" : "Disk I/O",
-  "sf_chartIndex" : 5,
-  "sf_description" : "operations/sec",
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 1000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_19=id(report=1);find(query='(sf_metric:disk_ops.read AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:disk))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_19 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');find(query='(sf_metric:disk_ops.write AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:disk))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_19 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19')",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allDetectorDecorators" : [ ],
-    "allPlotConstructs" : [ ],
-    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.disk.*disk_ops.read AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_6_1_7=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_6_1_7',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_6_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_6_7')" ],
-    "allPlots" : [ {
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#b04600",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "read ops/sec",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "disk",
-        "query" : "plugin:disk",
-        "type" : "property",
-        "value" : "disk"
-      } ],
-      "seriesData" : {
-        "metric" : "disk_ops.read"
-      },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#0077c2",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "write ops/sec",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "disk",
-        "query" : "plugin:disk",
-        "type" : "property",
-        "value" : "disk"
-      } ],
-      "seriesData" : {
-        "metric" : "disk_ops.write"
-      },
-      "sf_programText" : "find(query='(sf_metric:disk_ops.read AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_CGraATNAgAA_3_10=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGraATNAgAA_3_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGraATNAgAA_10')",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "valid" : false,
-      "yAxisIndex" : 1
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 3,
-      "valid" : false,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : true,
-      "legendColumnConfiguration" : null,
-      "range" : -7200000,
-      "rangeEnd" : 0,
-      "sortPreference" : "",
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "read ops - RED",
-        "max" : null,
-        "min" : 0,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      }, {
-        "label" : "write ops - BLUE",
-        "max" : null,
-        "min" : 0,
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "title" : {
-          "text" : ""
-        }
-      } ]
-    },
-    "currentUniqueKey" : 5,
-    "revisionNumber" : 19,
-    "sf_detectorDecorators" : [ ],
-    "uiHelperValue" : "##CHARTID##_19"
-  }
-}, {
-  "marshallId" : 9,
+  "marshallId" : 5,
   "marshallMemberOf" : [ 3 ],
   "sf_chart" : "Network Errors",
   "sf_chartIndex" : 1465337015263,
   "sf_description" : "errors/sec",
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 1000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_22=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_22=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_22=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_22_MACROBLOCK=[?A,?B,!OUT]{?A  +  ?B->!OUT};find(query='(sf_metric:if_errors.rx AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:interface) AND (plugin_instance:e*))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> split -> _SF_PLOT_KEY_##CHARTID##_1_22;find(query='(sf_metric:if_errors.tx AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:interface) AND (plugin_instance:e*))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='DELTA_ROLLUP') -> split -> _SF_PLOT_KEY_##CHARTID##_2_22;_SF_PLOT_KEY_##CHARTID##_3_22_MACROBLOCK:!OUT->groupby()->stats:!sum->_SF_PLOT_KEY_##CHARTID##_3_22->groupby() -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_22',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_22');_SF_PLOT_KEY_##CHARTID##_1_22->?A:_SF_PLOT_KEY_##CHARTID##_3_22_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_22->?B:_SF_PLOT_KEY_##CHARTID##_3_22_MACROBLOCK",
   "sf_type" : "Chart",
   "sf_uiModel" : {
     "allDetectorDecorators" : [ ],
@@ -852,6 +323,14 @@
         "query" : "plugin_instance:e*",
         "type" : "property",
         "value" : "plugin_instance:e*"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
       } ],
       "seriesData" : {
         "metric" : "if_errors.rx"
@@ -891,6 +370,14 @@
         "query" : "plugin_instance:e*",
         "type" : "property",
         "value" : "plugin_instance:e*"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
       } ],
       "seriesData" : {
         "metric" : "if_errors.tx"
@@ -1000,588 +487,16 @@
     },
     "currentUniqueKey" : 6,
     "relatedDetectors" : [ ],
-    "revisionNumber" : 22,
+    "revisionNumber" : 23,
     "sf_detectorDecorators" : [ ],
-    "uiHelperValue" : "##CHARTID##_22"
+    "uiHelperValue" : "##CHARTID##_23"
   }
 }, {
-  "marshallId" : 10,
-  "marshallMemberOf" : [ 3 ],
-  "sf_chart" : "Memory",
-  "sf_chartIndex" : 4,
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 1000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_13_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_14_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_15_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_16_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_17_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_18_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_19_21=id(report=1);find(query='(sf_metric:memory.free AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_21 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');find(query='(sf_metric:memory.used AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_21 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');find(query='(sf_metric:memory.buffered AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_13_21 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_13_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');find(query='(sf_metric:memory.cached AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_14_21 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_14_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');find(query='(sf_metric:memory.slab_recl AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_15_21 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_15_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');find(query='(sf_metric:memory.slab_unrecl AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_16_21 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_16_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');find(query='(sf_metric:memory.active AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_17_21 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_17_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');find(query='(sf_metric:memory.inactive AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_18_21 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_18_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');find(query='(sf_metric:memory.wired AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:memory))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_19_21 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_19_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21')",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allDetectorDecorators" : [ ],
-    "allPlotConstructs" : [ ],
-    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.free AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3=id", "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.used AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK=[?B,?A,!OUT]{?B  /  (?A  +  ?B)  *  100->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('sf_source')->groupby('aws_Name')->stats:!mean->_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_2_3');_SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3->?B:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK;_SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK" ],
-    "allPlots" : [ {
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#05ce00",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "bytes",
-      "queryItems" : [ {
-        "NOT" : false,
-        "displayName" : "memory",
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "memory",
-        "query" : "plugin:memory",
-        "type" : "property",
-        "value" : "memory"
-      } ],
-      "seriesData" : {
-        "metric" : "memory.free",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#bd468d",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "bytes",
-      "queryItems" : [ {
-        "NOT" : false,
-        "displayName" : "memory",
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "memory",
-        "query" : "plugin:memory",
-        "type" : "property",
-        "value" : "memory"
-      } ],
-      "seriesData" : {
-        "metric" : "memory.used",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#876ff3",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "bytes",
-      "queryItems" : [ {
-        "NOT" : false,
-        "displayName" : "memory",
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "memory",
-        "query" : "plugin:memory",
-        "type" : "property",
-        "value" : "memory"
-      } ],
-      "seriesData" : {
-        "metric" : "memory.buffered",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 13,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#ab99bc",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "bytes",
-      "queryItems" : [ {
-        "NOT" : false,
-        "displayName" : "memory",
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "memory",
-        "query" : "plugin:memory",
-        "type" : "property",
-        "value" : "memory"
-      } ],
-      "seriesData" : {
-        "metric" : "memory.cached",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 14,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#00b9ff",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "bytes",
-      "queryItems" : [ {
-        "NOT" : false,
-        "displayName" : "memory",
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "memory",
-        "query" : "plugin:memory",
-        "type" : "property",
-        "value" : "memory"
-      } ],
-      "seriesData" : {
-        "metric" : "memory.slab_recl",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 15,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#0077c2",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "bytes",
-      "queryItems" : [ {
-        "NOT" : false,
-        "displayName" : "memory",
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "memory",
-        "query" : "plugin:memory",
-        "type" : "property",
-        "value" : "memory"
-      } ],
-      "seriesData" : {
-        "metric" : "memory.slab_unrecl",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 16,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#b04600",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "bytes",
-      "queryItems" : [ {
-        "NOT" : false,
-        "displayName" : "memory",
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "memory",
-        "query" : "plugin:memory",
-        "type" : "property",
-        "value" : "memory"
-      } ],
-      "seriesData" : {
-        "metric" : "memory.active",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 17,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#f47e00",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "bytes",
-      "queryItems" : [ {
-        "NOT" : false,
-        "displayName" : "memory",
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "memory",
-        "query" : "plugin:memory",
-        "type" : "property",
-        "value" : "memory"
-      } ],
-      "seriesData" : {
-        "metric" : "memory.inactive",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 18,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#e5b312",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "bytes",
-      "queryItems" : [ {
-        "NOT" : false,
-        "displayName" : "memory",
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "memory",
-        "query" : "plugin:memory",
-        "type" : "property",
-        "value" : "memory"
-      } ],
-      "seriesData" : {
-        "metric" : "memory.wired",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 19,
-      "yAxisIndex" : 0
-    }, {
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 20,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "area",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : true,
-      "disableThrottle" : false,
-      "legendColumnConfiguration" : [ {
-        "enabled" : true,
-        "property" : "sf_originatingMetric"
-      }, {
-        "enabled" : true,
-        "property" : "sf_metric"
-      }, {
-        "enabled" : false,
-        "property" : "plugin"
-      }, {
-        "enabled" : false,
-        "property" : "dsname"
-      }, {
-        "enabled" : false,
-        "property" : "host"
-      }, {
-        "enabled" : false,
-        "property" : "AWSUniqueId"
-      } ],
-      "maxDecimalPlaces" : 3,
-      "range" : -7200000,
-      "rangeEnd" : 0,
-      "sortPreference" : "-value",
-      "stackedChart" : true,
-      "updateInterval" : "",
-      "useKMG2" : true,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "bytes",
-        "max" : null,
-        "min" : 0,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 21,
-    "revisionNumber" : 21,
-    "sf_detectorDecorators" : [ ],
-    "uiHelperValue" : "##CHARTID##_21"
-  }
-}, {
-  "marshallId" : 11,
-  "marshallMemberOf" : [ 3 ],
-  "sf_chart" : "Total Network bits/sec",
-  "sf_chartIndex" : 1459445812323,
-  "sf_description" : "",
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 10000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_29=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_29=id(report=1);find(query='(sf_metric:if_octets.rx AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin_instance:e*) AND (plugin:interface))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> { ?in * 8 -> !out } -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_29 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_29',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_29');find(query='(sf_metric:if_octets.tx AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin_instance:e*) AND (plugin:interface))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> { ?in * 8 -> !out } -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_29 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_29',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_29')",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allDetectorDecorators" : [ ],
-    "allPlotConstructs" : [ ],
-    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.interface*.if_octets.rx AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> ?a:math(b=8):!product -> _SF_PLOT_KEY_SYNTH_CHART_ID_7_1_6=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_7_1_6',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_7_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_7_6')" ],
-    "allPlots" : [ {
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#b04600",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "scaleAmount" : 8
-          },
-          "type" : "SCALE"
-        },
-        "showMe" : false
-      }, {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "input bits/sec",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin_instance",
-        "propertyValue" : "e*",
-        "query" : "plugin_instance:e*",
-        "type" : "property",
-        "value" : "plugin_instance:e*"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "interface",
-        "query" : "plugin:interface",
-        "type" : "property",
-        "value" : "interface"
-      } ],
-      "seriesData" : {
-        "metric" : "if_octets.rx"
-      },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#0077c2",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "scaleAmount" : 8
-          },
-          "type" : "SCALE"
-        },
-        "showMe" : false
-      }, {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "output bits/sec",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin_instance",
-        "propertyValue" : "e*",
-        "query" : "plugin_instance:e*",
-        "type" : "property",
-        "value" : "plugin_instance:e*"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "interface",
-        "query" : "plugin:interface",
-        "type" : "property",
-        "value" : "interface"
-      } ],
-      "seriesData" : {
-        "metric" : "if_octets.tx"
-      },
-      "sf_programText" : "find(query='(sf_metric:if_octets.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2) AND (plugin_instance:e*))') -> fetch -> split -> stats:!mean -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_CGraATOAYAA_2_12=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGraATOAYAA_2_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGraATOAYAA_12')",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "valid" : false,
-      "yAxisIndex" : 1
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 3,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "list",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : true,
-      "forcedResolution" : "0",
-      "hideDimensionsInList" : true,
-      "legendColumnConfiguration" : null,
-      "maxDecimalPlaces" : 4,
-      "range" : -7200000,
-      "rangeEnd" : 0,
-      "sortPreference" : "+sf_metric",
-      "updateInterval" : "",
-      "useKMG2" : true,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "bits/s",
-        "max" : null,
-        "min" : 0,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      }, {
-        "label" : "",
-        "max" : null,
-        "min" : 0,
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "title" : {
-          "text" : ""
-        }
-      } ]
-    },
-    "currentUniqueKey" : 5,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 29,
-    "sf_detectorDecorators" : [ ],
-    "uiHelperValue" : "##CHARTID##_29"
-  }
-}, {
-  "marshallId" : 12,
+  "marshallId" : 6,
   "marshallMemberOf" : [ 3 ],
   "sf_chart" : "Network I/O",
   "sf_chartIndex" : 8,
   "sf_description" : "bits/sec",
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 1000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_22=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_22=id(report=1);find(query='(sf_metric:if_octets.rx AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin_instance:e*) AND (plugin:interface))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_22 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_22',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_22');find(query='(sf_metric:if_octets.tx AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin_instance:e*) AND (plugin:interface))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_2_22 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_22',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_22')",
   "sf_type" : "Chart",
   "sf_uiModel" : {
     "allDetectorDecorators" : [ ],
@@ -1632,6 +547,14 @@
         "query" : "plugin:interface",
         "type" : "property",
         "value" : "interface"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
       } ],
       "seriesData" : {
         "metric" : "if_octets.rx"
@@ -1687,6 +610,14 @@
         "query" : "plugin:interface",
         "type" : "property",
         "value" : "interface"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
       } ],
       "seriesData" : {
         "metric" : "if_octets.tx"
@@ -1752,110 +683,15 @@
       } ]
     },
     "currentUniqueKey" : 4,
-    "revisionNumber" : 22,
+    "revisionNumber" : 23,
     "sf_detectorDecorators" : [ ],
-    "uiHelperValue" : "##CHARTID##_22"
+    "uiHelperValue" : "##CHARTID##_23"
   }
 }, {
-  "marshallId" : 13,
-  "marshallMemberOf" : [ 3 ],
-  "sf_chart" : "CPU %",
-  "sf_chartIndex" : 1,
-  "sf_description" : "",
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 1000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_19=id(report=1);find(query='(sf_metric:cpu.utilization AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:signalfx\\\\-metadata))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_19 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19')",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allDetectorDecorators" : [ ],
-    "allPlotConstructs" : [ ],
-    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.aggregation.cpu-average.cpu.idle AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('aws_Name')->_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_0_5');_SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK" ],
-    "allPlots" : [ {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "CPU utilization (%)",
-      "queryItems" : [ {
-        "NOT" : false,
-        "displayName" : "signalfx-metadata",
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "signalfx-metadata",
-        "query" : "plugin:\"signalfx-metadata\"",
-        "type" : "property",
-        "value" : "signalfx-metadata"
-      } ],
-      "seriesData" : {
-        "metric" : "cpu.utilization",
-        "regExStyle" : null
-      },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "area",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "legendColumnConfiguration" : null,
-      "range" : -7200000,
-      "rangeEnd" : 0,
-      "sortPreference" : "",
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "%",
-        "max" : 110,
-        "min" : 0,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 7,
-    "revisionNumber" : 19,
-    "sf_detectorDecorators" : [ ],
-    "uiHelperValue" : "##CHARTID##_19"
-  }
-}, {
-  "marshallId" : 14,
+  "marshallId" : 7,
   "marshallMemberOf" : [ 3 ],
   "sf_chart" : "Disk Free %",
   "sf_chartIndex" : 1433463909939,
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 10000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_9_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};find(query='(sf_metric:disk.utilization AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:signalfx\\\\-metadata))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_9;_SF_PLOT_KEY_##CHARTID##_2_9_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_2_9->groupby() -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_2_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');_SF_PLOT_KEY_##CHARTID##_1_9->?A:_SF_PLOT_KEY_##CHARTID##_2_9_MACROBLOCK",
   "sf_type" : "Chart",
   "sf_uiModel" : {
     "allPlotConstructs" : [ ],
@@ -1897,6 +733,14 @@
         "query" : "plugin:\"signalfx-metadata\"",
         "type" : "property",
         "value" : "signalfx-metadata"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
       } ],
       "seriesData" : {
         "metric" : "disk.utilization",
@@ -1970,18 +814,679 @@
       } ]
     },
     "currentUniqueKey" : 6,
-    "revisionNumber" : 9,
-    "uiHelperValue" : "##CHARTID##_9"
+    "revisionNumber" : 10,
+    "uiHelperValue" : "##CHARTID##_10"
   }
 }, {
-  "marshallId" : 15,
+  "marshallId" : 8,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Memory Used %",
+  "sf_chartIndex" : 1459445051615,
+  "sf_description" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.free AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3=id", "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.used AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK=[?B,?A,!OUT]{?B  /  (?A  +  ?B)  *  100->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('sf_source')->groupby('aws_Name')->stats:!mean->_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_2_3');_SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3->?B:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK;_SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#05ce00",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "free",
+      "queryItems" : [ {
+        "NOT" : false,
+        "displayName" : "signalfx-metadata",
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "signalfx-metadata",
+        "query" : "plugin:\"signalfx-metadata\"",
+        "type" : "property",
+        "value" : "signalfx-metadata"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
+      } ],
+      "seriesData" : {
+        "metric" : "memory.utilization",
+        "regExStyle" : null
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "single",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "disableThrottle" : false,
+      "hideTimestamp" : false,
+      "maxDecimalPlaces" : 3,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "-value",
+      "stackedChart" : true,
+      "updateInterval" : "",
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "%",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 9,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 19,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_19"
+  }
+}, {
+  "marshallId" : 9,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Memory",
+  "sf_chartIndex" : 4,
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.free AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3=id", "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.used AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK=[?B,?A,!OUT]{?B  /  (?A  +  ?B)  *  100->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('sf_source')->groupby('aws_Name')->stats:!mean->_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_2_3');_SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3->?B:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK;_SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#05ce00",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "bytes",
+      "queryItems" : [ {
+        "NOT" : false,
+        "displayName" : "memory",
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memory",
+        "query" : "plugin:memory",
+        "type" : "property",
+        "value" : "memory"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
+      } ],
+      "seriesData" : {
+        "metric" : "memory.free",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#bd468d",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "bytes",
+      "queryItems" : [ {
+        "NOT" : false,
+        "displayName" : "memory",
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memory",
+        "query" : "plugin:memory",
+        "type" : "property",
+        "value" : "memory"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
+      } ],
+      "seriesData" : {
+        "metric" : "memory.used",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#876ff3",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "bytes",
+      "queryItems" : [ {
+        "NOT" : false,
+        "displayName" : "memory",
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memory",
+        "query" : "plugin:memory",
+        "type" : "property",
+        "value" : "memory"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
+      } ],
+      "seriesData" : {
+        "metric" : "memory.buffered",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 13,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#ab99bc",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "bytes",
+      "queryItems" : [ {
+        "NOT" : false,
+        "displayName" : "memory",
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memory",
+        "query" : "plugin:memory",
+        "type" : "property",
+        "value" : "memory"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
+      } ],
+      "seriesData" : {
+        "metric" : "memory.cached",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 14,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#00b9ff",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "bytes",
+      "queryItems" : [ {
+        "NOT" : false,
+        "displayName" : "memory",
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memory",
+        "query" : "plugin:memory",
+        "type" : "property",
+        "value" : "memory"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
+      } ],
+      "seriesData" : {
+        "metric" : "memory.slab_recl",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 15,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#0077c2",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "bytes",
+      "queryItems" : [ {
+        "NOT" : false,
+        "displayName" : "memory",
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memory",
+        "query" : "plugin:memory",
+        "type" : "property",
+        "value" : "memory"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
+      } ],
+      "seriesData" : {
+        "metric" : "memory.slab_unrecl",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 16,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "bytes",
+      "queryItems" : [ {
+        "NOT" : false,
+        "displayName" : "memory",
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memory",
+        "query" : "plugin:memory",
+        "type" : "property",
+        "value" : "memory"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
+      } ],
+      "seriesData" : {
+        "metric" : "memory.active",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 17,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#f47e00",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "bytes",
+      "queryItems" : [ {
+        "NOT" : false,
+        "displayName" : "memory",
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memory",
+        "query" : "plugin:memory",
+        "type" : "property",
+        "value" : "memory"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
+      } ],
+      "seriesData" : {
+        "metric" : "memory.inactive",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 18,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#e5b312",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "bytes",
+      "queryItems" : [ {
+        "NOT" : false,
+        "displayName" : "memory",
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "memory",
+        "query" : "plugin:memory",
+        "type" : "property",
+        "value" : "memory"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
+      } ],
+      "seriesData" : {
+        "metric" : "memory.wired",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 19,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 20,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "disableThrottle" : false,
+      "legendColumnConfiguration" : [ {
+        "enabled" : true,
+        "property" : "sf_originatingMetric"
+      }, {
+        "enabled" : true,
+        "property" : "sf_metric"
+      }, {
+        "enabled" : false,
+        "property" : "plugin"
+      }, {
+        "enabled" : false,
+        "property" : "dsname"
+      }, {
+        "enabled" : false,
+        "property" : "host"
+      }, {
+        "enabled" : false,
+        "property" : "AWSUniqueId"
+      } ],
+      "maxDecimalPlaces" : 3,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "-value",
+      "stackedChart" : true,
+      "updateInterval" : "",
+      "useKMG2" : true,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "bytes",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 21,
+    "revisionNumber" : 22,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_22"
+  }
+}, {
+  "marshallId" : 10,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Disk Used %",
+  "sf_chartIndex" : 1459445557108,
+  "sf_description" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlotConstructs" : [ ],
+    "allPlots" : [ {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "",
+      "queryItems" : [ {
+        "NOT" : false,
+        "displayName" : "signalfx-metadata",
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "signalfx-metadata",
+        "query" : "plugin:\"signalfx-metadata\"",
+        "type" : "property",
+        "value" : "signalfx-metadata"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
+      } ],
+      "seriesData" : {
+        "metric" : "disk.utilization",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "expressionText" : "A",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 2,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "list",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "legendColumnConfiguration" : null,
+      "maxDecimalPlaces" : 3,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "-value",
+      "stackedChart" : true,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "%",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 7,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 15,
+    "uiHelperValue" : "##CHARTID##_15"
+  }
+}, {
+  "marshallId" : 11,
   "marshallMemberOf" : [ 3 ],
   "sf_chart" : "Load Average",
   "sf_chartIndex" : 2,
   "sf_description" : "",
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 10000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_15=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_15=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_15=id(report=1);find(query='(sf_metric:load.shortterm AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:load))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_15 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_15',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_15');find(query='(sf_metric:load.midterm AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:load))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_15 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_15',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_15');find(query='(sf_metric:load.longterm AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:load))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_15 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_15',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_15')",
   "sf_type" : "Chart",
   "sf_uiModel" : {
     "allDetectorDecorators" : [ ],
@@ -2022,6 +1527,14 @@
         "query" : "plugin:load",
         "type" : "property",
         "value" : "load"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
       } ],
       "seriesData" : {
         "metric" : "load.shortterm"
@@ -2067,6 +1580,14 @@
         "query" : "plugin:load",
         "type" : "property",
         "value" : "load"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
       } ],
       "seriesData" : {
         "metric" : "load.midterm"
@@ -2112,6 +1633,14 @@
         "query" : "plugin:load",
         "type" : "property",
         "value" : "load"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
       } ],
       "seriesData" : {
         "metric" : "load.longterm"
@@ -2165,9 +1694,665 @@
       } ]
     },
     "currentUniqueKey" : 5,
-    "revisionNumber" : 15,
+    "revisionNumber" : 16,
     "sf_detectorDecorators" : [ ],
-    "uiHelperValue" : "##CHARTID##_15"
+    "uiHelperValue" : "##CHARTID##_16"
+  }
+}, {
+  "marshallId" : 12,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Disk I/O",
+  "sf_chartIndex" : 5,
+  "sf_description" : "operations/sec",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.disk.*disk_ops.read AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_6_1_7=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_6_1_7',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_6_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_6_7')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "read ops/sec",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "disk",
+        "query" : "plugin:disk",
+        "type" : "property",
+        "value" : "disk"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
+      } ],
+      "seriesData" : {
+        "metric" : "disk_ops.read"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#0077c2",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "write ops/sec",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "disk",
+        "query" : "plugin:disk",
+        "type" : "property",
+        "value" : "disk"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
+      } ],
+      "seriesData" : {
+        "metric" : "disk_ops.write"
+      },
+      "sf_programText" : "find(query='(sf_metric:disk_ops.read AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2))') -> fetch -> groupby() -> stats:!sum -> _SF_PLOT_KEY_CGraATNAgAA_3_10=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGraATNAgAA_3_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGraATNAgAA_10')",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 1
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "valid" : false,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "legendColumnConfiguration" : null,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "read ops - RED",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "label" : "write ops - BLUE",
+        "max" : null,
+        "min" : 0,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
+      } ]
+    },
+    "currentUniqueKey" : 5,
+    "revisionNumber" : 20,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_20"
+  }
+}, {
+  "marshallId" : 13,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "CPU %",
+  "sf_chartIndex" : 1,
+  "sf_description" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.aggregation.cpu-average.cpu.idle AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('aws_Name')->_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_0_5');_SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "CPU utilization (%)",
+      "queryItems" : [ {
+        "NOT" : false,
+        "displayName" : "signalfx-metadata",
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "signalfx-metadata",
+        "query" : "plugin:\"signalfx-metadata\"",
+        "type" : "property",
+        "value" : "signalfx-metadata"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
+      } ],
+      "seriesData" : {
+        "metric" : "cpu.utilization",
+        "regExStyle" : null
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "legendColumnConfiguration" : null,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "%",
+        "max" : 110,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 7,
+    "revisionNumber" : 20,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_20"
+  }
+}, {
+  "marshallId" : 14,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Memory Paging",
+  "sf_chartIndex" : 3,
+  "sf_description" : "page swaps/sec",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.vmem.vmpage_io.swap.in AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_3_4')", "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.vmem.vmpage_io.swap.out AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_3_4')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "DELTA_ROLLUP"
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "swapped in",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "vmem",
+        "query" : "plugin:vmem",
+        "type" : "property",
+        "value" : "vmem"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
+      } ],
+      "seriesData" : {
+        "metric" : "vmpage_io.swap.in"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#0077c2",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "DELTA_ROLLUP"
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "swapped out",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "vmem",
+        "query" : "plugin:vmem",
+        "type" : "property",
+        "value" : "vmem"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
+      } ],
+      "seriesData" : {
+        "metric" : "vmpage_io.swap.out"
+      },
+      "sf_programText" : "find(refresh=300000,query='sf_metric:collectd.vmem.vmpage_io.swap.in AND sf_organizationID:BqDQY5OAAAA AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_BwzVGs0AEAA_2_2=id -> publish(defaultSource='_SF_PLOT_KEY_BwzVGs0AEAA_2_2',metric='_SF_PLOT_KEY_BwzVGs0AEAA_2_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='BwzVGs0AEAA_2')",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 1
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "query" : "aws_service:quantizer",
+        "type" : "property",
+        "value" : "Aws_service:quantizer"
+      } ],
+      "seriesData" : { },
+      "sf_programText" : "",
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "valid" : false,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "legendColumnConfiguration" : null,
+      "maxDecimalPlaces" : 3,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : false,
+      "updateInterval" : "",
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "swapped in - RED",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "label" : "swapped out - BLUE",
+        "max" : null,
+        "min" : 0,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
+      } ]
+    },
+    "currentUniqueKey" : 4,
+    "revisionNumber" : 16,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_16"
+  }
+}, {
+  "marshallId" : 15,
+  "marshallMemberOf" : [ 3 ],
+  "sf_chart" : "Total Network bits/sec",
+  "sf_chartIndex" : 1459445812323,
+  "sf_description" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.interface*.if_octets.rx AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> ?a:math(b=8):!product -> _SF_PLOT_KEY_SYNTH_CHART_ID_7_1_6=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_7_1_6',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_7_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_7_6')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "scaleAmount" : 8
+          },
+          "type" : "SCALE"
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "input bits/sec",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "e*",
+        "query" : "plugin_instance:e*",
+        "type" : "property",
+        "value" : "plugin_instance:e*"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "interface",
+        "query" : "plugin:interface",
+        "type" : "property",
+        "value" : "interface"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
+      } ],
+      "seriesData" : {
+        "metric" : "if_octets.rx"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#0077c2",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "scaleAmount" : 8
+          },
+          "type" : "SCALE"
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "output bits/sec",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "e*",
+        "query" : "plugin_instance:e*",
+        "type" : "property",
+        "value" : "plugin_instance:e*"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "interface",
+        "query" : "plugin:interface",
+        "type" : "property",
+        "value" : "interface"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
+      } ],
+      "seriesData" : {
+        "metric" : "if_octets.tx"
+      },
+      "sf_programText" : "find(query='(sf_metric:if_octets.rx AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((host:i\\\\-1cb43ef2) AND (plugin_instance:e*))') -> fetch -> split -> stats:!mean -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_CGraATOAYAA_2_12=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGraATOAYAA_2_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGraATOAYAA_12')",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 1
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "list",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "forcedResolution" : "0",
+      "hideDimensionsInList" : true,
+      "legendColumnConfiguration" : null,
+      "maxDecimalPlaces" : 4,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "+sf_metric",
+      "updateInterval" : "",
+      "useKMG2" : true,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "bits/s",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "label" : "",
+        "max" : null,
+        "min" : 0,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
+      } ]
+    },
+    "currentUniqueKey" : 5,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 30,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_30"
   }
 }, {
   "marshallId" : 16,
@@ -2316,12 +2501,564 @@
 }, {
   "marshallId" : 17,
   "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "Total Network I/O",
+  "sf_chartIndex" : 1433978780955,
+  "sf_description" : "bits/sec",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.disk.*disk_ops.write AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_5_6')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#0077c2",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "name" : "New Aggregation",
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "scaleAmount" : 8
+          },
+          "type" : "SCALE"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "transmitted bits/sec",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "interface",
+        "query" : "plugin:interface",
+        "type" : "property",
+        "value" : "interface"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "e*",
+        "query" : "plugin_instance:e*",
+        "type" : "property",
+        "value" : "plugin_instance:e*"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
+      } ],
+      "seriesData" : {
+        "metric" : "if_octets.tx"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 1
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "name" : "New Aggregation",
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "scaleAmount" : 8
+          },
+          "type" : "SCALE"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "received bits/sec",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "interface",
+        "query" : "plugin:interface",
+        "type" : "property",
+        "value" : "interface"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "e*",
+        "query" : "plugin_instance:e*",
+        "type" : "property",
+        "value" : "plugin_instance:e*"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
+      } ],
+      "seriesData" : {
+        "metric" : "if_octets.rx"
+      },
+      "sf_programText" : "find(query='(sf_metric:disk_ops.write AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_CGrk08YAgAA_3_9=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGrk08YAgAA_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08YAgAA_9')",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "valid" : false,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "legendColumnConfiguration" : null,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "showDots" : false,
+      "sortPreference" : "",
+      "updateInterval" : "",
+      "useKMG2" : true,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "received - RED",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "label" : "transmitted - BLUE",
+        "max" : null,
+        "min" : 0,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
+      } ]
+    },
+    "currentUniqueKey" : 5,
+    "revisionNumber" : 16,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_16"
+  }
+}, {
+  "marshallId" : 18,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "Total Disk I/O Ops",
+  "sf_chartIndex" : 6,
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.disk.*disk_ops.write AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_5_6')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#0077c2",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "name" : "New Aggregation",
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "write ops/sec",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "disk",
+        "query" : "plugin:disk",
+        "type" : "property",
+        "value" : "disk"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
+      } ],
+      "seriesData" : {
+        "metric" : "disk_ops.write"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 1
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "name" : "New Aggregation",
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "read ops/sec",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "disk",
+        "query" : "plugin:disk",
+        "type" : "property",
+        "value" : "disk"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
+      } ],
+      "seriesData" : {
+        "metric" : "disk_ops.read"
+      },
+      "sf_programText" : "find(query='(sf_metric:disk_ops.write AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_CGrk08YAgAA_3_9=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGrk08YAgAA_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08YAgAA_9')",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "valid" : false,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "legendColumnConfiguration" : null,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "reads / s - RED",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "label" : "writes / s - BLUE",
+        "max" : null,
+        "min" : 0,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
+      } ]
+    },
+    "currentUniqueKey" : 5,
+    "revisionNumber" : 13,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_13"
+  }
+}, {
+  "marshallId" : 19,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "Top 5-min Load Avg",
+  "sf_chartIndex" : 2,
+  "sf_description" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.load.load.shortterm AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_1_5')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "amount" : 1,
+            "transformTimeRange" : "1m",
+            "unit" : "m"
+          },
+          "type" : "transformation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "name" : "New Aggregation",
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "count" : 10
+          },
+          "type" : "TOPN"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "load",
+        "query" : "plugin:load",
+        "type" : "property",
+        "value" : "load"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
+      } ],
+      "seriesData" : {
+        "metric" : "load.midterm"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "query" : "aws_service:quantizer",
+        "type" : "property",
+        "value" : "Aws_service:quantizer"
+      } ],
+      "seriesData" : { },
+      "sf_programText" : "",
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "list",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "forcedResolution" : "0",
+      "legendColumnConfiguration" : null,
+      "maxDecimalPlaces" : 3,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "-value",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 3,
+    "revisionNumber" : 14,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_14"
+  }
+}, {
+  "marshallId" : 20,
+  "marshallMemberOf" : [ 16 ],
   "sf_chart" : "CPU %",
   "sf_chartIndex" : 1,
   "sf_description" : "percentile distribution",
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 1000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_28=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_28=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_28_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_3_28=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_28_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_4_28=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_28_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_5_28=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_28_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_6_28=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_28_MACROBLOCK=[?A,!OUT]{?A->!OUT};find(query='(sf_metric:cpu.utilization AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:signalfx\\\\-metadata) AND (NOT _exists_:agent))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_28;_SF_PLOT_KEY_##CHARTID##_2_28_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_2_28->groupby() -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_2_28',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_28');_SF_PLOT_KEY_##CHARTID##_1_28->?A:_SF_PLOT_KEY_##CHARTID##_2_28_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_28_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_3_28->groupby() -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_28',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_28');_SF_PLOT_KEY_##CHARTID##_1_28->?A:_SF_PLOT_KEY_##CHARTID##_3_28_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_28_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_4_28->groupby() -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_28',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_28');_SF_PLOT_KEY_##CHARTID##_1_28->?A:_SF_PLOT_KEY_##CHARTID##_4_28_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_28_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_5_28->groupby() -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_28',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_28');_SF_PLOT_KEY_##CHARTID##_1_28->?A:_SF_PLOT_KEY_##CHARTID##_5_28_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_28_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_6_28->groupby() -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_28',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_28');_SF_PLOT_KEY_##CHARTID##_1_28->?A:_SF_PLOT_KEY_##CHARTID##_6_28_MACROBLOCK",
   "sf_type" : "Chart",
   "sf_uiModel" : {
     "allDetectorDecorators" : [ ],
@@ -2641,1235 +3378,10 @@
     "uiHelperValue" : "##CHARTID##_28"
   }
 }, {
-  "marshallId" : 18,
-  "marshallMemberOf" : [ 16 ],
-  "sf_chart" : "Total Network I/O",
-  "sf_chartIndex" : 1433978780955,
-  "sf_description" : "bits/sec",
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 1000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_16=id(report=1);find(query='(sf_metric:if_octets.tx AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:interface) AND (plugin_instance:e*) AND (NOT _exists_:agent))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_1_16 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');find(query='(sf_metric:if_octets.rx AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:interface) AND (plugin_instance:e*) AND (NOT _exists_:agent))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> { ?in * 8 -> !out } -> _SF_PLOT_KEY_##CHARTID##_2_16 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16')",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allDetectorDecorators" : [ ],
-    "allPlotConstructs" : [ ],
-    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.disk.*disk_ops.write AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_5_6')" ],
-    "allPlots" : [ {
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#0077c2",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "name" : "New Aggregation",
-        "showMe" : false
-      }, {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "scaleAmount" : 8
-          },
-          "type" : "SCALE"
-        },
-        "showMe" : false
-      } ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "transmitted bits/sec",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "interface",
-        "query" : "plugin:interface",
-        "type" : "property",
-        "value" : "interface"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin_instance",
-        "propertyValue" : "e*",
-        "query" : "plugin_instance:e*",
-        "type" : "property",
-        "value" : "plugin_instance:e*"
-      }, {
-        "NOT" : true,
-        "iconClass" : "icon-properties",
-        "property" : "agent",
-        "propertyValue" : "*",
-        "query" : "NOT agent:*",
-        "type" : "property",
-        "value" : "agent:*"
-      } ],
-      "seriesData" : {
-        "metric" : "if_octets.tx"
-      },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "valid" : false,
-      "yAxisIndex" : 1
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#b04600",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "name" : "New Aggregation",
-        "showMe" : false
-      }, {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "scaleAmount" : 8
-          },
-          "type" : "SCALE"
-        },
-        "showMe" : false
-      } ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "received bits/sec",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "interface",
-        "query" : "plugin:interface",
-        "type" : "property",
-        "value" : "interface"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin_instance",
-        "propertyValue" : "e*",
-        "query" : "plugin_instance:e*",
-        "type" : "property",
-        "value" : "plugin_instance:e*"
-      }, {
-        "NOT" : true,
-        "iconClass" : "icon-properties",
-        "property" : "agent",
-        "propertyValue" : "*",
-        "query" : "NOT agent:*",
-        "type" : "property",
-        "value" : "agent:*"
-      } ],
-      "seriesData" : {
-        "metric" : "if_octets.rx"
-      },
-      "sf_programText" : "find(query='(sf_metric:disk_ops.write AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_CGrk08YAgAA_3_9=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGrk08YAgAA_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08YAgAA_9')",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 3,
-      "valid" : false,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "disableThrottle" : false,
-      "legendColumnConfiguration" : null,
-      "range" : -7200000,
-      "rangeEnd" : 0,
-      "showDots" : false,
-      "sortPreference" : "",
-      "updateInterval" : "",
-      "useKMG2" : true,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "received - RED",
-        "max" : null,
-        "min" : 0,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      }, {
-        "label" : "transmitted - BLUE",
-        "max" : null,
-        "min" : 0,
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "title" : {
-          "text" : ""
-        }
-      } ]
-    },
-    "currentUniqueKey" : 5,
-    "revisionNumber" : 16,
-    "sf_detectorDecorators" : [ ],
-    "uiHelperValue" : "##CHARTID##_16"
-  }
-}, {
-  "marshallId" : 19,
-  "marshallMemberOf" : [ 16 ],
-  "sf_chart" : "Top CPU %",
-  "sf_chartIndex" : 1433981315431,
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 10000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_22=id(report=1);find(query='(sf_metric:cpu.utilization AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:signalfx\\\\-metadata) AND (NOT _exists_:agent))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('host') -> stats:!mean -> window(1m) -> stats:!mean -> groupby() -> groupby() -> select(count=10):!top -> split -> _SF_PLOT_KEY_##CHARTID##_1_22 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_22',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_22')",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allDetectorDecorators" : [ ],
-    "allPlotConstructs" : [ ],
-    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.aggregation.cpu-average.cpu.idle AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('aws_Name')->_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_0_5');_SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK" ],
-    "allPlots" : [ {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "host"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "MEAN"
-        },
-        "name" : "New Aggregation",
-        "showMe" : false
-      }, {
-        "direction" : {
-          "options" : {
-            "amount" : 1,
-            "transformTimeRange" : "1m",
-            "unit" : "m"
-          },
-          "type" : "transformation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "MEAN"
-        },
-        "name" : "New Transform",
-        "showMe" : false
-      }, {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "count" : 10
-          },
-          "type" : "TOPN"
-        },
-        "showMe" : false
-      } ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "",
-      "queryItems" : [ {
-        "NOT" : false,
-        "displayName" : "signalfx-metadata",
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "signalfx-metadata",
-        "query" : "plugin:\"signalfx-metadata\"",
-        "type" : "property",
-        "value" : "signalfx-metadata"
-      }, {
-        "NOT" : true,
-        "iconClass" : "icon-properties",
-        "property" : "agent",
-        "propertyValue" : "*",
-        "query" : "NOT agent:*",
-        "type" : "dimension",
-        "value" : "agent:*"
-      } ],
-      "seriesData" : {
-        "metric" : "cpu.utilization",
-        "regExStyle" : null
-      },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "list",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "disableThrottle" : false,
-      "forcedResolution" : "0",
-      "hideDimensionsInList" : false,
-      "legendColumnConfiguration" : null,
-      "maxDecimalPlaces" : 3,
-      "range" : -7200000,
-      "rangeEnd" : 0,
-      "sortPreference" : "-value",
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "max" : 120,
-        "min" : 0,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 7,
-    "revisionNumber" : 22,
-    "sf_detectorDecorators" : [ ],
-    "uiHelperValue" : "##CHARTID##_22"
-  }
-}, {
-  "marshallId" : 20,
-  "marshallMemberOf" : [ 16 ],
-  "sf_chart" : "Total Disk I/O Ops",
-  "sf_chartIndex" : 6,
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 1000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_13=id(report=1);find(query='(sf_metric:disk_ops.write AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:disk) AND (NOT _exists_:agent))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_13 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:disk_ops.read AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:disk) AND (NOT _exists_:agent))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_13 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allDetectorDecorators" : [ ],
-    "allPlotConstructs" : [ ],
-    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.disk.*disk_ops.write AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_5_1_6',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_5_6')" ],
-    "allPlots" : [ {
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#0077c2",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "name" : "New Aggregation",
-        "showMe" : false
-      } ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "write ops/sec",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "disk",
-        "query" : "plugin:disk",
-        "type" : "property",
-        "value" : "disk"
-      }, {
-        "NOT" : true,
-        "iconClass" : "icon-properties",
-        "property" : "agent",
-        "propertyValue" : "*",
-        "query" : "NOT agent:*",
-        "type" : "property",
-        "value" : "agent:*"
-      } ],
-      "seriesData" : {
-        "metric" : "disk_ops.write"
-      },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "valid" : false,
-      "yAxisIndex" : 1
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#b04600",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "name" : "New Aggregation",
-        "showMe" : false
-      } ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "read ops/sec",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "disk",
-        "query" : "plugin:disk",
-        "type" : "property",
-        "value" : "disk"
-      }, {
-        "NOT" : true,
-        "iconClass" : "icon-properties",
-        "property" : "agent",
-        "propertyValue" : "*",
-        "query" : "NOT agent:*",
-        "type" : "property",
-        "value" : "agent:*"
-      } ],
-      "seriesData" : {
-        "metric" : "disk_ops.read"
-      },
-      "sf_programText" : "find(query='(sf_metric:disk_ops.write AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_CGrk08YAgAA_3_9=id(report=1) -> publish(metric='_SF_PLOT_KEY_CGrk08YAgAA_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08YAgAA_9')",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 3,
-      "valid" : false,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "legendColumnConfiguration" : null,
-      "range" : -7200000,
-      "rangeEnd" : 0,
-      "sortPreference" : "",
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "reads / s - RED",
-        "max" : null,
-        "min" : 0,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      }, {
-        "label" : "writes / s - BLUE",
-        "max" : null,
-        "min" : 0,
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "title" : {
-          "text" : ""
-        }
-      } ]
-    },
-    "currentUniqueKey" : 5,
-    "revisionNumber" : 13,
-    "sf_detectorDecorators" : [ ],
-    "uiHelperValue" : "##CHARTID##_13"
-  }
-}, {
   "marshallId" : 21,
-  "marshallMemberOf" : [ 16 ],
-  "sf_chart" : "Memory Used %",
-  "sf_chartIndex" : 4,
-  "sf_description" : "percentile distribution",
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 1000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_19_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_3_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_4_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_19_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_5_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_19_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_6_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_19_MACROBLOCK=[?A,!OUT]{?A->!OUT};find(query='(sf_metric:memory.utilization AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:signalfx\\\\-metadata) AND (NOT _exists_:agent))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_19;_SF_PLOT_KEY_##CHARTID##_2_19_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_2_19->groupby() -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_2_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');_SF_PLOT_KEY_##CHARTID##_1_19->?A:_SF_PLOT_KEY_##CHARTID##_2_19_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_3_19->groupby() -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');_SF_PLOT_KEY_##CHARTID##_1_19->?A:_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_19_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_4_19->groupby() -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');_SF_PLOT_KEY_##CHARTID##_1_19->?A:_SF_PLOT_KEY_##CHARTID##_4_19_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_19_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_5_19->groupby() -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');_SF_PLOT_KEY_##CHARTID##_1_19->?A:_SF_PLOT_KEY_##CHARTID##_5_19_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_19_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_6_19->groupby() -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');_SF_PLOT_KEY_##CHARTID##_1_19->?A:_SF_PLOT_KEY_##CHARTID##_6_19_MACROBLOCK",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allDetectorDecorators" : [ ],
-    "allPlotConstructs" : [ ],
-    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.free AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3=id", "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.used AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK=[?B,?A,!OUT]{?B  /  (?A  +  ?B)  *  100->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('sf_source')->groupby('aws_Name')->stats:!mean->_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_2_3');_SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3->?B:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK;_SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK" ],
-    "allPlots" : [ {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "memory.utilization",
-      "queryItems" : [ {
-        "NOT" : false,
-        "displayName" : "signalfx-metadata",
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "signalfx-metadata",
-        "query" : "plugin:\"signalfx-metadata\"",
-        "type" : "property",
-        "value" : "signalfx-metadata"
-      }, {
-        "NOT" : true,
-        "iconClass" : "icon-properties",
-        "property" : "agent",
-        "propertyValue" : "*",
-        "query" : "NOT agent:*",
-        "type" : "dimension",
-        "value" : "agent:*"
-      } ],
-      "seriesData" : {
-        "metric" : "memory.utilization",
-        "regExStyle" : null
-      },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#05ce00",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "MIN"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "A",
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "min",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 2,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#0dba8f",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "percentile" : 10
-          },
-          "type" : "PERCENTILE"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "A",
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "p10",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "sf_programText" : "_SF_PLOT_KEY_CGrk08TAYAA_6_12_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08TAYAA_6_12_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_CGrk08TAYAA_6_12=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08TAYAA_6_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08TAYAA_12');_SF_PLOT_KEY_CGrk08TAYAA_3_12->?C:_SF_PLOT_KEY_CGrk08TAYAA_6_12_MACROBLOCK",
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 3,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#00b9ff",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "percentile" : 50
-          },
-          "type" : "PERCENTILE"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "A",
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "median",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "sf_programText" : "_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_CGrk08TAYAA_7_12=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08TAYAA_7_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08TAYAA_12');_SF_PLOT_KEY_CGrk08TAYAA_3_12->?C:_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK",
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 4,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#ff8dd1",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "percentile" : 90
-          },
-          "type" : "PERCENTILE"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "A",
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "p90",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "sf_programText" : "_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_CGrk08TAYAA_7_12=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08TAYAA_7_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08TAYAA_12');_SF_PLOT_KEY_CGrk08TAYAA_3_12->?C:_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK",
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 5,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#bd468d",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "MAX"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "A",
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "max",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "sf_programText" : "_SF_PLOT_KEY_CGrk08TAYAA_5_13_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08TAYAA_5_13_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_CGrk08TAYAA_5_13=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08TAYAA_5_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08TAYAA_13');_SF_PLOT_KEY_CGrk08TAYAA_3_13->?C:_SF_PLOT_KEY_CGrk08TAYAA_5_13_MACROBLOCK",
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 6,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 7,
-      "valid" : false,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "area",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "disableThrottle" : false,
-      "legendColumnConfiguration" : null,
-      "range" : -7200000,
-      "rangeEnd" : 0,
-      "sortPreference" : "",
-      "stackedChart" : false,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "max" : 120,
-        "min" : 0,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 12,
-    "revisionNumber" : 19,
-    "sf_detectorDecorators" : [ ],
-    "uiHelperValue" : "##CHARTID##_19"
-  }
-}, {
-  "marshallId" : 22,
-  "marshallMemberOf" : [ 16 ],
-  "sf_chart" : "Top Mem Page Swaps/sec",
-  "sf_chartIndex" : 3,
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 10000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_13_MACROBLOCK=[?A,?B,!OUT]{?A + ?B->!OUT};find(query='(sf_metric:vmpage_io.swap.in AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:vmem) AND (NOT _exists_:agent))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_13;find(query='(sf_metric:vmpage_io.swap.out AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:vmem) AND (NOT _exists_:agent))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_13;_SF_PLOT_KEY_##CHARTID##_3_13_MACROBLOCK:!OUT->groupby('host')->stats:!mean->groupby()->groupby()->select(count=10):!top->split->_SF_PLOT_KEY_##CHARTID##_3_13->groupby() -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');_SF_PLOT_KEY_##CHARTID##_1_13->?A:_SF_PLOT_KEY_##CHARTID##_3_13_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_13->?B:_SF_PLOT_KEY_##CHARTID##_3_13_MACROBLOCK",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allDetectorDecorators" : [ ],
-    "allPlotConstructs" : [ ],
-    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.vmem.vmpage_io.swap.in AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_3_4')", "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.vmem.vmpage_io.swap.out AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_3_4')" ],
-    "allPlots" : [ {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "pages swapped in/sec",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "vmem",
-        "query" : "plugin:vmem",
-        "type" : "property",
-        "value" : "vmem"
-      }, {
-        "NOT" : true,
-        "iconClass" : "icon-properties",
-        "property" : "agent",
-        "propertyValue" : "*",
-        "query" : "NOT agent:*",
-        "type" : "property",
-        "value" : "agent:*"
-      } ],
-      "seriesData" : {
-        "metric" : "vmpage_io.swap.in"
-      },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "pages swapped out/sec",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "vmem",
-        "query" : "plugin:vmem",
-        "type" : "property",
-        "value" : "vmem"
-      }, {
-        "NOT" : true,
-        "iconClass" : "icon-properties",
-        "property" : "agent",
-        "propertyValue" : "*",
-        "query" : "NOT agent:*",
-        "type" : "property",
-        "value" : "agent:*"
-      } ],
-      "seriesData" : {
-        "metric" : "vmpage_io.swap.out"
-      },
-      "sf_programText" : "find(refresh=300000,query='sf_metric:collectd.vmem.vmpage_io.swap.in AND sf_organizationID:BqDQY5OAAAA AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_BwzVGs0AEAA_2_2=id -> publish(defaultSource='_SF_PLOT_KEY_BwzVGs0AEAA_2_2',metric='_SF_PLOT_KEY_BwzVGs0AEAA_2_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='BwzVGs0AEAA_2')",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "valid" : false,
-      "yAxisIndex" : 1
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "host"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "MEAN"
-        },
-        "name" : "New Aggregation",
-        "showMe" : false
-      }, {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "count" : 10
-          },
-          "type" : "TOPN"
-        },
-        "name" : "New Aggregation",
-        "showMe" : false
-      } ],
-      "expressionText" : "A+B",
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "",
-      "queryItems" : [ {
-        "iconClass" : "sf-icon-property",
-        "query" : "aws_service:quantizer",
-        "type" : "property",
-        "value" : "Aws_service:quantizer"
-      } ],
-      "seriesData" : { },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 3,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 4,
-      "valid" : false,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "list",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "legendColumnConfiguration" : null,
-      "range" : -7200000,
-      "rangeEnd" : 0,
-      "sortPreference" : "-value",
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      }, {
-        "max" : null,
-        "min" : null,
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "title" : {
-          "text" : ""
-        }
-      } ]
-    },
-    "currentUniqueKey" : 5,
-    "revisionNumber" : 13,
-    "sf_detectorDecorators" : [ ],
-    "uiHelperValue" : "##CHARTID##_13"
-  }
-}, {
-  "marshallId" : 23,
-  "marshallMemberOf" : [ 16 ],
-  "sf_chart" : "Total Network Errors",
-  "sf_chartIndex" : 1465340609155,
-  "sf_description" : "errors/sec",
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 1000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_23=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_23=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_23=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_23_MACROBLOCK=[?A,?B,!OUT]{?A  +  ?B->!OUT};find(query='(sf_metric:if_errors.rx AND _missing_:sf_programId) AND ((plugin:interface) AND (plugin_instance:e*))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_23;find(query='(sf_metric:if_errors.tx AND _missing_:sf_programId) AND ((plugin:interface) AND (plugin_instance:e*))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_23;_SF_PLOT_KEY_##CHARTID##_3_23_MACROBLOCK:!OUT->groupby()->stats:!sum->_SF_PLOT_KEY_##CHARTID##_3_23->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');_SF_PLOT_KEY_##CHARTID##_1_23->?A:_SF_PLOT_KEY_##CHARTID##_3_23_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_23->?B:_SF_PLOT_KEY_##CHARTID##_3_23_MACROBLOCK",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allDetectorDecorators" : [ ],
-    "allPlotConstructs" : [ ],
-    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.interface.*.if_errors.* AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_10_8')" ],
-    "allPlots" : [ {
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "errors/sec",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "interface",
-        "query" : "plugin:interface",
-        "type" : "property",
-        "value" : "interface"
-      }, {
-        "NOT" : false,
-        "displayName" : "plugin_instance:e*",
-        "iconClass" : "icon-properties",
-        "property" : "plugin_instance",
-        "propertyValue" : "e*",
-        "query" : "plugin_instance:e*",
-        "type" : "property",
-        "value" : "plugin_instance:e*"
-      } ],
-      "seriesData" : {
-        "metric" : "if_errors.rx"
-      },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "if_errors.tx",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "interface",
-        "query" : "plugin:interface",
-        "type" : "property",
-        "value" : "interface"
-      }, {
-        "NOT" : false,
-        "displayName" : "plugin_instance:e*",
-        "iconClass" : "icon-properties",
-        "property" : "plugin_instance",
-        "propertyValue" : "e*",
-        "query" : "plugin_instance:e*",
-        "type" : "property",
-        "value" : "plugin_instance:e*"
-      } ],
-      "seriesData" : {
-        "metric" : "if_errors.tx"
-      },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "valid" : false,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "colorOverride" : "#b04600",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "name" : "New Aggregation",
-        "showMe" : false
-      } ],
-      "expressionText" : "A + B",
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "interface errors / sec",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "sf_programText" : "",
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 3,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "dataManipulations" : [ ],
-      "focusNext" : false,
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 4,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : true,
-      "disableThrottle" : false,
-      "forcedResolution" : "0",
-      "range" : -7200000,
-      "rangeEnd" : 0,
-      "sortPreference" : "",
-      "stackedChart" : false,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "interface errors - RED",
-        "max" : null,
-        "min" : 0,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      }, {
-        "label" : "retransmits - BLUE",
-        "max" : null,
-        "min" : null,
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "title" : {
-          "text" : ""
-        }
-      } ]
-    },
-    "currentUniqueKey" : 7,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 23,
-    "sf_detectorDecorators" : [ ],
-    "uiHelperValue" : "##CHARTID##_23"
-  }
-}, {
-  "marshallId" : 24,
   "marshallMemberOf" : [ 16 ],
   "sf_chart" : "Total Memory",
   "sf_chartIndex" : 1433972294516,
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 1000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_22=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_22=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_22=id(report=1);_SF_PLOT_KEY_##CHARTID##_9_22=id(report=1);_SF_PLOT_KEY_##CHARTID##_10_22=id(report=1);_SF_PLOT_KEY_##CHARTID##_11_22=id(report=1);_SF_PLOT_KEY_##CHARTID##_12_22=id(report=1);_SF_PLOT_KEY_##CHARTID##_13_22=id(report=1);_SF_PLOT_KEY_##CHARTID##_14_22=id(report=1);find(query='(sf_metric:memory.free AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:memory) AND (NOT _exists_:agent))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_22 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_22',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_22');find(query='(sf_metric:memory.used AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:memory) AND (NOT _exists_:agent))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_22 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_22',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_22');find(query='(sf_metric:memory.buffered AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:memory) AND (NOT _exists_:agent))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_8_22 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_8_22',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_22');find(query='(sf_metric:memory.cached AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:memory) AND (NOT _exists_:agent))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_9_22 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_9_22',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_22');find(query='(sf_metric:memory.slab_recl AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:memory) AND (NOT _exists_:agent))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_10_22 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_10_22',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_22');find(query='(sf_metric:memory.slab_unrecl AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:memory) AND (NOT _exists_:agent))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_11_22 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_11_22',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_22');find(query='(sf_metric:memory.active AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:memory) AND (NOT _exists_:agent))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_12_22 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_12_22',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_22');find(query='(sf_metric:memory.inactive AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:memory) AND (NOT _exists_:agent))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_13_22 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_13_22',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_22');find(query='(sf_metric:memory.wired AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:memory) AND (NOT _exists_:agent))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_14_22 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_14_22',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_22')",
   "sf_type" : "Chart",
   "sf_uiModel" : {
     "allDetectorDecorators" : [ ],
@@ -4430,19 +3942,16 @@
     "uiHelperValue" : "##CHARTID##_22"
   }
 }, {
-  "marshallId" : 25,
+  "marshallId" : 22,
   "marshallMemberOf" : [ 16 ],
-  "sf_chart" : "Top 5-min Load Avg",
-  "sf_chartIndex" : 2,
-  "sf_description" : "",
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 10000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);find(query='(sf_metric:load.midterm AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:load) AND (NOT _exists_:agent))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> window(1m) -> stats:!mean -> groupby('host') -> stats:!mean -> groupby() -> groupby() -> select(count=10):!top -> split -> _SF_PLOT_KEY_##CHARTID##_1_14 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
+  "sf_chart" : "Memory Used %",
+  "sf_chartIndex" : 4,
+  "sf_description" : "percentile distribution",
   "sf_type" : "Chart",
   "sf_uiModel" : {
     "allDetectorDecorators" : [ ],
     "allPlotConstructs" : [ ],
-    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.load.load.shortterm AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_1_1_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_1_5')" ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.free AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3=id", "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.memory.memory.used AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK=[?B,?A,!OUT]{?B  /  (?A  +  ?B)  *  100->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('sf_source')->groupby('aws_Name')->stats:!mean->_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_2_3');_SF_PLOT_KEY_SYNTH_CHART_ID_2_2_3->?B:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK;_SF_PLOT_KEY_SYNTH_CHART_ID_2_1_3->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_2_3_3_MACROBLOCK" ],
     "allPlots" : [ {
       "configuration" : {
         "aliases" : { },
@@ -4450,26 +3959,50 @@
         "maxExtrapolations" : -1,
         "rollupPolicy" : null
       },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "memory.utilization",
+      "queryItems" : [ {
+        "NOT" : false,
+        "displayName" : "signalfx-metadata",
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "signalfx-metadata",
+        "query" : "plugin:\"signalfx-metadata\"",
+        "type" : "property",
+        "value" : "signalfx-metadata"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "dimension",
+        "value" : "agent:*"
+      } ],
+      "seriesData" : {
+        "metric" : "memory.utilization",
+        "regExStyle" : null
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#05ce00",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
       "dataManipulations" : [ {
         "direction" : {
           "options" : {
-            "amount" : 1,
-            "transformTimeRange" : "1m",
-            "unit" : "m"
-          },
-          "type" : "transformation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "MEAN"
-        },
-        "showMe" : false
-      }, {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "host"
-            } ],
+            "aggregateGroupBy" : [ ],
             "collapseGroups" : false,
             "transformTimeRange" : null
           },
@@ -4477,11 +4010,30 @@
         },
         "fn" : {
           "options" : { },
-          "type" : "MEAN"
+          "type" : "MIN"
         },
-        "name" : "New Aggregation",
         "showMe" : false
-      }, {
+      } ],
+      "expressionText" : "A",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "min",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 2,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#0dba8f",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
         "direction" : {
           "options" : {
             "aggregateGroupBy" : [ ],
@@ -4492,24 +4044,226 @@
         },
         "fn" : {
           "options" : {
-            "count" : 10
+            "percentile" : 10
           },
-          "type" : "TOPN"
+          "type" : "PERCENTILE"
         },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "p10",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "sf_programText" : "_SF_PLOT_KEY_CGrk08TAYAA_6_12_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08TAYAA_6_12_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_CGrk08TAYAA_6_12=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08TAYAA_6_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08TAYAA_12');_SF_PLOT_KEY_CGrk08TAYAA_3_12->?C:_SF_PLOT_KEY_CGrk08TAYAA_6_12_MACROBLOCK",
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#00b9ff",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "percentile" : 50
+          },
+          "type" : "PERCENTILE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "median",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "sf_programText" : "_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_CGrk08TAYAA_7_12=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08TAYAA_7_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08TAYAA_12');_SF_PLOT_KEY_CGrk08TAYAA_3_12->?C:_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK",
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 4,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#ff8dd1",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "percentile" : 90
+          },
+          "type" : "PERCENTILE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "p90",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "sf_programText" : "_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_CGrk08TAYAA_7_12=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08TAYAA_7_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08TAYAA_12');_SF_PLOT_KEY_CGrk08TAYAA_3_12->?C:_SF_PLOT_KEY_CGrk08TAYAA_7_12_MACROBLOCK",
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 5,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#bd468d",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MAX"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "max",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "sf_programText" : "_SF_PLOT_KEY_CGrk08TAYAA_5_13_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_CGrk08TAYAA_5_13_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_CGrk08TAYAA_5_13=id(report=1)->publish(metric='_SF_PLOT_KEY_CGrk08TAYAA_5_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='CGrk08TAYAA_13');_SF_PLOT_KEY_CGrk08TAYAA_3_13->?C:_SF_PLOT_KEY_CGrk08TAYAA_5_13_MACROBLOCK",
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 6,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 7,
+      "valid" : false,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "legendColumnConfiguration" : null,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : false,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : 120,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 12,
+    "revisionNumber" : 19,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_19"
+  }
+}, {
+  "marshallId" : 23,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "# Active Hosts",
+  "sf_chartIndex" : 13,
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlots" : [ {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION",
+        "maxExtrapolations" : 5,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "COUNT"
+        },
+        "name" : "New Aggregation",
         "showMe" : false
       } ],
       "focusNext" : false,
       "invisible" : false,
       "metricDefinition" : { },
-      "name" : "",
+      "name" : "cpu.idle - COUNT",
       "queryItems" : [ {
         "NOT" : false,
         "iconClass" : "icon-properties",
         "property" : "plugin",
-        "propertyValue" : "load",
-        "query" : "plugin:load",
+        "propertyValue" : "memory",
+        "query" : "plugin:memory",
         "type" : "property",
-        "value" : "load"
+        "value" : "memory"
       }, {
         "NOT" : true,
         "iconClass" : "icon-properties",
@@ -4520,7 +4274,7 @@
         "value" : "agent:*"
       } ],
       "seriesData" : {
-        "metric" : "load.midterm"
+        "metric" : "memory.free"
       },
       "sf_programText" : "",
       "transient" : false,
@@ -4539,12 +4293,7 @@
       "invisible" : false,
       "metricDefinition" : { },
       "name" : "New Plot",
-      "queryItems" : [ {
-        "iconClass" : "sf-icon-property",
-        "query" : "aws_service:quantizer",
-        "type" : "property",
-        "value" : "Aws_service:quantizer"
-      } ],
+      "queryItems" : [ ],
       "seriesData" : { },
       "sf_programText" : "",
       "transient" : true,
@@ -4553,24 +4302,23 @@
       "valid" : false,
       "yAxisIndex" : 0
     } ],
-    "chartMode" : "list",
+    "chartMode" : "single",
     "chartType" : "line",
     "chartconfig" : {
       "absoluteEnd" : null,
       "absoluteStart" : null,
       "colorByMetric" : false,
       "disableThrottle" : false,
-      "forcedResolution" : "0",
-      "legendColumnConfiguration" : null,
-      "maxDecimalPlaces" : 3,
+      "hideTimestamp" : false,
+      "maxDecimalPlaces" : 4,
       "range" : -7200000,
       "rangeEnd" : 0,
-      "sortPreference" : "-value",
+      "sortPreference" : "",
       "updateInterval" : "",
       "yAxisConfigurations" : [ {
         "id" : "yAxis0",
         "max" : null,
-        "min" : 0,
+        "min" : null,
         "name" : "yAxis0",
         "plotlines" : {
           "high" : null,
@@ -4578,19 +4326,15 @@
         }
       } ]
     },
-    "currentUniqueKey" : 3,
+    "currentUniqueKey" : 4,
     "revisionNumber" : 14,
-    "sf_detectorDecorators" : [ ],
     "uiHelperValue" : "##CHARTID##_14"
   }
 }, {
-  "marshallId" : 26,
+  "marshallId" : 24,
   "marshallMemberOf" : [ 16 ],
   "sf_chart" : "Total Disk Space",
   "sf_chartIndex" : 1433983517758,
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 1000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_9=id(report=1);find(query='(sf_metric:df_complex.used AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:df) AND (NOT _exists_:agent))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_9 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');find(query='(sf_metric:df_complex.free AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:df) AND (NOT _exists_:agent))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby() -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_9 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9')",
   "sf_type" : "Chart",
   "sf_uiModel" : {
     "allPlotConstructs" : [ ],
@@ -4750,23 +4494,116 @@
     "uiHelperValue" : "##CHARTID##_9"
   }
 }, {
-  "marshallId" : 27,
+  "marshallId" : 25,
   "marshallMemberOf" : [ 16 ],
-  "sf_chart" : "# Active Hosts",
-  "sf_chartIndex" : 13,
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 10000,
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_14=id(report=1);find(query='(sf_metric:memory.free AND (_missing_:sf_programId AND _missing_:computationId)) AND ((plugin:memory) AND (NOT _exists_:agent))') -> fetch(extrapolation='LAST_VALUE_EXTRAPOLATION',maxExtrapolations=5) -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_14 -> groupby() -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_14',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_14')",
+  "sf_chart" : "Total Network Errors",
+  "sf_chartIndex" : 1465340609155,
+  "sf_description" : "errors/sec",
   "sf_type" : "Chart",
   "sf_uiModel" : {
     "allDetectorDecorators" : [ ],
     "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.interface.*.if_errors.* AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!sum -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_10_1_8',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_10_8')" ],
     "allPlots" : [ {
       "configuration" : {
         "aliases" : { },
-        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION",
-        "maxExtrapolations" : 5,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
         "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "errors/sec",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "interface",
+        "query" : "plugin:interface",
+        "type" : "property",
+        "value" : "interface"
+      }, {
+        "NOT" : false,
+        "displayName" : "plugin_instance:e*",
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "e*",
+        "query" : "plugin_instance:e*",
+        "type" : "property",
+        "value" : "plugin_instance:e*"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
+      } ],
+      "seriesData" : {
+        "metric" : "if_errors.rx"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "if_errors.tx",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "interface",
+        "query" : "plugin:interface",
+        "type" : "property",
+        "value" : "interface"
+      }, {
+        "NOT" : false,
+        "displayName" : "plugin_instance:e*",
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "e*",
+        "query" : "plugin_instance:e*",
+        "type" : "property",
+        "value" : "plugin_instance:e*"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
+      } ],
+      "seriesData" : {
+        "metric" : "if_errors.tx"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
       },
       "dataManipulations" : [ {
         "direction" : {
@@ -4779,23 +4616,114 @@
         },
         "fn" : {
           "options" : { },
-          "type" : "COUNT"
+          "type" : "SUM"
         },
         "name" : "New Aggregation",
         "showMe" : false
       } ],
+      "expressionText" : "A + B",
       "focusNext" : false,
       "invisible" : false,
       "metricDefinition" : { },
-      "name" : "cpu.idle - COUNT",
+      "name" : "interface errors / sec",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "disableThrottle" : false,
+      "legendColumnConfiguration" : null,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : false,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "interface errors - RED",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "label" : "retransmits - BLUE",
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
+      } ]
+    },
+    "currentUniqueKey" : 7,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 24,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_24"
+  }
+}, {
+  "marshallId" : 26,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "Top Mem Page Swaps/sec",
+  "sf_chartIndex" : 3,
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.vmem.vmpage_io.swap.in AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_3_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_3_4')", "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.vmem.vmpage_io.swap.out AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> groupby() -> select(count=5):!top -> groupby('aws_Name') -> _SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4=id -> publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_3_2_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_3_4')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "pages swapped in/sec",
       "queryItems" : [ {
         "NOT" : false,
         "iconClass" : "icon-properties",
         "property" : "plugin",
-        "propertyValue" : "memory",
-        "query" : "plugin:memory",
+        "propertyValue" : "vmem",
+        "query" : "plugin:vmem",
         "type" : "property",
-        "value" : "memory"
+        "value" : "vmem"
       }, {
         "NOT" : true,
         "iconClass" : "icon-properties",
@@ -4806,7 +4734,258 @@
         "value" : "agent:*"
       } ],
       "seriesData" : {
-        "metric" : "memory.free"
+        "metric" : "vmpage_io.swap.in"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "pages swapped out/sec",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "vmem",
+        "query" : "plugin:vmem",
+        "type" : "property",
+        "value" : "vmem"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "property",
+        "value" : "agent:*"
+      } ],
+      "seriesData" : {
+        "metric" : "vmpage_io.swap.out"
+      },
+      "sf_programText" : "find(refresh=300000,query='sf_metric:collectd.vmem.vmpage_io.swap.in AND sf_organizationID:BqDQY5OAAAA AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_BwzVGs0AEAA_2_2=id -> publish(defaultSource='_SF_PLOT_KEY_BwzVGs0AEAA_2_2',metric='_SF_PLOT_KEY_BwzVGs0AEAA_2_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='BwzVGs0AEAA_2')",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 1
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "name" : "New Aggregation",
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "count" : 10
+          },
+          "type" : "TOPN"
+        },
+        "name" : "New Aggregation",
+        "showMe" : false
+      } ],
+      "expressionText" : "A+B",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "",
+      "queryItems" : [ {
+        "iconClass" : "sf-icon-property",
+        "query" : "aws_service:quantizer",
+        "type" : "property",
+        "value" : "Aws_service:quantizer"
+      } ],
+      "seriesData" : { },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "valid" : false,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "list",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "legendColumnConfiguration" : null,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "-value",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
+      } ]
+    },
+    "currentUniqueKey" : 5,
+    "revisionNumber" : 13,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_13"
+  }
+}, {
+  "marshallId" : 27,
+  "marshallMemberOf" : [ 16 ],
+  "sf_chart" : "Top CPU %",
+  "sf_chartIndex" : 1433981315431,
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='(aws_service:quantizer) AND sf_metric:collectd.aggregation.cpu-average.cpu.idle AND sf_organizationID:SYNTH_ORG_ID AND NOT sf_metric:_*') -> fetch -> groupby('aws_Name') -> stats:!mean -> _SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5=id", "_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK=[?A,!OUT]{100  -  ?A->!OUT};_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK:!OUT->groupby()->select(count=5):!top->groupby('aws_Name')->_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5=id->publish(defaultSource='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',metric='_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='SYNTH_CHART_ID_0_5');_SF_PLOT_KEY_SYNTH_CHART_ID_0_1_5->?A:_SF_PLOT_KEY_SYNTH_CHART_ID_0_2_5_MACROBLOCK" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "name" : "New Aggregation",
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "amount" : 1,
+            "transformTimeRange" : "1m",
+            "unit" : "m"
+          },
+          "type" : "transformation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "name" : "New Transform",
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "count" : 10
+          },
+          "type" : "TOPN"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "",
+      "queryItems" : [ {
+        "NOT" : false,
+        "displayName" : "signalfx-metadata",
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "signalfx-metadata",
+        "query" : "plugin:\"signalfx-metadata\"",
+        "type" : "property",
+        "value" : "signalfx-metadata"
+      }, {
+        "NOT" : true,
+        "iconClass" : "icon-properties",
+        "property" : "agent",
+        "propertyValue" : "*",
+        "query" : "NOT agent:*",
+        "type" : "dimension",
+        "value" : "agent:*"
+      } ],
+      "seriesData" : {
+        "metric" : "cpu.utilization",
+        "regExStyle" : null
       },
       "sf_programText" : "",
       "transient" : false,
@@ -4827,30 +5006,30 @@
       "name" : "New Plot",
       "queryItems" : [ ],
       "seriesData" : { },
-      "sf_programText" : "",
       "transient" : true,
       "type" : "plot",
       "uniqueKey" : 2,
-      "valid" : false,
       "yAxisIndex" : 0
     } ],
-    "chartMode" : "single",
+    "chartMode" : "list",
     "chartType" : "line",
     "chartconfig" : {
       "absoluteEnd" : null,
       "absoluteStart" : null,
       "colorByMetric" : false,
       "disableThrottle" : false,
-      "hideTimestamp" : false,
-      "maxDecimalPlaces" : 4,
+      "forcedResolution" : "0",
+      "hideDimensionsInList" : false,
+      "legendColumnConfiguration" : null,
+      "maxDecimalPlaces" : 3,
       "range" : -7200000,
       "rangeEnd" : 0,
-      "sortPreference" : "",
+      "sortPreference" : "-value",
       "updateInterval" : "",
       "yAxisConfigurations" : [ {
         "id" : "yAxis0",
-        "max" : null,
-        "min" : null,
+        "max" : 120,
+        "min" : 0,
         "name" : "yAxis0",
         "plotlines" : {
           "high" : null,
@@ -4858,8 +5037,9 @@
         }
       } ]
     },
-    "currentUniqueKey" : 4,
-    "revisionNumber" : 14,
-    "uiHelperValue" : "##CHARTID##_14"
+    "currentUniqueKey" : 7,
+    "revisionNumber" : 22,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_22"
   }
 } ]


### PR DESCRIPTION
Adds filter `!agent:*` to charts on collectd dashboard.
This ensures that telegraf hosts will not appear in collectd charts, while matching it to the updated collectd detector templates.
Tested with lab using "page-imports-staging" repository.