### PR TITLE
Short-term Fix for cAdvisor/k8s Pod Nav View

### DIFF
--- a/Kubernetes/Page_Kubernetes.json
+++ b/Kubernetes/Page_Kubernetes.json
@@ -15,7 +15,7 @@
   "marshallId" : 3,
   "marshallMemberOf" : [ 2 ],
   "sf_dashboard" : "K8s Node",
-  "sf_discoveryQuery" : "metric_source:kubernetes AND sf_metric:machine_cpu_cores",
+  "sf_discoveryQuery" : "metric_source:kubernetes AND sf_metric:machine_cpu_cores AND _exists_:kubernetes_cluster",
   "sf_discoverySelectors" : [ "_exists_:host" ],
   "sf_filterAlias" : {
     "variables" : [ {
@@ -1232,7 +1232,7 @@
   "marshallId" : 13,
   "marshallMemberOf" : [ 2 ],
   "sf_dashboard" : "K8s Pod",
-  "sf_discoveryQuery" : "metric_source:kubernetes",
+  "sf_discoveryQuery" : "metric_source:kubernetes AND _exists_:kubernetes_cluster",
   "sf_discoverySelectors" : [ "_exists_:kubernetes_pod_name" ],
   "sf_filterAlias" : {
     "variables" : [ {
@@ -2400,7 +2400,7 @@
   "marshallId" : 22,
   "marshallMemberOf" : [ 2 ],
   "sf_dashboard" : "K8s Clusters",
-  "sf_discoveryQuery" : "metric_source:kubernetes AND sf_metric:machine_cpu_cores",
+  "sf_discoveryQuery" : "metric_source:kubernetes AND sf_metric:machine_cpu_cores AND _exists_:kubernetes_cluster",
   "sf_discoverySelectors" : [ "_exists_:kubernetes_cluster" ],
   "sf_isLocked" : false,
   "sf_savedFilters" : {

--- a/Kubernetes/Page_cAdvisor.json
+++ b/Kubernetes/Page_cAdvisor.json
@@ -91,7 +91,7 @@
   },
   "sf_discoverySelectors" : [ "sf_key:cluster", "metric_source:kubernetes" ],
   "sf_type" : "Dashboard",
-  "sf_discoveryQuery" : "metric_source:kubernetes",
+  "sf_discoveryQuery" : "metric_source:kubernetes AND _missing_:kubernetes_cluster",
   "sf_savedFilters" : {
     "sources" : null,
     "variables" : null,
@@ -954,7 +954,7 @@
   },
   "sf_discoverySelectors" : [ "_exists_:node" ],
   "sf_type" : "Dashboard",
-  "sf_discoveryQuery" : "metric_source:kubernetes",
+  "sf_discoveryQuery" : "metric_source:kubernetes AND _missing_:kubernetes_cluster",
   "sf_savedFilters" : {
     "sources" : null,
     "variables" : null,
@@ -2314,9 +2314,9 @@
     } ],
     "version" : 1
   },
-  "sf_discoverySelectors" : [ "_exists_:cluster" ],
+  "sf_discoverySelectors" : [ "_exists_:cluster"],
   "sf_type" : "Dashboard",
-  "sf_discoveryQuery" : "metric_source:kubernetes",
+  "sf_discoveryQuery" : "metric_source:kubernetes AND _missing_:kubernetes_cluster",
   "sf_savedFilters" : {
     "sources" : null,
     "variables" : null,
@@ -4509,7 +4509,7 @@
   },
   "sf_discoverySelectors" : [ "_exists_:kubernetes_pod_name" ],
   "sf_type" : "Dashboard",
-  "sf_discoveryQuery" : "metric_source:kubernetes",
+  "sf_discoveryQuery" : "metric_source:kubernetes AND _missing_:kubernetes_cluster",
   "sf_savedFilters" : {
     "sources" : null,
     "variables" : null,


### PR DESCRIPTION
This will only go out long enough to be propagated to each org and then the cAdvisor dashboards will be deleted.