### PR TITLE
Add Splunk notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,6 @@ considered for automatic import via SignalFx's Service Discovery
 feature.
 
 For more information on how to use dashboards, see
-https://docs.signalfx.com/en/latest/dashboards/dashboard-basics.html
+https://docs.splunk.com/Observability/data-visualization/dashboards/dashboards.html#nav-Dashboards
+
+>ℹ️&nbsp;&nbsp;SignalFx was acquired by Splunk in October 2019. See [Splunk SignalFx](https://www.splunk.com/en_us/investor-relations/acquisitions/signalfx.html) for more information.


### PR DESCRIPTION
This small PR adds the acquisition notice with a link to the README file.